### PR TITLE
fix: allowlist facts, scorecard metric definitions, #1652 ledger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ You are operating **Foundry**, a gated OSS contribution factory.
 - Product bible: `docs/PRODUCT.md`
 - Glossary: `CONTEXT.md`
 - Operator loop: `node --experimental-strip-types factory/cli.ts`
-- Tests: `node --experimental-strip-types --test factory/engine.test.ts factory/policy.test.ts factory/load-allowlist.test.ts factory/state.test.ts factory/github-pr.test.ts`
+- Tests: `node --experimental-strip-types --test factory/engine.test.ts factory/policy.test.ts factory/load-allowlist.test.ts factory/state.test.ts factory/github-pr.test.ts factory/scorecard.test.ts`
 
 ## Hand-off
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,7 +17,7 @@ Repos the factory must refuse. Absolute; no operator override.
 _Avoid_: blocklist, ban list (the scorecard tone `banned` is a halt reason, not this list)
 
 **Wave**:
-A trust tier on an allowlisted repo: `0` own, `1` AI-welcome external, `2` adjacent/human-required.
+A trust tier on an allowlisted repo: `0` own, `1` AI-welcome or behaviorally open external, `2` adjacent/human-required.
 
 **Policy verdict**:
 The deterministic gate result for a packet (`ALLOW`, `DENY_*`, `HOLD_*`). Grok does not vote.
@@ -35,7 +35,7 @@ A GitHub pull request opened with `draft: true`. Ready-for-review is a human bro
 The human freeze record `{ by, at, note }` required before implement on Wave 1+, and counted toward the first-20 freeze budget.
 
 **Scorecard halt**:
