### PR TITLE
fix(allowlist): correct six live-verified factual errors

### DIFF
--- a/allowlist.yaml
+++ b/allowlist.yaml
@@ -15,9 +15,9 @@ denylist:
   - id: curl/curl
     reason: Maintainer asked agents to stop after HackerOne flood.
   - id: pydantic/pydantic
-    reason: High slop-PR close rate in 2026.
+    reason: "Welcomes AI-assisted PRs, but auto-closes unassigned PRs and reserves closing mass-submitted PRs across repos - the factory pattern. Denied as a poor factory fit, not as anti-AI."
   - id: stablyai/orca
-    reason: Contribute via orca-fleet, not drive-by PRs.
+    reason: "No upstream AI restriction (PRs must include an AI review summary). Denied for conflict of interest: it is the runtime Foundry rides. Contribute via orca-fleet."
 
 repos:
   - id: ravidsrk/orca-fleet
@@ -51,7 +51,8 @@ repos:
   - id: ColeMurray/background-agents
     wave: 1
     language: TypeScript
-    aiPolicy: welcome
+    aiPolicy: unknown
+    policyNotes: "No written AI-contribution policy in CONTRIBUTING, AGENTS.md, or CLAUDE.md as of 2026-08-28. Behaviorally open (141 of 272 external PRs merged). Unknown until policy text exists - see issue 3."
     testCommand: npm test
     maxFiles: 6
     maxDiffLines: 280
@@ -64,7 +65,7 @@ repos:
 
   - id: github/awesome-copilot
     wave: 1
-    language: Markdown
+    language: Markdown content (repo language JavaScript)
     aiPolicy: welcome
     testCommand: "true"
     maxFiles: 3
@@ -77,6 +78,7 @@ repos:
     wave: 1
     language: TypeScript / Python
     aiPolicy: welcome
+    policyNotes: "Docs and SDK examples moved out of this repo (PR 1769 merged 2026-08-25). Realistic surface is e2b-dev/e2b-cookbook. Retarget tracked in issue 12."
     testCommand: npm test
     maxFiles: 5
     maxDiffLines: 220
@@ -117,7 +119,7 @@ repos:
     preferredLabels: ["good first issue", documentation]
     firstIssues: []
 
-  - id: All-Hands-AI/OpenHands
+  - id: OpenHands/OpenHands
     wave: 2
     language: Python
     aiPolicy: human-required

--- a/docs/00-vision.md
+++ b/docs/00-vision.md
@@ -6,7 +6,7 @@ The product is not “open more PRs.” The product is **merged, etiquette-corre
 
 ## Why this exists
 
-2026 made unattended OSS agents radioactive. curl’s HackerOne queue, matplotlib’s autonomous-agent ban, Pydantic’s slop-PR close rate, and OpenClaw-style maintainer attacks all taught the same lesson: volume without governance is vandalism.
+2026 made unattended OSS agents radioactive. curl’s HackerOne shutdown, matplotlib’s agent-interaction ban, and OpenClaw-style maintainer attacks all taught the same lesson: volume without governance is vandalism. (Pydantic, often cited alongside these, actually welcomes AI-assisted PRs — what it bans is factory-pattern mass submission; see the denylist reason.)
 
 Foundry is the opposite posture:
 

