### PR TITLE
chore(factory): remove doctrine-only surfaces

### DIFF
--- a/docs/02-good-neighbor.md
+++ b/docs/02-good-neighbor.md
@@ -33,4 +33,4 @@ The factory does not merge. Maintainers own the merge.
 
 ## Lighting
 
-Every packet is `lit` by default: a reviewer who did not implement it reads the diff. `dark-eligible` is not used in Foundry v1/v2. Upstream is not our default branch.
+Every packet is `lit`: a reviewer who did not implement it reads the diff. `dark-eligible` is not representable in Foundry — the type and the state loader both refuse it. Upstream is not our default branch.

--- a/docs/02-good-neighbor.md
+++ b/docs/02-good-neighbor.md
@@ -33,4 +33,4 @@ The factory does not merge. Maintainers own the merge.
 
 ## Lighting
 
-Every packet is `lit`: a reviewer who did not implement it reads the diff. `dark-eligible` is not representable in Foundry — the type and the state loader both refuse it. Upstream is not our default branch.
+Every packet is `lit`: a reviewer who did not implement it reads the diff. `dark-eligible` is not representable in Foundry — the state loader refuses it at load, and the type no longer carries it. Upstream is not our default branch.

--- a/docs/07-github-app.md
+++ b/docs/07-github-app.md
@@ -38,6 +38,5 @@ Live in the operator host / GHA environment:
 - `FOUNDRY_APP_PRIVATE_KEY`
 - `FOUNDRY_INSTALLATION_ID`
 - `E2B_API_KEY` (v2)