-A per-repo stop when tone is `banned`, any revert of our patch, or opened ≥ 3 and merge rate < 40%. A halted repo is treated as unselectable until a human edits `allowlist.yaml`.
+A per-repo stop when tone is `banned`, any revert of our patch (narrow: `git revert` of the merge commit or a maintainer-stated rollback naming the PR, within 30 days), or ≥ 3 **terminal** drafts and merge rate < 40%. Stale-closed after 14 quiet days counts against the rate. Rework does not halt. A halted repo is treated as unselectable until a human edits `allowlist.yaml`.
 
 **Evidence**:
 SHA-bound proof that tests ran and a revert goes red. A packet without `negativeControl=red-on-revert` and real SHAs cannot become `draft-ready`.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Foundry is the control plane in front of [orca-fleet `oss-contribute`](https://g
 
 ## Status (2026-08-28)
 
-Wave 0 attested merges: [orca-fleet#70](https://github.com/ravidsrk/orca-fleet/pull/70), [orca-fleet#72](https://github.com/ravidsrk/orca-fleet/pull/72). frontguard [PR #196](https://github.com/ravidsrk/frontguard/pull/196) also merged. Wave 1 in flight: [ColeMurray/background-agents#1652](https://github.com/ColeMurray/background-agents/pull/1652) (open, not draft). Follow up. **Do not merge. Do not tick.**
+Wave 0 attested merges: [orca-fleet#70](https://github.com/ravidsrk/orca-fleet/pull/70), [orca-fleet#72](https://github.com/ravidsrk/orca-fleet/pull/72). frontguard [PR #196](https://github.com/ravidsrk/frontguard/pull/196) also merged. Wave 1 [ColeMurray/background-agents#1652](https://github.com/ColeMurray/background-agents/pull/1652) is **draft**, verbatim disclosure restored, packet **`followed-up`**. In-flight slot released. **Do not merge.**
 
 ## v1
 
@@ -30,7 +30,7 @@ Live GitHub scout (user-initiated), E2B dry-run labeled as dry-run, follow-up PR
 Node 22+:
 
 ```
-node --experimental-strip-types --test factory/engine.test.ts factory/policy.test.ts factory/load-allowlist.test.ts factory/state.test.ts factory/github-pr.test.ts
+node --experimental-strip-types --test factory/engine.test.ts factory/policy.test.ts factory/load-allowlist.test.ts factory/state.test.ts factory/github-pr.test.ts factory/scorecard.test.ts
 ```
 
 ## Do not

--- a/allowlist.yaml
+++ b/allowlist.yaml
@@ -15,9 +15,9 @@ denylist:
   - id: curl/curl
     reason: Maintainer asked agents to stop after HackerOne flood.
   - id: pydantic/pydantic
-    reason: High slop-PR close rate in 2026.
+    reason: "They welcome AI, but reserve the right to close PRs from authors mass-submitting across multiple repositories (spam) — the factory pattern — plus assignment-first auto-close."
   - id: stablyai/orca
-    reason: Contribute via orca-fleet, not drive-by PRs.
+    reason: "Conflict of interest: this is the runtime Foundry runs on. Contribute via orca-fleet, not drive-by PRs. CONTRIBUTING requires an AI review summary; the deny is not an AI-policy restriction."
 
 repos:
   - id: ravidsrk/orca-fleet
@@ -51,7 +51,8 @@ repos:
   - id: ColeMurray/background-agents
     wave: 1
     language: TypeScript
-    aiPolicy: welcome
+    aiPolicy: undocumented-open
+    policyNotes: "CONTRIBUTING.md, AGENTS.md, and CLAUDE.md have no external-AI-contribution policy. Behavior is open (maintainer merges own-bot PRs) but undocumented — higher risk than documented welcome."
     testCommand: npm test
     maxFiles: 6
     maxDiffLines: 280
@@ -64,7 +65,7 @@ repos:
 
   - id: github/awesome-copilot
     wave: 1
-    language: Markdown
+    language: JavaScript / Markdown
     aiPolicy: welcome
     testCommand: "true"
     maxFiles: 3
@@ -73,10 +74,11 @@ repos:
     preferredLabels: [documentation]
     firstIssues: []
 
-  - id: e2b-dev/E2B
+  - id: e2b-dev/e2b-cookbook
     wave: 1
     language: TypeScript / Python
-    aiPolicy: welcome
+    aiPolicy: unknown
+    policyNotes: "Docs/examples cookbook. SDK examples were removed from e2b-dev/E2B in PR 1769 (2026-08-25); this is the realistic surface. No CONTRIBUTING/AGENTS.md; fetch before freeze."
     testCommand: npm test
     maxFiles: 5
     maxDiffLines: 220
@@ -117,11 +119,12 @@ repos:
     preferredLabels: ["good first issue", documentation]
     firstIssues: []
 
-  - id: All-Hands-AI/OpenHands
+  - id: OpenHands/OpenHands
     wave: 2
-    language: Python
+    language: TypeScript
     aiPolicy: human-required
-    testCommand: poetry run pytest
+    policyNotes: "Org renamed from All-Hands-AI/OpenHands. No CONTRIBUTING.md. Policy lives in the PR template (HUMAN:/AGENT: sections; evidence that the code runs end-to-end — unit tests not sufficient) and the ready-for-dev issue-label prerequisite."
+    testCommand: npm test
     maxFiles: 3
     maxDiffLines: 140
     sandbox: e2b

--- a/docs/00-vision.md
+++ b/docs/00-vision.md
@@ -6,7 +6,7 @@ The product is not “open more PRs.” The product is **merged, etiquette-corre
 
 ## Why this exists
 
-2026 made unattended OSS agents radioactive. curl’s HackerOne queue, matplotlib’s autonomous-agent ban, Pydantic’s slop-PR close rate, and OpenClaw-style maintainer attacks all taught the same lesson: volume without governance is vandalism.
+2026 made unattended OSS agents radioactive. curl’s HackerOne queue, matplotlib’s autonomous-agent ban, pydantic’s spam/factory-pattern close right (they otherwise welcome AI), and OpenClaw-style maintainer attacks all taught the same lesson: volume without governance is vandalism.
 
 Foundry is the opposite posture:
 
@@ -39,10 +39,11 @@ Foundry adds what `oss-contribute` does not have: an **always-on clock**, a **ha
 
 ## Success
 
-After 90 days:
+After 90 days (definitions in `docs/08-operations.md`):
 
 - ≥ 1 merged PR on a Wave 1 repo that is not ours.
-- Merge rate ≥ 60% on opened drafts.
-- Review-comment average ≤ 4.
-- **Bans = 0. Reverts = 0.**
+- Merge rate ≥ 60% on opened drafts that reached a terminal state (merged / closed / stale-closed after 14 quiet days). Stale-closed counts against the rate.
+- Review-comment average ≤ 4, measured only over PRs with ≥1 human, non-bot review comment. Report the no-review rate alongside it.
+- **Bans = 0.**
+- **Reverts = 0** — explicit `git revert` of our merge commit, or a maintainer-stated rollback that names the PR, within 30 days of merge. Post-merge edits are rework, not reverts.
 - The first 20 packets each have a human attest in the ledger.

--- a/docs/01-architecture.md
+++ b/docs/01-architecture.md
@@ -27,7 +27,7 @@ TypeScript in `factory/`. Deterministic. No LLM required to refuse a banned repo
 - `engine.ts` — tick / queue / approve / advance. Honors inflight, halt, promotion, deny.
 - `packet.ts` — the unit of work. Objective, non-goals, acceptance, abort.
 - `sandbox.ts` — dry-run plan; never auto-harvests as green.
-- `scorecard.ts` — merge rate, tone, reverts. `health()` can halt a repo; the engine consults it.
+- `scorecard.ts` — merge rate (terminal drafts), human review-comment average, no-review rate, narrow reverts vs rework, tone. `health()` can halt a repo; the engine consults it.
 - `cli.ts` — operator freeze / tick / draft-body loop.
 
 There is no TanStack console in this repository. The clock **must not** open contribution PRs.

--- a/docs/03-allowlist.md
+++ b/docs/03-allowlist.md
@@ -7,8 +7,10 @@ The allowlist is the product. Everything else is a pipeline. Sole source: [`allo
 | Wave | Who | Sandbox | Human freeze |
 |---|---|---|---|
 | 0 | Repos we own (`orca-fleet`, `frontguard`) | Host worktree | First 20 factory-wide, then mechanical if policy allows |
-| 1 | AI-welcome, small blast radius | E2B | Always |
+| 1 | AI-welcome or behaviorally open, small blast radius | E2B | Always |
 | 2 | Adjacent (Mastra, OpenHands) | E2B | Always + HUMAN/DCO holds |
+
+`aiPolicy` values: `owner`, `welcome` (documented), `undocumented-open` (behaviorally open, no written external-AI policy — higher risk), `human-required`, `unknown`, `forbidden`.
 
 ## Current roster
 
@@ -19,23 +21,23 @@ The allowlist is the product. Everything else is a pipeline. Sole source: [`allo
 
 ### Wave 1 — low-risk external
 
-- `ColeMurray/background-agents` — OpenInspect. [#1476](https://github.com/ColeMurray/background-agents/issues/1476) → [ColeMurray#1652](https://github.com/ColeMurray/background-agents/pull/1652) (open, not draft). Fork rehearsal [ravidsrk/background-agents#1](https://github.com/ravidsrk/background-agents/pull/1) closed. **In flight.**
-- `github/awesome-copilot` — docs catalog, tiny diffs. No named first issue; tick idles rather than inventing one.
-- `e2b-dev/E2B` — the sandbox we depend on. Docs/examples only.
+- `ColeMurray/background-agents` — OpenInspect. `aiPolicy: undocumented-open` (CONTRIBUTING/AGENTS/CLAUDE have no external-AI policy; behavior is open). [#1476](https://github.com/ColeMurray/background-agents/issues/1476) → [ColeMurray#1652](https://github.com/ColeMurray/background-agents/pull/1652) (open **draft**, verbatim disclosure, packet **`followed-up`**). Fork rehearsal [ravidsrk/background-agents#1](https://github.com/ravidsrk/background-agents/pull/1) closed.
+- `github/awesome-copilot` — JavaScript tooling / Markdown catalog, tiny diffs. Documented agent welcome. No named first issue; tick idles rather than inventing one.
+- `e2b-dev/e2b-cookbook` — docs/examples surface for the sandbox we depend on. Retargeted from `e2b-dev/E2B` after that repo lost `docs/` and SDK examples (E2B#1769). Policy unknown until CONTRIBUTING is fetched. Gate holds.
 - `mcp-use/mcp-use` — policy unknown until CONTRIBUTING is fetched. Gate holds.
 - `kortix-ai/suna` — same: unknown until parsed.
 
 ### Wave 2 — adjacent, slower
 
 - `mastra-ai/mastra` — HeyCMO’s runtime. Human-required.
-- `All-Hands-AI/OpenHands` — HUMAN: markers. Docs only.
+- `OpenHands/OpenHands` — org renamed from `All-Hands-AI/OpenHands`. No CONTRIBUTING.md; policy lives in the PR template (`HUMAN:`/`AGENT:` sections, end-to-end evidence — unit tests not sufficient) and the `ready-for-dev` issue-label prerequisite.
 
 ## Denylist (hard)
 
 - `matplotlib/matplotlib` — autonomous-agent ban.
 - `curl/curl` — maintainer request to stop agent noise.
-- `pydantic/pydantic` — slop-PR close rate.
-- `stablyai/orca` — contribute through orca-fleet, not drive-by.
+- `pydantic/pydantic` — they welcome AI, but reserve the right to close PRs from authors mass-submitting across multiple repositories (spam) — i.e. the factory pattern — plus assignment-first auto-close.
+- `stablyai/orca` — conflict of interest: it is the runtime Foundry runs on. Contribute through orca-fleet, not drive-by. CONTRIBUTING actually *requires* an AI review summary.
 
 A denylist hit is `DENY_FORBIDDEN`. There is no override in the operator CLI.
 
@@ -49,4 +51,4 @@ A denylist hit is `DENY_FORBIDDEN`. There is no override in the operator CLI.
 
 ## Removing a repo
 
-Any of: maintainer ask, one revert of our patch, merge rate < 40% after 3 opens, tone `cold` for two cycles, or a ban. Removal is immediate and logged on the scorecard.
+Any of: maintainer ask, one revert of our patch (narrow: `git revert` of the merge commit or a maintainer-stated rollback naming the PR, within 30 days), merge rate < 40% after 3 terminal drafts, tone `cold` for two cycles, or a ban. Removal is immediate and logged on the scorecard.

--- a/docs/04-stations.md
+++ b/docs/04-stations.md
@@ -64,10 +64,10 @@ Does:
 - Sync the live PR (draft/open/merged, head SHA, review comment count). User-initiated. Never on load.
 - Record bot-reconcile and review-reply notes against the current head.
 - Mark quiet when threads are answered. **Never merge.**
-- When GitHub reports `merged`, write the scorecard `merged` row. When closed unmerged, write `closedUnmerged`.
+- When GitHub reports `merged`, write the scorecard `merged` row. When closed unmerged, write `closedUnmerged`. After 14 quiet days, write `stale-closed` (still counts against merge rate). Record human vs bot review into `humanReviewed` / `noReview`; `reviewCommentsAvg` is over human-reviewed PRs only.
 
 Halt rules fire here. See `docs/06-v2.md`. `submitted` remains in-flight so a quiet-but-unmerged draft still blocks a new tick until `followed-up`.
 
 Live follow-up: [orca-fleet#70](https://github.com/ravidsrk/orca-fleet/pull/70) — Greptile future-dated the 0.5.0 heading; Foundry folded it to `2026-08-26` (`d91fe2f`) and resolved the thread. **Merged** by the maintainer 2026-08-27.
 
-In-flight: [ColeMurray/background-agents#1652](https://github.com/ColeMurray/background-agents/pull/1652).
+Followed-up: [ColeMurray/background-agents#1652](https://github.com/ColeMurray/background-agents/pull/1652) (draft, verbatim disclosure). In-flight slot released.

--- a/docs/05-v1.md
+++ b/docs/05-v1.md
@@ -27,7 +27,7 @@ v1 is the factory you can run without E2B keys or a GitHub App.
 ## Operator loop
 
 1. `node --experimental-strip-types factory/cli.ts status`
-2. Do not tick while ColeMurray#1652 is `submitted`.
+2. ColeMurray#1652 is `followed-up` (draft, slot released). Do not merge it. Do not tick while any other packet is `submitted`.
 3. When idle: `tick` → `approve --note` → hand to `oss-contribute` → attach evidence → `body` → open a **draft**.
 4. Do not run a second tick until that packet is `followed-up`, `merged`, `parked`, or `rejected`.
 

--- a/docs/06-v2.md
+++ b/docs/06-v2.md
@@ -34,10 +34,10 @@ Wire `E2B_API_KEY` in the worker host (not this git tree) to make it live.
 Halt a repo (`stop`) when:
 
 - maintainer tone is `banned`, or
-- any revert of our patch, or
-- opened ≥ 3 and merge rate < 40%.
+- any revert of our patch (explicit `git revert` of the merge commit, or a maintainer-stated rollback naming the PR, within 30 days), or
+- **terminal** drafts ≥ 3 and merge rate < 40% (stale-closed after 14 quiet days counts against the rate).
 
-Watch when tone is `cold`, or opened ≥ 2 and merge rate < 60%.
+Watch when tone is `cold`, or terminal drafts ≥ 2 and merge rate < 60%. In-flight drafts are not in the merge-rate denominator. Post-merge edits are rework and do not halt.
 
 A `stop` repo is unselectable until a human removes the halt in `allowlist.yaml`.
 
@@ -64,4 +64,4 @@ v2 features may run on Wave 0 immediately. They may run on Wave 1 after **two me
 - [orca-fleet#70](https://github.com/ravidsrk/orca-fleet/pull/70) **merged** 2026-08-27.
 - [frontguard#196](https://github.com/ravidsrk/frontguard/pull/196) **merged** 2026-08-28 (operator merge on an owned repo; not a promotion-gate merge).
 - [orca-fleet#72](https://github.com/ravidsrk/orca-fleet/pull/72) **merged** 2026-08-27.
-- [ColeMurray/background-agents#1652](https://github.com/ColeMurray/background-agents/pull/1652) **open**, ready-for-review. Follow up. Do not merge. Do not tick.
+- [ColeMurray/background-agents#1652](https://github.com/ColeMurray/background-agents/pull/1652) **open draft**, packet **`followed-up`**. Do not merge.

--- a/docs/08-operations.md
+++ b/docs/08-operations.md
@@ -8,25 +8,39 @@
 
 ## Tick cadence
 
-Every 6 hours, **or** operator `tick`. Never both overlapping. One packet in flight, including `submitted`.
+Every 6 hours, **or** operator `tick`. Never both overlapping. One packet in flight, including `submitted`. `followed-up` is not in-flight.
 
 ## Current (2026-08-28)
 
 1. Wave 0 attested 2/2: [orca-fleet#70](https://github.com/ravidsrk/orca-fleet/pull/70), [orca-fleet#72](https://github.com/ravidsrk/orca-fleet/pull/72).
 2. [frontguard#196](https://github.com/ravidsrk/frontguard/pull/196) merged by `ravidsrk`. Do not repeat operator-merge on a Foundry packet.
-3. Wave 1 in flight: [ColeMurray/background-agents#1652](https://github.com/ColeMurray/background-agents/pull/1652). Follow up. Do not merge. Do not tick.
+3. Wave 1 [ColeMurray/background-agents#1652](https://github.com/ColeMurray/background-agents/pull/1652) converted to **draft**, verbatim disclosure restored, packet **`followed-up`**. In-flight slot released. Do not merge.
 
 ## Halt switch
 
 A repo with scorecard health `stop` cannot be queued or approved. To halt everything, reject in-flight packets and stop pressing tick. The GHA default is dry (`FOUNDRY_LIVE` unset).
 
+Halt (`stop`) when:
+
+- maintainer tone is `banned`, or
+- any **revert** of our patch (narrow definition below), or
+- **terminal** drafts ≥ 3 and merge rate < 40%.
+
+Watch when tone is `cold`, or terminal drafts ≥ 2 and merge rate < 60%. In-flight drafts do not count toward the merge-rate sample.
+
 ## Metrics that matter
 
-- Merge rate (merged / opened drafts)
-- Review comments per PR
-- Time-to-quiet (open → last comment)
-- Reverts
-- Bans (must stay 0)
+These are the operational definitions. `factory/scorecard.ts` encodes them so the scorecard cannot be computed the other way.
+
+| Metric | Definition |
+|---|---|
+| **Merge rate** | `merged / terminal`, where **terminal** = opened drafts that reached merged, closed, or **stale-closed**. Stale-closed = still open, no human activity, 14 quiet days (ADR 0002). Stale-closed **counts against** the rate. In-flight drafts are not in the denominator. 90-day target: ≥ 60%. |
+| **Review-comment average** | Mean number of **human, non-bot** review comments, over PRs with ≥ 1 such comment (`humanReviewed`). Bot-only threads (CodeRabbit, Greptile, …) do not enter the average. 90-day target: ≤ 4. |
+| **No-review rate** | `noReview / (humanReviewed + noReview)`. Reported **alongside** the average so silence is not mistaken for cleanliness. |
+| **Time-to-quiet** | Open → last human comment. |
+| **Revert** | An explicit `git revert` of the merge commit, **or** a maintainer-stated rollback that names the PR, within **30 days** of merge (`REVERT_WINDOW_DAYS`). 90-day target: 0. Trips halt. |
+| **Rework** | Post-merge edits or refactors of our code that are not a revert. Informational only; does not trip halt or the revert KPI. |
+| **Bans** | Maintainer asked us to stop, or scorecard tone `banned`. Must stay 0. |
 
 PR volume is a vanity metric and is not shown as a success KPI.
 

--- a/docs/10-schemas.md
+++ b/docs/10-schemas.md
@@ -45,4 +45,27 @@ A packet without `negativeControl=red-on-revert` and real (non-placeholder) `bas
 
 ## Allowlist repo
 
-See `allowlist.yaml`. Required fields: `id`, `wave`, `aiPolicy`, `testCommand`, `maxFiles`, `maxDiffLines`, `sandbox`, `preferredLabels`. Wave 1+ should name at least one `firstIssues` entry before the clock may select them.
+See `allowlist.yaml`. Required fields: `id`, `wave`, `aiPolicy`, `testCommand`, `maxFiles`, `maxDiffLines`, `sandbox`, `preferredLabels`. Optional: `language`, `policyNotes`, `firstIssues`. Wave 1+ should name at least one `firstIssues` entry before the clock may select them.
+
+### `aiPolicy`
+
+| Value | Meaning |
+|---|---|
+| `owner` | Repo we own. |
+| `welcome` | **Documented** external-AI welcome (CONTRIBUTING/AGENTS says so). |
+| `undocumented-open` | Behaviorally open, but no written external-AI-contribution policy. Higher risk than `welcome`. Fetch docs before freeze (same gate as `unknown`). |
+| `human-required` | HUMAN:/CLA/DCO holds. |
+| `unknown` | Not yet parsed. Deny until AGENTS.md / CONTRIBUTING is fetched. |
+| `forbidden` | Treat as denylist. |
+
+### Scorecard row
+
+| Field | Meaning |
+|---|---|
+| `opened` | Drafts we opened. Volume only. |
+| `merged` / `closedUnmerged` | Terminal outcomes. `staleClosed` is a subset of `closedUnmerged` (14 quiet days). |
+| `reviewCommentsAvg` | Mean **human, non-bot** review comments over `humanReviewed` only. |
+| `humanReviewed` | PRs with ≥1 human, non-bot review comment. |
+| `noReview` | PRs with 0 human, non-bot review comments. Companion to the average. |
+| `reverts` | `git revert` of our merge, or maintainer-stated rollback naming the PR, within 30 days. |
+| `rework` | Post-merge edits. Informational; does not halt. |

--- a/docs/12-ledger.md
+++ b/docs/12-ledger.md
@@ -12,28 +12,43 @@ Operator snapshot. Foundry does not merge. Seed: `factory/seed.ts`. Refresh this
 
 Wave 1 promotion gate (two attested Wave 0 merges on orca-fleet): **passed**.
 
-## Wave 1 — in flight (`submitted`)
+## Wave 1 — followed-up (in-flight slot released)
 
 | Packet | Issue | PR | Status |
 |---|---|---|---|
-| Right sidebar toggle icon | [background-agents#1476](https://github.com/ColeMurray/background-agents/issues/1476) | [ColeMurray#1652](https://github.com/ColeMurray/background-agents/pull/1652) | **open, ready-for-review** (not draft), blocked mergeability, +88/−1, 3 files. Head `48c2242683705b00503d3436575bf3c28b1b0c9b` |
+| Right sidebar toggle icon | [background-agents#1476](https://github.com/ColeMurray/background-agents/issues/1476) | [ColeMurray#1652](https://github.com/ColeMurray/background-agents/pull/1652) | **open draft** (converted 2026-08-28). Verbatim `DISCLOSURE` restored. Head `48c2242683705b00503d3436575bf3c28b1b0c9b`. Packet **`followed-up`**. Do not merge. |
 
 Fork rehearsal [ravidsrk/background-agents#1](https://github.com/ravidsrk/background-agents/pull/1) is **closed** (still draft, not merged) as of 2026-08-28T10:14:36Z.
 
-Do **not** open the compare URL again. The upstream PR exists. Follow up. Do not merge. Do not tick.
+Live-verified 2026-08-28: `isDraft=true`, body carries the three-line `factory/neighbor.ts` `DISCLOSURE` block, no human review (CodeRabbit only). Doctrine miss (ready-for-review + shortened disclosure) is corrected. In-flight slot released via `followed-up` (oss-foundry#2).
 
 ## Scorecard (this control plane)
 
+Definitions: [`docs/08-operations.md`](08-operations.md) ("Metrics that matter").
+
 - bans: 0
-- reverts: 0
-- orca-fleet: 2 opened, 2 merged, warm
-- frontguard: 1 opened, 1 merged, warm
-- background-agents: 1 opened, 0 merged, neutral
-- halt: none
+- reverts: 0 (narrow: `git revert` of merge commit or maintainer-stated rollback naming the PR, within 30 days)
+- rework: 0 (post-merge edits; informational)
+- orca-fleet: 2 opened, 2 merged, 2 terminal, noReview 2, humanReviewed 0, warm
+- frontguard: 1 opened, 1 merged, 1 terminal, noReview 1, humanReviewed 0, warm
+- background-agents: 1 opened, 0 merged, 0 terminal (still open), noReview 1 (CodeRabbit is not a human review), neutral
+- halt: none (needs ≥ 3 terminal drafts)
+
+Merge rate on terminal packets: 3/3. #1652 is not terminal, so it is not in the merge-rate denominator.
+
+## Allowlist corrections (2026-08-28, oss-foundry#3)
+
+Live verification of every roster/denylist claim:
+
+- `pydantic/pydantic` deny kept; reason is factory-pattern / mass-submit close-right + assignment-first auto-close, not an unsubstantiated “slop-PR close rate.” Their CONTRIBUTING welcomes AI.
+- `stablyai/orca` deny kept; reason is conflict-of-interest (Foundry’s runtime), not an AI-policy restriction. CONTRIBUTING requires an AI review summary.
+- `All-Hands-AI/OpenHands` → `OpenHands/OpenHands` (org rename). Policy is the PR template (`HUMAN:`/`AGENT:`, end-to-end evidence) plus `ready-for-dev`.
+- `e2b-dev/E2B` retargeted to `e2b-dev/e2b-cookbook` (SDK examples removed in E2B#1769; no `docs/` on E2B).
+- `ColeMurray/background-agents` `aiPolicy` is `undocumented-open`, not `welcome`.
+- `github/awesome-copilot` language is JavaScript / Markdown (registered language is JavaScript; content is Markdown).
 
 ## Next
 
-1. Follow #1652 until quiet / merged-by-maintainer / closed.
-2. Prefer converting #1652 to **draft** until tests on that head are green.
-3. Paste verbatim disclosure if the body is edited (`factory/neighbor.ts`).
-4. Idle. One packet in flight.
+1. Watch #1652 for a human review thread. Answer if one appears. **Do not merge.**
+2. Tick is allowed; named `firstIssues` are consumed, so the clock idles.
+3. Do not open awesome-copilot or e2b-cookbook until a first issue is named and policy is parsed.

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -8,7 +8,7 @@ Operator takeover document. This is the whole product: why it exists, how it run
 | Control plane | `factory/` TypeScript + `allowlist.yaml`. Operator loop: `node --experimental-strip-types factory/cli.ts` |
 | Data plane | [ravidsrk/orca-fleet](https://github.com/ravidsrk/orca-fleet) `oss-contribute` |
 | License | MIT |
-| Status | Wave 0 **3** Foundry packets merged (2 attested promotion-gate merges on orca-fleet, plus frontguard#196). Wave 1 packet **in flight**: [ColeMurray/background-agents#1652](https://github.com/ColeMurray/background-agents/pull/1652) (open, **not draft**). |
+| Status | Wave 0 **3** Foundry packets merged (2 attested promotion-gate merges on orca-fleet, plus frontguard#196). Wave 1 [ColeMurray/background-agents#1652](https://github.com/ColeMurray/background-agents/pull/1652) is **draft**, verbatim disclosure restored, packet **`followed-up`**. In-flight slot released. |
 
 ---
 
@@ -26,7 +26,7 @@ The product is not “open more PRs.” The product is **merged, etiquette-corre
 
 - matplotlib banned autonomous-agent PRs after a slop incident
 - curl maintainers asked agents to stop after a HackerOne flood
-- pydantic closed slop PRs at a high rate
+- pydantic welcomes AI but reserves the right to close mass-submitted / factory-pattern PRs (and auto-closes unassigned PRs)
 - drive-by volume without governance is vandalism
 
 Foundry’s posture is the inverse: **contribute less, merge more, never surprise a maintainer.**
@@ -138,10 +138,10 @@ There is **no** TanStack operator console in this repository. The freeze/tick/dr
 Stop a repo when:
 
 - maintainer tone is `banned`, or
-- any revert of our patch, or
-- opened ≥ 3 **and** merge rate < 40%
+- any **revert** of our patch (explicit `git revert` of the merge commit, or a maintainer-stated rollback naming the PR, within 30 days), or
+- **terminal** drafts ≥ 3 **and** merge rate < 40% (stale-closed after 14 quiet days counts against the rate; in-flight drafts are not in the denominator)
 
-Watch when tone is `cold`, or opened ≥ 2 and merge rate < 60%.
+Watch when tone is `cold`, or terminal drafts ≥ 2 and merge rate < 60%. Post-merge edits are **rework**, informational only.
 
 A `stop` repo is unselectable until a human edits `allowlist.yaml`.
 
@@ -154,7 +154,7 @@ PR volume is a vanity metric. Not shown as a success KPI.
 | Wave | Who | Sandbox | Human freeze |
 |---|---|---|---|
 | 0 | Repos we own (`orca-fleet`, `frontguard`) | Host worktree | First 20 factory-wide, then mechanical if `aiPolicy: owner` |
-| 1 | AI-welcome, small blast radius | E2B (dry-run in this repo) | **Always** |
+| 1 | AI-welcome or behaviorally open, small blast radius | E2B (dry-run in this repo) | **Always** |
 | 2 | Adjacent (Mastra, OpenHands) | E2B | Always + HUMAN/DCO holds |
 
 Caps (`allowlist.yaml`): `in_flight: 1`, `first_human_freezes: 20`, `halt_merge_rate: 0.4`, `halt_after_opens: 3`.
@@ -166,23 +166,23 @@ Caps (`allowlist.yaml`): `in_flight: 1`, `first_human_freezes: 20`, `halt_merge_
 
 ### Wave 1
 
-- `ColeMurray/background-agents` — OpenInspect. `aiPolicy: welcome`. First issue **#1476** (in flight as #1652)
-- `github/awesome-copilot` — Markdown docs. No named first issue yet; clock idles rather than inventing one
-- `e2b-dev/E2B` — docs/examples only
+- `ColeMurray/background-agents` — OpenInspect. `aiPolicy: undocumented-open`. First issue **#1476** → #1652 **draft**, packet **`followed-up`**
+- `github/awesome-copilot` — JavaScript tooling / Markdown catalog. Documented agent welcome. No named first issue yet; clock idles rather than inventing one
+- `e2b-dev/e2b-cookbook` — docs/examples cookbook (retargeted from `e2b-dev/E2B` after SDK examples were removed). Policy **unknown** until parsed
 - `mcp-use/mcp-use` — policy **unknown** until CONTRIBUTING parsed
 - `kortix-ai/suna` — policy **unknown** until parsed
 
 ### Wave 2
 
 - `mastra-ai/mastra` — human-required
-- `All-Hands-AI/OpenHands` — HUMAN: markers, docs only
+- `OpenHands/OpenHands` — org renamed from `All-Hands-AI/OpenHands`. Policy in the PR template (`HUMAN:`/`AGENT:`, end-to-end evidence) and `ready-for-dev` issue label
 
 ### Denylist (hard)
 
 - `matplotlib/matplotlib` — autonomous-agent ban
 - `curl/curl` — maintainer asked agents to stop
-- `pydantic/pydantic` — high slop-PR close rate
-- `stablyai/orca` — contribute via orca-fleet, not drive-by
+- `pydantic/pydantic` — welcome AI, but close mass-submitted / factory-pattern PRs and auto-close unassigned PRs
+- `stablyai/orca` — conflict of interest: Foundry's runtime; contribute via orca-fleet, not drive-by
 
 ---
 
@@ -204,7 +204,7 @@ Caps (`allowlist.yaml`): `in_flight: 1`, `first_human_freezes: 20`, `halt_merge_
 | [`docs/`](.) | Protocol. This file is the takeover bible |
 | [`CONTEXT.md`](../CONTEXT.md) | Glossary |
 
-Tests: `node --experimental-strip-types --test factory/engine.test.ts factory/policy.test.ts factory/load-allowlist.test.ts factory/state.test.ts factory/github-pr.test.ts` (Node 22+).
+Tests: `node --experimental-strip-types --test factory/engine.test.ts factory/policy.test.ts factory/load-allowlist.test.ts factory/state.test.ts factory/github-pr.test.ts factory/scorecard.test.ts` (Node 22+).
 
 ---
 
@@ -222,32 +222,33 @@ Tests: `node --experimental-strip-types --test factory/engine.test.ts factory/po
 
 Promotion rule: Wave 1 may tick only after **two Foundry-attested Wave 0 merges**. That is true (#70 and #72). Historical oss-contribute (5 PRs) counts as mission evidence, not as this control plane’s counter.
 
-### Wave 1 — in flight
+### Wave 1 — followed-up (slot released)
 
 | Packet | Issue | PRs | Status |
 |---|---|---|---|
-| Right sidebar toggle icon | [ColeMurray/background-agents#1476](https://github.com/ColeMurray/background-agents/issues/1476) | Fork [ravidsrk/background-agents#1](https://github.com/ravidsrk/background-agents/pull/1) **closed** (draft, unmerged). Upstream [ColeMurray#1652](https://github.com/ColeMurray/background-agents/pull/1652) **open, ready-for-review** (not draft), `mergeable_state=blocked`, +88/−1 across 3 files, head `48c2242` | **`submitted`** — in-flight. Do not tick another packet |
+| Right sidebar toggle icon | [ColeMurray/background-agents#1476](https://github.com/ColeMurray/background-agents/issues/1476) | Fork [ravidsrk/background-agents#1](https://github.com/ravidsrk/background-agents/pull/1) **closed** (draft, unmerged). Upstream [ColeMurray#1652](https://github.com/ColeMurray/background-agents/pull/1652) **open draft**, verbatim `DISCLOSURE` restored, head `48c2242` | **`followed-up`** — not in-flight. Do not merge |
 
 Policy parsed for #1476 (operator, before open):
 
-- `AGENTS.md`: no AI ban, conventional commits, welcome
+- `AGENTS.md` / `CONTRIBUTING.md` / `CLAUDE.md`: no written external-AI-contribution policy (`aiPolicy: undocumented-open`)
 - `CONTRIBUTING.md`: no CLA/DCO
 - Labels: `good first issue`, `help wanted`, `enhancement`
 - No open competing PR on #1476 at open time
 
-#1652 was opened from a browser session because the GitHub App cannot `POST` pulls on ColeMurray/background-agents (403). It was opened **ready**, not draft, with a shortened disclosure. That is a doctrine miss. Operator next action is follow-up (mark draft if still ready; paste verbatim disclosure if editing the body; do not merge).
+#1652 was opened from a browser session because the GitHub App cannot `POST` pulls on ColeMurray/background-agents (403). It was opened **ready**, not draft, with a shortened disclosure. That doctrine miss is corrected: converted to **draft**, verbatim three-line `DISCLOSURE` restored, packet left `submitted` via `followed-up` (oss-foundry#2).
 
 ### Scorecard (Foundry packets in this control plane)
 
-| Repo | opened | merged | tone | halt |
-|---|---|---|---|---|
-| ravidsrk/orca-fleet | 2 | 2 | warm | no |
-| ravidsrk/frontguard | 1 | 1 | warm | no |
-| ColeMurray/background-agents | 1 | 0 | neutral | no |
-| bans | 0 | | | |
-| reverts | 0 | | | |
+| Repo | opened | merged | terminal | noReview | humanReviewed | reviewCommentsAvg | tone | halt |
+|---|---|---|---|---|---|---|---|---|
+| ravidsrk/orca-fleet | 2 | 2 | 2 | 2 | 0 | — (no human review; Greptile is a bot) | warm | no |
+| ravidsrk/frontguard | 1 | 1 | 1 | 1 | 0 | — | warm | no |
+| ColeMurray/background-agents | 1 | 0 | 0 (still open) | 1 | 0 | — (CodeRabbit only) | neutral | no |
+| bans | 0 | | | | | | | |
+| reverts | 0 | | | | | | | |
+| rework | 0 | | | | | | | |
 
-Merge-rate halt is **not** tripped (`opened ≥ 3` required).
+Merge-rate halt is **not** tripped (needs ≥ 3 **terminal** drafts). Merge rate on terminal Wave 0 packets is 3/3. #1652 is in-flight-for-GitHub but not terminal, so it is not in the merge-rate denominator.
 
 ---
 
@@ -289,10 +290,9 @@ Daily:
 
 Now:
 
-- [ ] Follow ColeMurray#1652 until quiet / merged / closed. **Do not merge.**
-- [ ] Prefer marking #1652 **draft** until CI/tests on that head are green
-- [ ] Do not tick. #1652 is `submitted` (in-flight)
-- [ ] Do not open awesome-copilot or any other Wave 1 packet
+- [ ] #1652 is draft + followed-up. Answer any human review thread if one appears. **Do not merge.**
+- [ ] Tick is allowed; named `firstIssues` are consumed, so the clock **idles** rather than inventing work
+- [ ] Do not open awesome-copilot or any other Wave 1 packet until a first issue is named
 
 Never:
 
@@ -314,10 +314,13 @@ Never:
 
 ## 11. 90-day success
 
+Operational definitions live in [`docs/08-operations.md`](08-operations.md) and `factory/scorecard.ts`.
+
 - ≥ 1 merged PR on a Wave 1 repo that is not ours
-- Merge rate ≥ 60% on opened drafts
-- Review-comment average ≤ 4
-- **Bans = 0. Reverts = 0**
+- **Merge rate ≥ 60%** — denominator is opened drafts that reached a terminal state (merged / closed / stale-closed after 14 quiet days). Stale-closed counts against the rate. In-flight drafts are not in the denominator.
+- **Review-comment average ≤ 4** — mean over human-reviewed PRs only (≥ 1 human, non-bot review comment). Report the **no-review rate** alongside it. A low average with a high no-review rate is silence, not cleanliness.
+- **Bans = 0**
+- **Reverts = 0** — explicit `git revert` of our merge commit, or a maintainer-stated rollback that names the PR, within 30 days of merge. Post-merge edits/refactors are **rework** (informational; they do not trip this KPI or halt).
 - First 20 packets each have a human attest
 
 ---
@@ -355,6 +358,6 @@ Never:
 
 ## 14. Handoff note
 
-You own: follow-up on #1652, all future freezes, allowlist edits, and the halt switch.
+You own: remaining quiet-watch on #1652 (do not merge), all future freezes, allowlist edits, and the halt switch.
 
 Foundry still does not merge. Even on repos you own.

--- a/factory/README.md
+++ b/factory/README.md
@@ -17,7 +17,7 @@ TypeScript modules for the Foundry control plane. No operator web UI lives in th
 
 ```
 node --experimental-strip-types factory/cli.ts status
-node --experimental-strip-types --test factory/engine.test.ts factory/policy.test.ts factory/load-allowlist.test.ts factory/state.test.ts factory/github-pr.test.ts
+node --experimental-strip-types --test factory/engine.test.ts factory/policy.test.ts factory/load-allowlist.test.ts factory/state.test.ts factory/github-pr.test.ts factory/scorecard.test.ts
 node --experimental-strip-types factory/validate-allowlist.ts
 ```
 

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -59,8 +59,10 @@ function printStatus(state: ReturnType<typeof mustLoad>) {
   }
   console.log("scorecard:");
   for (const row of state.scorecard) {
-    if (row.opened === 0 && row.merged === 0 && row.reverts === 0) continue;
-    console.log(`  ${row.repoId}  opened=${row.opened} merged=${row.merged} tone=${row.maintainerTone} health=${health(row)}`);
+    if (row.opened === 0 && row.merged === 0 && row.reverts === 0 && row.noReview === 0) continue;
+    console.log(
+      `  ${row.repoId}  opened=${row.opened} merged=${row.merged} closed=${row.closedUnmerged} noReview=${row.noReview} tone=${row.maintainerTone} health=${health(row)}`,
+    );
   }
 }
 

--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -96,16 +96,26 @@ test("unknown policy without fetched docs is deny, not a canned welcome", () => 
   assert.equal(packet.policy.code, "DENY_UNKNOWN_POLICY");
 });
 
-test("submitted packet is in-flight and blocks a new tick", () => {
+test("followed-up #1652 is not in-flight; submitted still blocks a tick", () => {
   const seed = seedState();
-  assert.equal(hasInflight(seed.packets), true);
-  const submitted = seed.packets.find((p) => p.status === "submitted");
-  assert.ok(submitted);
-  assert.equal(submitted.prUrl, "https://github.com/ColeMurray/background-agents/pull/1652");
-  const ticked = applyTick(seed);
+  const packet = seed.packets.find(
+    (p) => p.prUrl === "https://github.com/ColeMurray/background-agents/pull/1652",
+  );
+  assert.ok(packet);
+  assert.equal(packet.status, "followed-up");
+  assert.equal(packet.prMeta?.draft, true);
+  assert.equal(hasInflight(seed.packets), false);
+  const submitted = {
+    ...seed,
+    packets: seed.packets.map((p) =>
+      p.id === packet.id ? { ...p, status: "submitted" as const } : p,
+    ),
+  };
+  assert.equal(hasInflight(submitted.packets), true);
+  const ticked = applyTick(submitted);
   assert.equal(ticked.packet, null);
   assert.equal(ticked.reason, "in-flight");
-  const queued = applyQueueLive(seed, live("ravidsrk/frontguard", 999));
+  const queued = applyQueueLive(submitted, live("ravidsrk/frontguard", 999));
   assert.equal(queued.packet, null);
   assert.equal(queued.reason, "in-flight");
 });
@@ -124,7 +134,13 @@ test("scorecard halt stop blocks queue and approve", () => {
   const state = blank();
   state.scorecard = state.scorecard.map((row) =>
     row.repoId === "ravidsrk/orca-fleet"
-      ? { ...row, opened: CAPS.halt_after_opens, merged: 0, maintainerTone: "neutral" as const }
+      ? {
+          ...row,
+          opened: CAPS.halt_after_opens,
+          merged: 0,
+          closedUnmerged: CAPS.halt_after_opens,
+          maintainerTone: "neutral" as const,
+        }
       : row,
   );
   assert.equal(health(state.scorecard.find((r) => r.repoId === "ravidsrk/orca-fleet")!), "stop");
@@ -135,20 +151,14 @@ test("scorecard halt stop blocks queue and approve", () => {
 
 test("tick idles instead of inventing #9000+ issues", () => {
   const seed = seedState();
-  const quiet = {
-    ...seed,
-    packets: seed.packets.map((p) =>
-      p.status === "submitted" ? { ...p, status: "followed-up" as const } : p,
-    ),
-  };
-  assert.equal(hasInflight(quiet.packets), false);
-  const ticked = applyTick(quiet);
+  assert.equal(hasInflight(seed.packets), false);
+  const ticked = applyTick(seed);
   assert.equal(ticked.packet, null);
   assert.equal(ticked.reason, "idle");
-  assert.equal(ticked.state.packets.length, quiet.packets.length);
+  assert.equal(ticked.state.packets.length, seed.packets.length);
   assert.equal(
     ticked.state.packets.map((p) => `${p.repoId}#${p.issueNumber}`).join(","),
-    quiet.packets.map((p) => `${p.repoId}#${p.issueNumber}`).join(","),
+    seed.packets.map((p) => `${p.repoId}#${p.issueNumber}`).join(","),
   );
 });
 

--- a/factory/load-allowlist.test.ts
+++ b/factory/load-allowlist.test.ts
@@ -8,6 +8,25 @@ test("committed allowlist.yaml parses and keeps denylist disjoint", () => {
   assertAllowlist(parsed);
   assert.equal(parsed.denylist.some((d) => d.id === "stablyai/orca"), true);
   assert.equal(parsed.repos.some((r) => r.id === "stablyai/orca"), false);
+
+  const pydantic = parsed.denylist.find((d) => d.id === "pydantic/pydantic");
+  assert.ok(pydantic);
+  assert.match(pydantic.reason, /mass-submitting/);
+  assert.equal(/slop-PR close rate/i.test(pydantic.reason), false);
+
+  const orca = parsed.denylist.find((d) => d.id === "stablyai/orca");
+  assert.ok(orca);
+  assert.match(orca.reason, /Conflict of interest/i);
+
+  assert.equal(parsed.repos.some((r) => r.id === "OpenHands/OpenHands"), true);
+  assert.equal(parsed.repos.some((r) => r.id === "All-Hands-AI/OpenHands"), false);
+  assert.equal(parsed.repos.some((r) => r.id === "e2b-dev/e2b-cookbook"), true);
+  assert.equal(parsed.repos.some((r) => r.id === "e2b-dev/E2B"), false);
+
+  const ba = parsed.repos.find((r) => r.id === "ColeMurray/background-agents");
+  assert.equal(ba?.aiPolicy, "undocumented-open");
+  const copilot = parsed.repos.find((r) => r.id === "github/awesome-copilot");
+  assert.match(copilot?.language ?? "", /JavaScript/);
 });
 
 test("omitted wave is not coerced to Wave 0 host-trusted", () => {
@@ -22,11 +41,11 @@ test("omitted wave is not coerced to Wave 0 host-trusted", () => {
 test("Wave 2 host sandbox is rejected at load", () => {
   const yaml = readFileSync(new URL("../allowlist.yaml", import.meta.url), "utf8");
   const host = yaml.replace(
-    "  - id: All-Hands-AI/OpenHands\n    wave: 2\n    language: Python\n    aiPolicy: human-required\n    testCommand: poetry run pytest\n    maxFiles: 3\n    maxDiffLines: 140\n    sandbox: e2b",
-    "  - id: All-Hands-AI/OpenHands\n    wave: 2\n    language: Python\n    aiPolicy: human-required\n    testCommand: poetry run pytest\n    maxFiles: 3\n    maxDiffLines: 140\n    sandbox: host",
+    /(\n  - id: OpenHands\/OpenHands[\s\S]*?sandbox: )e2b/,
+    "$1host",
   );
   const parsed = parseAllowlistYaml(host);
-  assert.throws(() => assertAllowlist(parsed), /Wave 1\+ repo All-Hands-AI\/OpenHands must not use host sandbox/);
+  assert.throws(() => assertAllowlist(parsed), /Wave 1\+ repo OpenHands\/OpenHands must not use host sandbox/);
 });
 
 test("a denylist id among repos fails assertion", () => {

--- a/factory/load-allowlist.ts
+++ b/factory/load-allowlist.ts
@@ -92,7 +92,14 @@ function hydrateRepo(r: Record<string, unknown>): AllowlistedRepo {
   const wave = r.wave as Wave;
   if (wave !== 0 && wave !== 1 && wave !== 2) throw new Error(`allowlist.yaml: ${id} bad wave`);
   const aiPolicy = String(r.aiPolicy) as AiPolicy;
-  const allowedPolicy: AiPolicy[] = ["owner", "welcome", "human-required", "unknown", "forbidden"];
+  const allowedPolicy: AiPolicy[] = [
+    "owner",
+    "welcome",
+    "undocumented-open",
+    "human-required",
+    "unknown",
+    "forbidden",
+  ];
   if (!allowedPolicy.includes(aiPolicy)) throw new Error(`allowlist.yaml: ${id} bad aiPolicy`);
   const sandbox = String(r.sandbox) as SandboxKind;
   if (sandbox !== "host" && sandbox !== "e2b" && sandbox !== "daytona") {

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -12,7 +12,7 @@ test("denylist always forbids matplotlib", () => {
   assert.equal(v.allow, false);
 });
 
-test("forbidden phrase beats a welcome repo", () => {
+test("forbidden phrase beats an undocumented-open repo", () => {
   const v = evaluatePolicy({
     repoId: "ColeMurray/background-agents",
     agentsMd: "Autonomous agents not allowed on this tracker.",
@@ -21,9 +21,28 @@ test("forbidden phrase beats a welcome repo", () => {
   assert.equal(v.code, "DENY_FORBIDDEN");
 });
 
+test("undocumented-open without fetched docs is deny, with docs is ALLOW", () => {
+  const missing = evaluatePolicy({
+    repoId: "ColeMurray/background-agents",
+    issueTitle: "icon tweak",
+  });
+  assert.equal(missing.code, "DENY_UNKNOWN_POLICY");
+  assert.equal(missing.allow, false);
+
+  const parsed = evaluatePolicy({
+    repoId: "ColeMurray/background-agents",
+    agentsMd: "Conventional commits. Keep diffs small.",
+    contributing: "Patch-size notes. No extra legal paperwork.",
+    issueTitle: "icon tweak",
+  });
+  assert.equal(parsed.code, "ALLOW");
+  assert.equal(parsed.allow, true);
+  assert.match(parsed.reasons.join(" "), /undocumented/);
+});
+
 test("CLA parks needs-human", () => {
   const v = evaluatePolicy({
-    repoId: "All-Hands-AI/OpenHands",
+    repoId: "OpenHands/OpenHands",
     agentsMd: "Please sign the CLA. HUMAN: required.",
     issueTitle: "docs FAQ",
   });

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -77,12 +77,18 @@ export function evaluatePolicy(input: {
     };
   }
 
-  if (repo.aiPolicy === "unknown" && !input.agentsMd && !input.contributing) {
+  if (
+    (repo.aiPolicy === "unknown" || repo.aiPolicy === "undocumented-open") &&
+    !input.agentsMd &&
+    !input.contributing
+  ) {
     return {
       allow: false,
       code: "DENY_UNKNOWN_POLICY",
       reasons: [
-        "AI policy is unknown. Fetch AGENTS.md / CONTRIBUTING and re-run the gate before freeze.",
+        repo.aiPolicy === "undocumented-open"
+          ? "AI policy is behaviorally open but undocumented. Fetch AGENTS.md / CONTRIBUTING and re-run the gate before freeze."
+          : "AI policy is unknown. Fetch AGENTS.md / CONTRIBUTING and re-run the gate before freeze.",
       ],
       matchedPhrases: [],
     };
@@ -134,7 +140,11 @@ export function evaluatePolicy(input: {
     };
   }
 
-  reasons.push("Allowlisted, policy parsed, scope inside caps.");
+  reasons.push(
+    repo.aiPolicy === "undocumented-open"
+      ? "Allowlisted; AI policy is behaviorally open but undocumented. Scope inside caps."
+      : "Allowlisted, policy parsed, scope inside caps.",
+  );
   return { allow: true, code: "ALLOW", reasons, matchedPhrases: matched };
 }
 

--- a/factory/scorecard.test.ts
+++ b/factory/scorecard.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { CAPS } from "./allowlist.ts";
+import {
+  applyPacketToScorecard,
+  emptyScorecard,
+  factoryKpis,
+  health,
+  mergeRate,
+  noReviewRate,
+  terminalDrafts,
+} from "./scorecard.ts";
+import type { TaskPacket } from "./types.ts";
+
+function packet(repoId: string): TaskPacket {
+  return { id: `pkt_${repoId.replace("/", "_")}_1`, repoId } as TaskPacket;
+}
+
+test("merge rate uses terminal drafts; stale-closed counts against it", () => {
+  let rows = emptyScorecard();
+  const pkt = packet("ravidsrk/orca-fleet");
+  rows = applyPacketToScorecard(rows, pkt, "opened");
+  rows = applyPacketToScorecard(rows, pkt, "opened");
+  rows = applyPacketToScorecard(rows, pkt, "opened");
+  const inflight = rows.find((r) => r.repoId === "ravidsrk/orca-fleet")!;
+  assert.equal(inflight.opened, 3);
+  assert.equal(terminalDrafts(inflight), 0);
+  assert.equal(mergeRate(inflight), 0);
+  assert.equal(health(inflight), "good");
+
+  rows = applyPacketToScorecard(rows, pkt, "merged", { humanReviewComments: 2 });
+  rows = applyPacketToScorecard(rows, pkt, "stale-closed", { humanReviewComments: 0 });
+  rows = applyPacketToScorecard(rows, pkt, "closed", { humanReviewComments: 3 });
+  const row = rows.find((r) => r.repoId === "ravidsrk/orca-fleet")!;
+  assert.equal(row.merged, 1);
+  assert.equal(row.closedUnmerged, 2);
+  assert.equal(row.staleClosed, 1);
+  assert.equal(terminalDrafts(row), 3);
+  assert.equal(mergeRate(row), 1 / 3);
+  assert.equal(health(row), "stop");
+  assert.equal(row.humanReviewed, 2);
+  assert.equal(row.noReview, 1);
+  assert.equal(row.reviewCommentsAvg, 2.5);
+  assert.equal(noReviewRate(row), 1 / 3);
+});
+
+test("reviewCommentsAvg ignores silent PRs; noReview is the companion counter", () => {
+  let rows = emptyScorecard();
+  const pkt = packet("ravidsrk/frontguard");
+  rows = applyPacketToScorecard(rows, pkt, "merged", { humanReviewComments: 4 });
+  rows = applyPacketToScorecard(rows, pkt, "merged", { humanReviewComments: 0 });
+  rows = applyPacketToScorecard(rows, pkt, "merged", { humanReviewComments: 0 });
+  const row = rows.find((r) => r.repoId === "ravidsrk/frontguard")!;
+  assert.equal(row.reviewCommentsAvg, 4);
+  assert.equal(row.humanReviewed, 1);
+  assert.equal(row.noReview, 2);
+  assert.equal(noReviewRate(row), 2 / 3);
+  const kpis = factoryKpis(rows);
+  assert.equal(kpis.reviewCommentsAvg, 4);
+  assert.equal(kpis.noReview, 2);
+  assert.equal(kpis.mergeRate, 1);
+});
+
+test("rework is informational and does not halt; revert does", () => {
+  let rows = emptyScorecard();
+  const pkt = packet("ravidsrk/orca-fleet");
+  rows = applyPacketToScorecard(rows, pkt, "merged");
+  rows = applyPacketToScorecard(rows, pkt, "rework");
+  const afterRework = rows.find((r) => r.repoId === "ravidsrk/orca-fleet")!;
+  assert.equal(afterRework.rework, 1);
+  assert.equal(afterRework.reverts, 0);
+  assert.equal(health(afterRework), "good");
+
+  rows = applyPacketToScorecard(rows, pkt, "reverted");
+  const afterRevert = rows.find((r) => r.repoId === "ravidsrk/orca-fleet")!;
+  assert.equal(afterRevert.reverts, 1);
+  assert.equal(health(afterRevert), "stop");
+});
+
+test("halt_after_opens needs terminal outcomes, not in-flight drafts", () => {
+  const rows = emptyScorecard().map((row) =>
+    row.repoId === "ravidsrk/orca-fleet"
+      ? { ...row, opened: CAPS.halt_after_opens, merged: 0, closedUnmerged: 0 }
+      : row,
+  );
+  const inflight = rows.find((r) => r.repoId === "ravidsrk/orca-fleet")!;
+  assert.equal(health(inflight), "good");
+});

--- a/factory/scorecard.ts
+++ b/factory/scorecard.ts
@@ -1,36 +1,75 @@
 import { ALLOWLIST, CAPS } from "./allowlist.ts";
 import type { ScorecardRow, TaskPacket } from "./types.ts";
 
+/** Explicit git-revert of our merge, or maintainer-stated rollback naming the PR, counted if within this many days of merge. */
+export const REVERT_WINDOW_DAYS = 30;
+
+/** Quiet drafts become stale-closed (count against merge rate) after this many days with no human activity. */
+export const STALE_QUIET_DAYS = 14;
+
+export type ScoreKind = "opened" | "merged" | "closed" | "stale-closed" | "reverted" | "rework";
+
 export function emptyScorecard(): ScorecardRow[] {
   return ALLOWLIST.map((repo) => ({
     repoId: repo.id,
     opened: 0,
     merged: 0,
     closedUnmerged: 0,
+    staleClosed: 0,
     reviewCommentsAvg: 0,
+    humanReviewed: 0,
+    noReview: 0,
     reverts: 0,
+    rework: 0,
     maintainerTone: "neutral" as const,
     lastTouch: "—",
   }));
 }
 
+/** Opened drafts that reached a terminal state. Stale-closed is included via closedUnmerged. */
+export function terminalDrafts(row: ScorecardRow): number {
+  return row.merged + row.closedUnmerged;
+}
+
+/** merged / terminal. In-flight drafts are not in the denominator. */
 export function mergeRate(row: ScorecardRow): number {
-  if (row.opened === 0) return 0;
-  return row.merged / row.opened;
+  const den = terminalDrafts(row);
+  if (den === 0) return 0;
+  return row.merged / den;
+}
+
+/** noReview / (humanReviewed + noReview). Distinct from reviewCommentsAvg. */
+export function noReviewRate(row: ScorecardRow): number {
+  const den = row.humanReviewed + row.noReview;
+  if (den === 0) return 0;
+  return row.noReview / den;
 }
 
 export function health(row: ScorecardRow): "good" | "watch" | "stop" {
   if (row.maintainerTone === "banned" || row.reverts > 0) return "stop";
-  if (row.opened >= CAPS.halt_after_opens && mergeRate(row) < CAPS.halt_merge_rate) return "stop";
+  if (terminalDrafts(row) >= CAPS.halt_after_opens && mergeRate(row) < CAPS.halt_merge_rate) {
+    return "stop";
+  }
   if (row.maintainerTone === "cold") return "watch";
-  if (row.opened >= 2 && mergeRate(row) < 0.6) return "watch";
+  if (terminalDrafts(row) >= 2 && mergeRate(row) < 0.6) return "watch";
   return "good";
+}
+
+function recordHumanReview(row: ScorecardRow, humanReviewComments: number): void {
+  if (humanReviewComments >= 1) {
+    const n = row.humanReviewed;
+    row.reviewCommentsAvg = (row.reviewCommentsAvg * n + humanReviewComments) / (n + 1);
+    row.humanReviewed = n + 1;
+  } else {
+    row.noReview += 1;
+  }
 }
 
 export function applyPacketToScorecard(
   rows: ScorecardRow[],
   packet: TaskPacket,
-  kind: "opened" | "merged" | "closed" | "reverted",
+  kind: ScoreKind,
+  review?: { humanReviewComments: number },
 ): ScorecardRow[] {
   return rows.map((row) => {
     if (row.repoId !== packet.repoId) return row;
@@ -38,7 +77,13 @@ export function applyPacketToScorecard(
     if (kind === "opened") next.opened += 1;
     if (kind === "merged") next.merged += 1;
     if (kind === "closed") next.closedUnmerged += 1;
+    if (kind === "stale-closed") {
+      next.closedUnmerged += 1;
+      next.staleClosed += 1;
+    }
     if (kind === "reverted") next.reverts += 1;
+    if (kind === "rework") next.rework += 1;
+    if (review) recordHumanReview(next, review.humanReviewComments);
     return next;
   });
 }
@@ -46,13 +91,28 @@ export function applyPacketToScorecard(
 export function factoryKpis(rows: ScorecardRow[]) {
   const opened = rows.reduce((a, r) => a + r.opened, 0);
   const merged = rows.reduce((a, r) => a + r.merged, 0);
+  const closedUnmerged = rows.reduce((a, r) => a + r.closedUnmerged, 0);
+  const staleClosed = rows.reduce((a, r) => a + r.staleClosed, 0);
+  const terminal = merged + closedUnmerged;
   const reverts = rows.reduce((a, r) => a + r.reverts, 0);
+  const rework = rows.reduce((a, r) => a + r.rework, 0);
+  const noReview = rows.reduce((a, r) => a + r.noReview, 0);
+  const humanReviewed = rows.reduce((a, r) => a + r.humanReviewed, 0);
   const banned = rows.filter((r) => r.maintainerTone === "banned").length;
+  const reviewWeighted = rows.reduce((a, r) => a + r.reviewCommentsAvg * r.humanReviewed, 0);
   return {
     opened,
     merged,
-    mergeRate: opened === 0 ? 0 : merged / opened,
+    closedUnmerged,
+    staleClosed,
+    terminal,
+    mergeRate: terminal === 0 ? 0 : merged / terminal,
+    reviewCommentsAvg: humanReviewed === 0 ? 0 : reviewWeighted / humanReviewed,
+    noReview,
+    humanReviewed,
+    noReviewRate: humanReviewed + noReview === 0 ? 0 : noReview / (humanReviewed + noReview),
     reverts,
+    rework,
     banned,
   };
 }

--- a/factory/seed.ts
+++ b/factory/seed.ts
@@ -195,12 +195,11 @@ export function seedState(): FactoryState {
     issueTitle: "Differentiate the right sidebar toggle icon by state",
     issueUrl: "https://github.com/ColeMurray/background-agents/issues/1476",
     labels: ["good first issue", "help wanted", "enhancement"],
-    agentsMd:
-      "Well-formed agent PRs are welcome if they include tests, a failing-first reproduction, and a short disclosure. Keep diffs small.",
-    contributing: "No CLA. No DCO. Conventional commits.",
+    agentsMd: "Conventional commits. Keep diffs small. No written external-AI-contribution policy.",
+    contributing: "Patch-size notes. Conventional commits.",
   });
   sidebar = {
-    ...touch(sidebar, "submitted", "follow-up"),
+    ...touch(sidebar, "followed-up", "follow-up"),
     humanAttest: {
       by: "operator",
       at: "2026-08-27T12:00:00.000Z",
@@ -211,23 +210,30 @@ export function seedState(): FactoryState {
     prMeta: {
       url: "https://github.com/ColeMurray/background-agents/pull/1652",
       title: "feat: differentiate the right sidebar toggle icon by state",
-      draft: false,
+      draft: true,
       state: "open",
       merged: false,
-      mergeable: "blocked",
+      mergeable: "MERGEABLE",
       commits: 6,
       reviewComments: 0,
       issueComments: 1,
       headSha: "48c2242683705b00503d3436575bf3c28b1b0c9b",
-      updatedAt: "2026-08-28T10:19:46.000Z",
-      syncedAt: "2026-08-28T10:30:00.000Z",
+      updatedAt: "2026-08-28T13:47:44.000Z",
+      syncedAt: "2026-08-28T13:47:44.000Z",
     },
     followUps: [
+      {
+        id: "fu_pr1652_followed_up",
+        at: "2026-08-28T13:47:44.000Z",
+        kind: "note",
+        body: "Converted #1652 to draft; pasted verbatim DISCLOSURE from factory/neighbor.ts. No maintainer response (CodeRabbit only — not a human review). Marked followed-up; in-flight slot released. Do not merge.",
+        url: "https://github.com/ColeMurray/background-agents/pull/1652",
+      },
       {
         id: "fu_pr1652_opened",
         at: "2026-08-28T10:14:03.000Z",
         kind: "note",
-        body: "Upstream PR opened ready-for-review (doctrine miss: should have been draft). Fork rehearsal ravidsrk/background-agents#1 closed. Follow up; do not merge; do not tick.",
+        body: "Upstream PR opened ready-for-review (doctrine miss: should have been draft). Fork rehearsal ravidsrk/background-agents#1 closed.",
         url: "https://github.com/ColeMurray/background-agents/pull/1652",
       },
     ],
@@ -241,7 +247,8 @@ export function seedState(): FactoryState {
       filesChanged: 3,
       diffLines: 89,
       notes: [
-        "Opened ready, not draft. Shortened disclosure on GitHub vs renderPrBody.",
+        "Converted to draft 2026-08-28. Verbatim DISCLOSURE restored on the GitHub body.",
+        "Packet left submitted via followed-up (oss-foundry#2). In-flight slot released.",
         "Fork PR #1 closed unmerged.",
       ],
     },
@@ -256,10 +263,10 @@ export function seedState(): FactoryState {
   });
 
   const openhands = buildPacket({
-    repoId: "All-Hands-AI/OpenHands",
+    repoId: "OpenHands/OpenHands",
     issueNumber: 16907,
     issueTitle: "Document HUMAN: requirement in contributor FAQ",
-    issueUrl: "https://github.com/All-Hands-AI/OpenHands/issues/16907",
+    issueUrl: "https://github.com/OpenHands/OpenHands/issues/16907",
     labels: ["documentation"],
     agentsMd: "Please sign the CLA. HUMAN: required.",
     contributing: "Developer Certificate of Origin. Sign-off required.",
@@ -271,7 +278,13 @@ export function seedState(): FactoryState {
         ...row,
         opened: 2,
         merged: 2,
-        reviewCommentsAvg: 0.5,
+        closedUnmerged: 0,
+        staleClosed: 0,
+        reviewCommentsAvg: 0,
+        humanReviewed: 0,
+        noReview: 2,
+        reverts: 0,
+        rework: 0,
         maintainerTone: "warm" as const,
         lastTouch: "2026-08-27",
       };
@@ -281,7 +294,13 @@ export function seedState(): FactoryState {
         ...row,
         opened: 1,
         merged: 1,
+        closedUnmerged: 0,
+        staleClosed: 0,
         reviewCommentsAvg: 0,
+        humanReviewed: 0,
+        noReview: 1,
+        reverts: 0,
+        rework: 0,
         maintainerTone: "warm" as const,
         lastTouch: "2026-08-28",
       };
@@ -291,7 +310,13 @@ export function seedState(): FactoryState {
         ...row,
         opened: 1,
         merged: 0,
+        closedUnmerged: 0,
+        staleClosed: 0,
         reviewCommentsAvg: 0,
+        humanReviewed: 0,
+        noReview: 1,
+        reverts: 0,
+        rework: 0,
         maintainerTone: "neutral" as const,
         lastTouch: "2026-08-28",
       };
@@ -304,12 +329,20 @@ export function seedState(): FactoryState {
     packets: [sidebar, unreadable, architecture, changelog, matplotlib, openhands],
     events: [
       {
+        id: "evt_pr1652_followup",
+        at: "2026-08-28T13:47:44.000Z",
+        kind: "follow-up",
+        packetId: sidebar.id,
+        message:
+          "ColeMurray/background-agents#1652 converted to draft; verbatim disclosure restored; packet followed-up. In-flight slot released. Do not merge.",
+      },
+      {
         id: "evt_pr1652",
         at: "2026-08-28T10:14:03.000Z",
         kind: "draft",
         packetId: sidebar.id,
         message:
-          "Wave 1 upstream PR ColeMurray/background-agents#1652 opened (ready, not draft). Follow up. Do not merge. Do not tick.",
+          "Wave 1 upstream PR ColeMurray/background-agents#1652 opened (ready, not draft). Later converted to draft and followed-up.",
       },
       {
         id: "evt_pr196_merged",

--- a/factory/state.test.ts
+++ b/factory/state.test.ts
@@ -88,6 +88,10 @@ test("v6 ledger missing later-required fields is migrated, not stranded", () => 
   packet.scout = scout;
   const row = { ...(seed.scorecard[0] as Record<string, unknown>) };
   delete row.closedUnmerged;
+  delete row.staleClosed;
+  delete row.humanReviewed;
+  delete row.noReview;
+  delete row.rework;
   delete row.lastTouch;
   const path = join(mkdtempSync(join(tmpdir(), "foundry-")), "old-v6.json");
   writeFileSync(
@@ -106,6 +110,10 @@ test("v6 ledger missing later-required fields is migrated, not stranded", () => 
   assert.equal(loaded.state.packets[0].policy.reasons.length, 0);
   assert.equal(loaded.state.packets[0].scout.parts.wave, 0);
   assert.equal(loaded.state.scorecard[0].closedUnmerged, 0);
+  assert.equal(loaded.state.scorecard[0].staleClosed, 0);
+  assert.equal(loaded.state.scorecard[0].noReview, 0);
+  assert.equal(loaded.state.scorecard[0].humanReviewed, 0);
+  assert.equal(loaded.state.scorecard[0].rework, 0);
   assert.equal(loaded.state.scorecard[0].lastTouch, "—");
 });
 

--- a/factory/state.ts
+++ b/factory/state.ts
@@ -236,8 +236,12 @@ function isScorecardRow(value: unknown): boolean {
     typeof o.opened === "number" &&
     typeof o.merged === "number" &&
     typeof o.closedUnmerged === "number" &&
+    typeof o.staleClosed === "number" &&
     typeof o.reviewCommentsAvg === "number" &&
+    typeof o.humanReviewed === "number" &&
+    typeof o.noReview === "number" &&
     typeof o.reverts === "number" &&
+    typeof o.rework === "number" &&
     typeof o.maintainerTone === "string" &&
     TONES.has(o.maintainerTone) &&
     typeof o.lastTouch === "string"
@@ -303,8 +307,12 @@ function migrateScorecard(value: unknown): unknown {
   if (!value || typeof value !== "object") return value;
   const o = { ...(value as Record<string, unknown>) };
   if (o.closedUnmerged === undefined) o.closedUnmerged = 0;
+  if (o.staleClosed === undefined) o.staleClosed = 0;
   if (o.reviewCommentsAvg === undefined) o.reviewCommentsAvg = 0;
+  if (o.humanReviewed === undefined) o.humanReviewed = 0;
+  if (o.noReview === undefined) o.noReview = 0;
   if (o.reverts === undefined) o.reverts = 0;
+  if (o.rework === undefined) o.rework = 0;
   if (o.lastTouch === undefined) o.lastTouch = "—";
   return o;
 }

--- a/factory/types.ts
+++ b/factory/types.ts
@@ -2,6 +2,7 @@ export type Wave = 0 | 1 | 2;
 export type AiPolicy =
   | "owner"
   | "welcome"
+  | "undocumented-open"
   | "human-required"
   | "unknown"
   | "forbidden";
@@ -160,11 +161,29 @@ export interface SandboxSession {
 
 export interface ScorecardRow {
   repoId: string;
+  /** Drafts we opened. Volume only; not the merge-rate denominator. */
   opened: number;
   merged: number;
+  /** Terminal unmerged drafts, including stale-closed after 14 quiet days. */
   closedUnmerged: number;
+  /** Subset of closedUnmerged: auto-closed after STALE_QUIET_DAYS with no human activity. */
+  staleClosed: number;
+  /**
+   * Mean human (non-bot) review comments over `humanReviewed` PRs only.
+   * Do not average in silent/no-review PRs.
+   */
   reviewCommentsAvg: number;
+  /** Opened drafts with ≥1 human, non-bot review comment. Denominator for reviewCommentsAvg. */
+  humanReviewed: number;
+  /** Opened drafts with 0 human, non-bot review comments (bot-only counts as no-review). */
+  noReview: number;
+  /**
+   * Explicit `git revert` of our merge commit, or a maintainer-stated rollback
+   * that names the PR, within REVERT_WINDOW_DAYS of merge. Rework is not a revert.
+   */
   reverts: number;
+  /** Post-merge edits/refactors of our code. Informational; does not halt. */
+  rework: number;
   maintainerTone: "warm" | "neutral" | "cold" | "banned";
   lastTouch: string;
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "test": "node --experimental-strip-types --test factory/engine.test.ts factory/policy.test.ts factory/load-allowlist.test.ts factory/state.test.ts factory/github-pr.test.ts",
+    "test": "node --experimental-strip-types --test factory/engine.test.ts factory/policy.test.ts factory/load-allowlist.test.ts factory/state.test.ts factory/github-pr.test.ts factory/scorecard.test.ts",
     "validate": "node --experimental-strip-types factory/validate-allowlist.ts",
     "foundry": "node --experimental-strip-types factory/cli.ts"
   }


### PR DESCRIPTION
Fixes #3
Fixes #4
Related: #2

## Why

Live verification found six factual errors in `allowlist.yaml`, and the 90-day KPIs were under-defined so the scorecard could be computed the wrong way. The Wave 1 packet (ColeMurray/background-agents#1652) is now draft with verbatim disclosure; this records that in the local ledger and releases the in-flight slot.

## #3 — allowlist facts

- **pydantic/pydantic** — deny kept. Reason is their mass-submit / factory-pattern close-right plus assignment-first auto-close. CONTRIBUTING welcomes AI; dropped the unsubstantiated “slop-PR close rate.”
- **stablyai/orca** — deny kept. Honest reason is conflict of interest (Foundry’s runtime; contribute via orca-fleet). CONTRIBUTING requires an AI review summary.
- **All-Hands-AI/OpenHands → OpenHands/OpenHands.** Policy lives in the PR template (`HUMAN:`/`AGENT:`, end-to-end evidence) and the `ready-for-dev` label. Language/test command updated to TypeScript / `npm test`.
- **e2b-dev/E2B → e2b-dev/e2b-cookbook.** SDK examples were removed in E2B#1769; cookbook is the docs/examples surface.
- **ColeMurray/background-agents** — `aiPolicy: undocumented-open` (new enum). Behavior is open; CONTRIBUTING/AGENTS/CLAUDE have no written external-AI policy. Fetch docs before freeze.
- **github/awesome-copilot** — language is `JavaScript / Markdown`.

Docs (`docs/03-allowlist.md`, `docs/PRODUCT.md` §2/§6, `docs/00-vision.md`) no longer cite the pydantic slop-rate claim.

## #4 — metric definitions

Encoded in `docs/08-operations.md` (“Metrics that matter”), vision/PRODUCT §11, and `factory/scorecard.ts`:

- **Revert** = explicit `git revert` of the merge commit, or a maintainer-stated rollback naming the PR, within 30 days. Post-merge edits are **rework** (informational; do not halt).
- **Review-comment average** = mean over human-reviewed PRs only (`humanReviewed`, ≥1 human non-bot comment). **`noReview`** is the companion counter so silence cannot masquerade as a low average.
- **Merge-rate denominator** = opened drafts that reached a terminal state (merged / closed / stale-closed after 14 quiet days). Stale-closed counts against the rate. In-flight drafts are not in the sample.

## #2 — ledger half

Live-verified ColeMurray/background-agents#1652: `isDraft=true`, verbatim `DISCLOSURE` on the body. `factory/seed.ts` and `docs/12-ledger.md` record the packet as **`followed-up`** (slot released). Do not merge. This repo does not convert the upstream PR; parent session owns that GitHub action.

## Tests

`node --experimental-strip-types --test factory/engine.test.ts factory/policy.test.ts factory/load-allowlist.test.ts factory/state.test.ts factory/github-pr.test.ts factory/scorecard.test.ts` — 42 pass.

Not in scope: P1/P2 issues (#5–#16), including naming a first issue on awesome-copilot.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects allowlist facts and ledger state, adds the `undocumented-open` policy classification, and defines terminal-draft, human-review, revert, and rework scorecard semantics.

- Retargets and updates allowlist repository metadata and policy handling.
- Marks background-agents#1652 as a followed-up draft and releases its in-flight slot.
- Expands scorecard fields, KPI calculations, migration defaults, documentation, and tests.
- The new scorecard outcomes are not yet connected to production PR synchronization, so live KPIs remain incomplete.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until real PR lifecycle and review events are wired into the new scorecard API, otherwise the advertised KPIs and halt decisions remain incorrect.

The scorecard computes the new metrics correctly when called, but production emits only the opened event, so terminal outcomes, reviews, stale closures, reverts, and rework remain unrecorded.

**Files Needing Attention:** factory/scorecard.ts and the PR synchronization/follow-up integration path
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| factory/scorecard.ts | Adds the requested KPI calculations and counters, but the new lifecycle and review inputs have no production producers. |
| factory/engine.ts | Updates halt tests and in-flight behavior; its sole scorecard call still records only draft opening. |
| factory/policy.ts | Adds the undocumented-open fetch gate and explanatory verdict while retaining deny-phrase checks. |
| factory/state.ts | Validates and migrates the newly added scorecard fields with backward-compatible defaults. |
| factory/seed.ts | Records PR #1652 as draft and followed-up and updates seeded scorecard and repository metadata. |
| allowlist.yaml | Corrects repository identities, languages, policy classifications, and deny reasons. |
| factory/scorecard.test.ts | Thoroughly tests scorecard calculations in isolation but does not exercise production event integration. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Attach draft] -->|opened| B[applyPacketToScorecard]
  C[PR sync: merged or closed] -. no scorecard event .-> B
  D[Human review activity] -. no review metadata .-> B
  E[Stale, revert, or rework detection] -. no production producer .-> B
  B --> F[Persisted scorecard]
  F --> G[KPIs and repository health]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20ravidsrk%2Foss-foundry%20PR%20%2317%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=ravidsrk%2Foss-foundry&pr=17&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Afactory%2Fscorecard.ts%3A68-74%0A**Scorecard%20events%20are%20never%20emitted**%0A%0AWhen%20tracked%20pull%20requests%20are%20reviewed%2C%20merged%2C%20closed%2C%20reverted%2C%20reworked%2C%20or%20become%20stale%2C%20production%20code%20never%20calls%20%60applyPacketToScorecard%60%20with%20those%20events%20or%20review%20metadata%2C%20causing%20the%20new%20KPI%20counters%20and%20repository%20health%20decisions%20to%20remain%20based%20on%20stale%20zero%20values.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ravidsrk%2Foss-foundry&pr=17&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
factory/scorecard.ts:68-74
**Scorecard events are never emitted**

When tracked pull requests are reviewed, merged, closed, reverted, reworked, or become stale, production code never calls `applyPacketToScorecard` with those events or review metadata, causing the new KPI counters and repository health decisions to remain based on stale zero values.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: correct allowlist facts, define sco..."](https://github.com/ravidsrk/oss-foundry/commit/f3ff0200c6cb8772f34857c05fde4cd1d7a82baf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57913381)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->