--- a/docs/03-allowlist.md
+++ b/docs/03-allowlist.md
@@ -28,12 +28,12 @@ The allowlist is the product. Everything else is a pipeline. Sole source: [`allo
 ### Wave 2 — adjacent, slower
 
 - `mastra-ai/mastra` — HeyCMO’s runtime. Human-required (assignment-first auto-close).
-- `OpenHands/OpenHands` — org renamed from `All-Hands-AI`. HUMAN: markers in the PR template. Docs only.
+- `OpenHands/OpenHands` — org renamed from `All-Hands-AI`. No CONTRIBUTING.md: policy lives in the PR template (reserved `HUMAN:` section, `AGENT:` sections, "evidence that the code runs properly end-to-end. Just running unit tests is NOT sufficient") and issues must be labeled `ready-for-dev` before a PR. Docs only.
 
 ## Denylist (hard)
 
-- `matplotlib/matplotlib` — policy bans agents directly interacting with the project (issues, PRs, comments) and multi-project contribution breadth.
-- `curl/curl` — maintainer request to stop agent noise; bug bounty closed over AI slop 2026-01-31.
+- `matplotlib/matplotlib` — autonomous-agent ban.
+- `curl/curl` — maintainer request to stop agent noise.
 - `pydantic/pydantic` — welcomes AI-assisted PRs; bans mass submission across repos and unassigned PRs. Denied as a poor factory fit, not as anti-AI.
 - `stablyai/orca` — no AI restriction upstream; denied for conflict of interest (it is the runtime Foundry rides). Contribute through orca-fleet.
 

--- a/docs/03-allowlist.md
+++ b/docs/03-allowlist.md
@@ -19,23 +19,23 @@ The allowlist is the product. Everything else is a pipeline. Sole source: [`allo
 
 ### Wave 1 — low-risk external
 
-- `ColeMurray/background-agents` — OpenInspect. [#1476](https://github.com/ColeMurray/background-agents/issues/1476) → [ColeMurray#1652](https://github.com/ColeMurray/background-agents/pull/1652) (open, not draft). Fork rehearsal [ravidsrk/background-agents#1](https://github.com/ravidsrk/background-agents/pull/1) closed. **In flight.**
-- `github/awesome-copilot` — docs catalog, tiny diffs. No named first issue; tick idles rather than inventing one.
-- `e2b-dev/E2B` — the sandbox we depend on. Docs/examples only.
+- `ColeMurray/background-agents` — OpenInspect. `aiPolicy: unknown` — no written AI policy anywhere (CONTRIBUTING, AGENTS.md, CLAUDE.md); behaviorally open, 141/272 external PRs merged. [#1476](https://github.com/ColeMurray/background-agents/issues/1476) → [ColeMurray#1652](https://github.com/ColeMurray/background-agents/pull/1652) (open, not draft). Fork rehearsal [ravidsrk/background-agents#1](https://github.com/ravidsrk/background-agents/pull/1) closed. **In flight.**
+- `github/awesome-copilot` — docs catalog, tiny diffs. Documented AI-agent fast track in CONTRIBUTING. No named first issue; tick idles rather than inventing one.
+- `e2b-dev/E2B` — the sandbox we depend on. Docs/examples surface moved to `e2b-dev/e2b-cookbook` (E2B#1769 removed in-repo examples, 2026-08-25); retarget tracked in issue 12.
 - `mcp-use/mcp-use` — policy unknown until CONTRIBUTING is fetched. Gate holds.
 - `kortix-ai/suna` — same: unknown until parsed.
 
 ### Wave 2 — adjacent, slower
 
-- `mastra-ai/mastra` — HeyCMO’s runtime. Human-required.
-- `All-Hands-AI/OpenHands` — HUMAN: markers. Docs only.
+- `mastra-ai/mastra` — HeyCMO’s runtime. Human-required (assignment-first auto-close).
+- `OpenHands/OpenHands` — org renamed from `All-Hands-AI`. HUMAN: markers in the PR template. Docs only.
 
 ## Denylist (hard)
 
-- `matplotlib/matplotlib` — autonomous-agent ban.
-- `curl/curl` — maintainer request to stop agent noise.
-- `pydantic/pydantic` — slop-PR close rate.
-- `stablyai/orca` — contribute through orca-fleet, not drive-by.
+- `matplotlib/matplotlib` — policy bans agents directly interacting with the project (issues, PRs, comments) and multi-project contribution breadth.
+- `curl/curl` — maintainer request to stop agent noise; bug bounty closed over AI slop 2026-01-31.
+- `pydantic/pydantic` — welcomes AI-assisted PRs; bans mass submission across repos and unassigned PRs. Denied as a poor factory fit, not as anti-AI.
+- `stablyai/orca` — no AI restriction upstream; denied for conflict of interest (it is the runtime Foundry rides). Contribute through orca-fleet.
 
 A denylist hit is `DENY_FORBIDDEN`. There is no override in the operator CLI.
 

--- a/docs/10-schemas.md
+++ b/docs/10-schemas.md
@@ -45,4 +45,4 @@ A packet without `negativeControl=red-on-revert` and real (non-placeholder) `bas
 
 ## Allowlist repo
 
-See `allowlist.yaml`. Required fields: `id`, `wave`, `aiPolicy`, `testCommand`, `maxFiles`, `maxDiffLines`, `sandbox`, `preferredLabels`. Wave 1+ should name at least one `firstIssues` entry before the clock may select them.
+See `allowlist.yaml`. Required fields: `id`, `wave`, `aiPolicy`, `testCommand`, `maxFiles`, `maxDiffLines`, `sandbox`, `preferredLabels`. Optional: `policyNotes` — a free-text provenance note (why a policy value was chosen, dated). It is appended to the policy-scan blob, so keep it free of gate phrases. Wave 1+ should name at least one `firstIssues` entry before the clock may select them.

--- a/docs/12-ledger.md
+++ b/docs/12-ledger.md
@@ -31,6 +31,17 @@ Do **not** open the compare URL again. The upstream PR exists. Follow up. Do not
 - background-agents: 1 opened, 0 merged, neutral
 - halt: none
 
+## Corrections — 2026-08-28 (issue #3)
+
+Live verification found six factual errors in the allowlist; all corrected:
+
+1. pydantic deny reason was "high slop-PR close rate" (unsubstantiated). Pydantic's CONTRIBUTING **welcomes** AI-assisted PRs; the real gates are anti-mass-submission and assignment-first. Deny kept, reason rewritten.
+2. stablyai/orca deny reason implied an AI restriction; upstream has none (PRs must *include* an AI review summary). Deny kept as conflict-of-interest.
+3. `All-Hands-AI/OpenHands` → `OpenHands/OpenHands` (org renamed; old id redirects).
+4. background-agents `aiPolicy: welcome` was an inference — no written AI policy exists. Now `unknown` with a `policyNotes` provenance record.
+5. E2B "docs/examples only" surface left that repo (E2B#1769, 2026-08-25); re-scoped via `policyNotes`, retarget tracked in issue #12.
+6. awesome-copilot repo language is JavaScript tooling; content Markdown.
+
 ## Next
 
 1. Follow #1652 until quiet / merged-by-maintainer / closed.

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -24,9 +24,9 @@ The product is not “open more PRs.” The product is **merged, etiquette-corre
 
 2026 made unattended OSS agents radioactive:
 
-- matplotlib banned agents interacting with the project after a slop incident
-- curl maintainers asked agents to stop after a HackerOne flood, then closed the bounty
-- pydantic welcomes AI-assisted PRs but bans factory-pattern mass submission — the pattern we are
+- matplotlib banned autonomous-agent PRs after a slop incident
+- curl maintainers asked agents to stop after a HackerOne flood
+- pydantic welcomes AI-assisted PRs but bans mass submission across repos — the very pattern a contribution factory is
 - drive-by volume without governance is vandalism
 
 Foundry’s posture is the inverse: **contribute less, merge more, never surprise a maintainer.**
@@ -179,8 +179,8 @@ Caps (`allowlist.yaml`): `in_flight: 1`, `first_human_freezes: 20`, `halt_merge_
 
 ### Denylist (hard)
 
-- `matplotlib/matplotlib` — bans agents directly interacting with the project (issues, PRs, comments)
-- `curl/curl` — maintainer asked agents to stop; bounty closed over AI slop
+- `matplotlib/matplotlib` — autonomous-agent ban
+- `curl/curl` — maintainer asked agents to stop
 - `pydantic/pydantic` — welcomes AI-assisted PRs; bans mass submission across repos + unassigned PRs. Denied as poor factory fit, not anti-AI
 - `stablyai/orca` — no AI restriction; denied for conflict of interest (the runtime Foundry rides). Contribute via orca-fleet
 
@@ -248,6 +248,8 @@ Policy parsed for #1476 (operator, before open):
 | reverts | 0 | | | |
 
 Merge-rate halt is **not** tripped (`opened ≥ 3` required).
+
+**Corrections 2026-08-28 (issue #3):** six allowlist facts fixed after live verification — pydantic and stablyai/orca deny reasons rewritten (both were mischaracterized as AI-restrictions), OpenHands org rename, background-agents `welcome` → `unknown` (no written policy), E2B surface re-scoped toward e2b-cookbook, awesome-copilot language. Details in [12-ledger.md](12-ledger.md).
 
 ---
 

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -24,9 +24,9 @@ The product is not “open more PRs.” The product is **merged, etiquette-corre
 
 2026 made unattended OSS agents radioactive:
 
-- matplotlib banned autonomous-agent PRs after a slop incident
-- curl maintainers asked agents to stop after a HackerOne flood
-- pydantic closed slop PRs at a high rate
+- matplotlib banned agents interacting with the project after a slop incident
+- curl maintainers asked agents to stop after a HackerOne flood, then closed the bounty
+- pydantic welcomes AI-assisted PRs but bans factory-pattern mass submission — the pattern we are
 - drive-by volume without governance is vandalism
 
 Foundry’s posture is the inverse: **contribute less, merge more, never surprise a maintainer.**
@@ -166,23 +166,23 @@ Caps (`allowlist.yaml`): `in_flight: 1`, `first_human_freezes: 20`, `halt_merge_
 
 ### Wave 1
 
-- `ColeMurray/background-agents` — OpenInspect. `aiPolicy: welcome`. First issue **#1476** (in flight as #1652)
-- `github/awesome-copilot` — Markdown docs. No named first issue yet; clock idles rather than inventing one
-- `e2b-dev/E2B` — docs/examples only
+- `ColeMurray/background-agents` — OpenInspect. `aiPolicy: unknown` — no written AI policy; behaviorally open (141/272 external PRs merged). First issue **#1476** (in flight as #1652)
+- `github/awesome-copilot` — Markdown content (repo language JavaScript). No named first issue yet; clock idles rather than inventing one
+- `e2b-dev/E2B` — docs/examples surface moved to e2b-dev/e2b-cookbook (retarget: issue 12)
 - `mcp-use/mcp-use` — policy **unknown** until CONTRIBUTING parsed
 - `kortix-ai/suna` — policy **unknown** until parsed
 
 ### Wave 2
 
 - `mastra-ai/mastra` — human-required
-- `All-Hands-AI/OpenHands` — HUMAN: markers, docs only
+- `OpenHands/OpenHands` (org renamed from All-Hands-AI) — HUMAN: markers, docs only
 
 ### Denylist (hard)
 
-- `matplotlib/matplotlib` — autonomous-agent ban
-- `curl/curl` — maintainer asked agents to stop
-- `pydantic/pydantic` — high slop-PR close rate
-- `stablyai/orca` — contribute via orca-fleet, not drive-by
+- `matplotlib/matplotlib` — bans agents directly interacting with the project (issues, PRs, comments)
+- `curl/curl` — maintainer asked agents to stop; bounty closed over AI slop
+- `pydantic/pydantic` — welcomes AI-assisted PRs; bans mass submission across repos + unassigned PRs. Denied as poor factory fit, not anti-AI
+- `stablyai/orca` — no AI restriction; denied for conflict of interest (the runtime Foundry rides). Contribute via orca-fleet
 
 ---
 

--- a/factory/load-allowlist.test.ts
+++ b/factory/load-allowlist.test.ts
@@ -22,11 +22,12 @@ test("omitted wave is not coerced to Wave 0 host-trusted", () => {
 test("Wave 2 host sandbox is rejected at load", () => {
   const yaml = readFileSync(new URL("../allowlist.yaml", import.meta.url), "utf8");
   const host = yaml.replace(
-    "  - id: All-Hands-AI/OpenHands\n    wave: 2\n    language: Python\n    aiPolicy: human-required\n    testCommand: poetry run pytest\n    maxFiles: 3\n    maxDiffLines: 140\n    sandbox: e2b",
-    "  - id: All-Hands-AI/OpenHands\n    wave: 2\n    language: Python\n    aiPolicy: human-required\n    testCommand: poetry run pytest\n    maxFiles: 3\n    maxDiffLines: 140\n    sandbox: host",
+    "  - id: OpenHands/OpenHands\n    wave: 2\n    language: Python\n    aiPolicy: human-required\n    testCommand: poetry run pytest\n    maxFiles: 3\n    maxDiffLines: 140\n    sandbox: e2b",
+    "  - id: OpenHands/OpenHands\n    wave: 2\n    language: Python\n    aiPolicy: human-required\n    testCommand: poetry run pytest\n    maxFiles: 3\n    maxDiffLines: 140\n    sandbox: host",
   );
+  assert.notEqual(host, yaml, "fixture replace matched nothing — committed entry drifted from this test");
   const parsed = parseAllowlistYaml(host);
-  assert.throws(() => assertAllowlist(parsed), /Wave 1\+ repo All-Hands-AI\/OpenHands must not use host sandbox/);
+  assert.throws(() => assertAllowlist(parsed), /Wave 1\+ repo OpenHands\/OpenHands must not use host sandbox/);
 });
 
 test("a denylist id among repos fails assertion", () => {

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -23,7 +23,7 @@ test("forbidden phrase beats a welcome repo", () => {
 
 test("CLA parks needs-human", () => {
   const v = evaluatePolicy({
-    repoId: "All-Hands-AI/OpenHands",
+    repoId: "OpenHands/OpenHands",
     agentsMd: "Please sign the CLA. HUMAN: required.",
     issueTitle: "docs FAQ",
   });

--- a/factory/seed.ts
+++ b/factory/seed.ts
@@ -256,10 +256,10 @@ export function seedState(): FactoryState {
   });
 
   const openhands = buildPacket({
-    repoId: "All-Hands-AI/OpenHands",
+    repoId: "OpenHands/OpenHands",
     issueNumber: 16907,
     issueTitle: "Document HUMAN: requirement in contributor FAQ",
-    issueUrl: "https://github.com/All-Hands-AI/OpenHands/issues/16907",
+    issueUrl: "https://github.com/OpenHands/OpenHands/issues/16907",
     labels: ["documentation"],
     agentsMd: "Please sign the CLA. HUMAN: required.",
     contributing: "Developer Certificate of Origin. Sign-off required.",


### PR DESCRIPTION
## Summary

Six factual corrections to the allowlist and docs, each live-verified against the target repo (issue #3). Denylist reasons for pydantic and stablyai/orca were mischaracterized as AI-restrictions; the OpenHands org name was stale; background-agents' welcome was an undocumented inference; E2B's docs/examples surface left that repo; awesome-copilot's registered language is JavaScript.

## Evidence (unit u3, doc-claims class)

- base 48dc031 → head 1f8ab3d (2 commits: fix + review round)
- `validate-allowlist` passes; full suite **37/37** at head
- Negative-control analogue for doc-claims: every corrected claim quoted from the live source (pydantic CONTRIBUTING, orca CONTRIBUTING, OpenHands PR template, E2B#1769) — re-verified independently by the reviewer
- Build-blind review: round 1 **REQUEST_CHANGES** (3 blockers: missing ledger note, uncited curl/matplotlib scope creep, truncated sentence) → fix commit → round 2 **APPROVE** at reviewed_sha `1f8ab3d407b1d2f51f535918d69ca5fd60edc1c9` (= head)

## Sweep

Unit u3 of the field-report clean-sweep (landing=direct-to-default; one PR per issue into main).

Closes #3

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR corrects six factual claims across the allowlist, documentation, fixtures, and seed state.
- Reclassifies policy facts for Pydantic, Orca, and background-agents.
- Renames the OpenHands repository and updates its seeded packet and tests.
- Records the moved E2B contribution surface and corrects awesome-copilot’s language description.
- The OpenHands rename does not migrate the corresponding persistent state key.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The OpenHands repository rename should be accompanied by a v6 state migration before this PR is merged.

Existing state files retain `All-Hands-AI/OpenHands`, while the changed allowlist and seed use `OpenHands/OpenHands`; exact repository-ID comparisons can consequently orphan the old packet and miss scorecard, halt, or duplicate reconciliation.

**Files Needing Attention:** allowlist.yaml, factory/state.ts, factory/seed.ts
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| allowlist.yaml | Corrects repository metadata and policy notes, but renames a repository ID used as a persistent key without a state migration. |
| factory/seed.ts | Updates newly seeded OpenHands packets to the canonical repository name, while existing v6 state remains unchanged. |
| factory/load-allowlist.test.ts | Updates the OpenHands sandbox fixture and adds a useful assertion that its string replacement matched. |
| factory/policy.test.ts | Updates the OpenHands repository identifier in the CLA policy test. |
| docs/03-allowlist.md | Documents the corrected roster, policy classifications, and contribution surfaces. |
| docs/12-ledger.md | Adds a concise ledger of the six factual corrections. |
| docs/PRODUCT.md | Propagates the corrected allowlist facts into the operator documentation. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20ravidsrk%2Foss-foundry%20PR%20%2318%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=ravidsrk%2Foss-foundry&pr=18&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aallowlist.yaml%3A122%0A**Repository%20key%20lacks%20migration**%0A%0AIf%20an%20existing%20v6%20state%20file%20contains%20the%20previous%20%60All-Hands-AI%2FOpenHands%60%20key%2C%20this%20rename%20leaves%20that%20persisted%20key%20unchanged%20while%20runtime%20lookups%20use%20exact%20ID%20equality%2C%20causing%20the%20existing%20packet%20to%20become%20unrecognized%20and%20scorecard%2C%20halt%2C%20and%20duplicate%20reconciliation%20to%20miss%20it.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ravidsrk%2Foss-foundry&pr=18&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
allowlist.yaml:122
**Repository key lacks migration**

If an existing v6 state file contains the previous `All-Hands-AI/OpenHands` key, this rename leaves that persisted key unchanged while runtime lookups use exact ID equality, causing the existing packet to become unrecognized and scorecard, halt, and duplicate reconciliation to miss it.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["review: restore out-of-scope deny wordin..."](https://github.com/ravidsrk/oss-foundry/commit/1f8ab3d407b1d2f51f535918d69ca5fd60edc1c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57916658)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->