-- `XAI_API_KEY` (optional; Grok overlay is not shipped)
 
 Never in `allowlist.yaml`, never in the E2B box, never in a packet.

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -8,6 +8,7 @@ import {
   applyHalt,
   applyReject,
   applyTick,
+  bindingFromCompare,
   findCompetingPull,
   hasInflight,
   INFLIGHT_STATUSES,
@@ -254,12 +255,7 @@ async function main() {
       console.error("no testCommand for this repo");
       process.exit(1);
     }
-    const result = applyAttachEvidence(state, id, evidence, {
-      fastForward: compared.aheadBy >= 1,
-      messages: compared.messages,
-      filesChanged: compared.filesChanged,
-      diffLines: compared.diffLines,
-    });
+    const result = applyAttachEvidence(state, id, evidence, bindingFromCompare(compared));
     if (result.error) {
       const parked = result.state.packets.find((p) => p.id === id)?.status === "parked";
       if (parked) saveFactoryState(STATE_FILE, result.state);

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -255,7 +255,7 @@ async function main() {
       process.exit(1);
     }
     const result = applyAttachEvidence(state, id, evidence, {
-      fastForward: true,
+      fastForward: compared.aheadBy >= 1,
       messages: compared.messages,
       filesChanged: compared.filesChanged,
       diffLines: compared.diffLines,

--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -561,3 +561,15 @@ test("findCompetingPull binds only a closing-keyword PR for this issue", () => {
     undefined,
   );
 });
+
+test("scout score carries no vestigial grok surface", () => {
+  const packet = buildPacket({
+    repoId: "ravidsrk/orca-fleet",
+    issueNumber: 71,
+    issueTitle: "[P2] Validator: one unreadable SKILL.md must not abort the catalog",
+    issueUrl: "https://github.com/ravidsrk/orca-fleet/issues/71",
+    labels: ["documentation"],
+  });
+  assert.equal("grok" in packet.scout.parts, false);
+  assert.equal("grokRationale" in packet.scout, false);
+});

--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -9,6 +9,7 @@ import {
   applyHalt,
   applyQueueLive,
   applyTick,
+  bindingFromCompare,
   evidenceIsReady,
   findCompetingPull,
   hasInflight,
@@ -572,4 +573,38 @@ test("scout score carries no vestigial grok surface", () => {
   });
   assert.equal("grok" in packet.scout.parts, false);
   assert.equal("grokRationale" in packet.scout, false);
+});
+
+test("a non-ahead compare cannot reach evidence attachment as fast-forward via the CLI binding path", () => {
+  let state = applyTick(blank()).state;
+  const id = state.packets[0].id;
+  state = applyApprove(state, id, "attest").state;
+  state = applyAdvance(state, id).state;
+  state = applyAdvance(state, id).state;
+  const packet = state.packets[0];
+  const stale = bindingFromCompare({
+    aheadBy: 0,
+    filesChanged: 1,
+    diffLines: 1,
+    messages: [`Fixes #${packet.issueNumber}`],
+  });
+  assert.equal(stale.fastForward, false);
+  const rejected = applyAttachEvidence(state, id, {
+    baseSha: BASE,
+    headSha: HEAD,
+    testCommand: "true",
+    testExit: 0,
+    negativeControl: "red-on-revert",
+    filesChanged: 1,
+    diffLines: 1,
+    notes: [],
+  }, stale);
+  assert.match(rejected.error ?? "", /fast-forward/);
+  const derived = bindingFromCompare({
+    aheadBy: 2,
+    filesChanged: 1,
+    diffLines: 1,
+    messages: [`Fixes #${packet.issueNumber}`],
+  });
+  assert.equal(derived.fastForward, true);
 });

--- a/factory/engine.ts
+++ b/factory/engine.ts
@@ -589,3 +589,18 @@ function park(
     events: [ev(kind, reason, id), ...state.events].slice(0, 80),
   };
 }
+
+/** The one place the CLI turns a compare result into an evidence binding — fastForward is derived, never asserted. */
+export function bindingFromCompare(compared: {
+  aheadBy: number;
+  filesChanged: number;
+  diffLines: number;
+  messages: string[];
+}): EvidenceBinding {
+  return {
+    fastForward: compared.aheadBy >= 1,
+    messages: compared.messages,
+    filesChanged: compared.filesChanged,
+    diffLines: compared.diffLines,
+  };
+}

--- a/factory/scout.ts
+++ b/factory/scout.ts
@@ -6,8 +6,6 @@ export function scoreIssue(input: {
   title: string;
   labels: string[];
   daysOld?: number;
-  grok?: number;
-  grokRationale?: string;
 }): ScoutScore {
   const repo = repoById(input.repoId);
   const wave = repo ? (repo.wave === 0 ? 40 : repo.wave === 1 ? 28 : 12) : 0;
@@ -27,13 +25,11 @@ export function scoreIssue(input: {
   const days = input.daysOld ?? 30;
   const freshness = days < 14 ? 12 : days < 60 ? 8 : 4;
 
-  const grok = typeof input.grok === "number" ? Math.max(0, Math.min(20, input.grok)) : undefined;
-  const total = wave + labels + size + freshness + (grok ?? 0);
+  const total = wave + labels + size + freshness;
 
   return {
     total,
-    parts: { wave, labels, size, freshness, grok },
-    grokRationale: input.grokRationale,
+    parts: { wave, labels, size, freshness },
   };
 }
 

--- a/factory/state.test.ts
+++ b/factory/state.test.ts
@@ -155,3 +155,12 @@ test("merge rate counts terminal outcomes; silence alone cannot trip the halt", 
   assert.ok(mergeRate(mixed) > 0.6);
   assert.equal(health(mixed), "good");
 });
+
+test("stored packet with dark-eligible lighting is refused", () => {
+  const seed = seedState();
+  const packet = { ...seed.packets[0], lighting: "dark-eligible" };
+  const path = join(mkdtempSync(join(tmpdir(), "foundry-")), "dark.json");
+  writeFileSync(path, JSON.stringify({ ...seed, packets: [packet, ...seed.packets.slice(1)] }));
+  const loaded = loadFactoryState(path);
+  assert.equal(loaded.ok, false);
+});

--- a/factory/state.ts
+++ b/factory/state.ts
@@ -56,7 +56,7 @@ const POLICY_CODES = new Set([
   "HOLD_HUMAN",
   "HOLD_SCOPE",
 ]);
-const LIGHTING = new Set(["lit", "dark-eligible"]);
+const LIGHTING = new Set(["lit"]);
 const NEGATIVE = new Set(["red-on-revert", "pending", "failed"]);
 const SANDBOX_KINDS = new Set(["host", "e2b", "daytona"]);
 const SANDBOX_STATUSES = new Set([

--- a/factory/types.ts
+++ b/factory/types.ts
@@ -38,7 +38,8 @@ export type PacketStatus =
   | "parked"
   | "rejected";
 
-export type Lighting = "lit" | "dark-eligible";
+/** Every Foundry packet is independently reviewed. The historical `dark-eligible` value is not representable. */
+export type Lighting = "lit";
 
 export type SandboxKind = "host" | "e2b" | "daytona";
 
@@ -80,9 +81,7 @@ export interface ScoutScore {
     labels: number;
     size: number;
     freshness: number;
-    grok?: number;
   };
-  grokRationale?: string;
 }
 
 export interface FollowUpEntry {


### PR DESCRIPTION
## Summary

Removes three doctrine-only surfaces (issue #16): Grok scout vestiges (unshipped overlay's fields left `scoreIssue`, `ScoutScore`, and the secrets doc), the `dark-eligible` lighting value (documented as unused — now unrepresentable in the type and refused by the state loader), and the decorative `fastForward: true` literal in the CLI evidence path — now derived through `bindingFromCompare`, the single tested composition both the CLI and the suite exercise.

## Evidence (unit u16)

- base ea894dc → head 68fc1fd (chore + review round)
- Failing-first: both guard tests red before removal; reviewer independently re-ran the negative control (reverted → exactly the 2 new tests red; restored → green)
- Full suite **43/43**, exit 0; `cli.ts help` exits 0
- Build-blind review: R1 **REQUEST_CHANGES** (missing CLI-path regression test — the exact class of gap the issue is about) → structural fix (single composition function) → R2 **APPROVE** at reviewed_sha `68fc1fd`

## Sweep

Unit u16 of the field-report clean-sweep (landing=direct-to-default).

Closes #16

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Removes doctrine-only Grok scoring and `dark-eligible` lighting surfaces while centralizing comparison-to-evidence binding.
- Removes optional Grok inputs, score fields, and obsolete secret documentation.
- Narrows packet lighting to `lit` and explicitly refuses stored `dark-eligible` values.
- Derives evidence fast-forward status from validated comparison results instead of asserting it in the CLI.
- Adds regression coverage for removed score fields, rejected lighting state, and comparison binding.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security failures identified.

The removed surfaces have no remaining runtime callers, the lighting-state refusal is an explicit compatibility decision, and the CLI’s comparison path rejects diverged histories before deriving the evidence binding.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| factory/cli.ts | Replaces a hard-coded fast-forward assertion with the shared comparison binding helper after upstream comparison validation. |
| factory/engine.ts | Adds the comparison-to-evidence adapter used by both the CLI and regression tests. |
| factory/scout.ts | Removes unused Grok score inputs and contributions without affecting current callers or consumers. |
| factory/state.ts | Restricts persisted packet lighting to `lit`, intentionally rejecting the removed legacy value. |
| factory/types.ts | Narrows the lighting and scout-score contracts to match the supported runtime model. |
| factory/engine.test.ts | Adds regression coverage for Grok-surface removal and comparison-derived evidence binding. |
| factory/state.test.ts | Verifies that persisted packets using the removed lighting value are refused. |

</details>

<sub>Reviews (1): Last reviewed commit: ["review: derive the CLI evidence binding ..."](https://github.com/ravidsrk/oss-foundry/commit/68fc1fdd34e18e05f6f26854d654ad4d8bb89597) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57932023)</sub>

<!-- /greptile_comment -->