### PR TITLE
feat(engine): two-tier competing-work detection beyond closing keywords

### DIFF
--- a/docs/04-stations.md
+++ b/docs/04-stations.md
@@ -12,8 +12,9 @@ Does:
 - Competing-work verdict is two-tier (`classifyCompetition`): **competing** = a closing-keyword PR
   or an open PR the issue's GitHub timeline cross-references → stand down; **adjacent** = a plain
   textual mention or an issue-numbered head branch → taste gate, held for human triage, never
-  silently scouted. The same check re-runs at `attach-draft` — a competitor that appeared since
-  gating refuses the attach.
+  silently scouted. The same check re-runs at `approve` (freeze) and at `attach-draft` — a
+  competitor that appeared since gating refuses the approval or the attach; an adjacent mention at
+  freeze is surfaced to the human doing the freezing, who is the taste gate.
 - Heuristic score: wave, labels, size, freshness.
 - Never invent issue numbers. If every named `firstIssues` row is consumed or blocked, the tick **idles**.
 
@@ -40,7 +41,7 @@ The gate is deterministic. Grok does not get a vote here. There is no demo CONTR
 
 The operator reads the packet: objective, non-goals, acceptance, abort, policy, scout.
 
-Actions: `approve` (attest) or `reject` (park). Denied, halted, and unlisted packets cannot be approved.
+Actions: `approve` (attest) or `reject` (park). Denied, halted, and unlisted packets cannot be approved. Approve re-runs the competing-work check live: a competitor that appeared since gating blocks the approval; an adjacent mention is shown to the approver.
 
 The first 20 factory-wide approvals decrement a visible counter. At zero, Wave 0 may auto-freeze only if policy is `owner` and lighting stays `lit`. Wave 1+ never auto-freeze.
 

--- a/docs/04-stations.md
+++ b/docs/04-stations.md
@@ -9,6 +9,11 @@ Input: allowlist + open issues + open PRs (both denominators).
 Does:
 
 - Drop denylist, RFC/meta/tracking, issues with an in-flight maintainer PR.
+- Competing-work verdict is two-tier (`classifyCompetition`): **competing** = a closing-keyword PR
+  or an open PR the issue's GitHub timeline cross-references → stand down; **adjacent** = a plain
+  textual mention or an issue-numbered head branch → taste gate, held for human triage, never
+  silently scouted. The same check re-runs at `attach-draft` — a competitor that appeared since
+  gating refuses the attach.
 - Heuristic score: wave, labels, size, freshness.
 - Never invent issue numbers. If every named `firstIssues` row is consumed or blocked, the tick **idles**.
 

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -9,7 +9,7 @@ import {
   applyReject,
   applyTick,
   bindingFromCompare,
-  findCompetingPull,
+  classifyCompetition,
   hasInflight,
   INFLIGHT_STATUSES,
 } from "./engine.ts";
@@ -17,6 +17,7 @@ import {
   compareCommits,
   draftPullPayload,
   fetchRepoFile,
+  listCrossReferencingOpenPulls,
   listOpenPulls,
   parsePrUrl,
   syncGithubPr,
@@ -68,6 +69,7 @@ function printStatus(state: ReturnType<typeof mustLoad>) {
 async function tickWithGithub(state: ReturnType<typeof mustLoad>) {
   if (hasInflight(state.packets)) return applyTick(state);
   const competingKeys: string[] = [];
+  const adjacentKeys: string[] = [];
   const live: LiveIssue[] = [];
   for (const repo of ALLOWLIST) {
     if (repo.firstIssues.length === 0) continue;
@@ -82,8 +84,25 @@ async function tickWithGithub(state: ReturnType<typeof mustLoad>) {
       (await fetchRepoFile(repo.id, ".github/CONTRIBUTING.md"));
     for (const issue of repo.firstIssues) {
       const key = `${repo.id}#${issue.number}`;
-      if (findCompetingPull(pulls.pulls, issue.number, issue.url, repo.id)) {
+      const crossRefs = await listCrossReferencingOpenPulls(repo.id, issue.number);
+      if (!crossRefs.ok) {
+        console.error(crossRefs.error);
+        process.exit(1);
+      }
+      const verdict = classifyCompetition(
+        { pulls: pulls.pulls, crossReferencedPullUrls: crossRefs.urls },
+        issue.number,
+        issue.url,
+        repo.id,
+      );
+      if (verdict.kind === "competing") {
+        console.error(`stand down ${key}: competing PR ${verdict.url} (${verdict.why})`);
         competingKeys.push(key);
+        continue;
+      }
+      if (verdict.kind === "adjacent") {
+        console.error(`hold ${key}: adjacent PR ${verdict.url} (${verdict.why}) — human triage before scouting`);
+        adjacentKeys.push(key);
         continue;
       }
       live.push({
@@ -99,7 +118,7 @@ async function tickWithGithub(state: ReturnType<typeof mustLoad>) {
       });
     }
   }
-  return applyTick(state, live, competingKeys);
+  return applyTick(state, live, competingKeys, adjacentKeys);
 }
 
 const [cmd, ...rest] = process.argv.slice(2);
@@ -301,6 +320,35 @@ async function main() {
     if (!synced.ok) {
       console.error(synced.error);
       process.exit(1);
+    }
+    const packetForDraft = state.packets.find((p) => p.id === id);
+    if (packetForDraft) {
+      const parsed = parsePrUrl(url)!;
+      const pulls = await listOpenPulls(packetForDraft.repoId);
+      const crossRefs = await listCrossReferencingOpenPulls(packetForDraft.repoId, packetForDraft.issueNumber);
+      if (!pulls.ok || !crossRefs.ok) {
+        console.error(!pulls.ok ? pulls.error : !crossRefs.ok ? crossRefs.error : "");
+        process.exit(1);
+      }
+      const others = pulls.pulls.filter((p) => p.number !== parsed.number);
+      const otherRefs = crossRefs.urls.filter((u) => parsePrUrl(u)?.number !== parsed.number);
+      const verdict = classifyCompetition(
+        { pulls: others, crossReferencedPullUrls: otherRefs },
+        packetForDraft.issueNumber,
+        packetForDraft.issueUrl,
+        packetForDraft.repoId,
+      );
+      if (verdict.kind === "competing") {
+        console.error(
+          `stand down: competing PR ${verdict.url} (${verdict.why}) appeared on ${packetForDraft.repoId}#${packetForDraft.issueNumber}. Assist or park — do not attach.`,
+        );
+        process.exit(1);
+      }
+      if (verdict.kind === "adjacent") {
+        console.error(
+          `taste gate: adjacent PR ${verdict.url} (${verdict.why}) mentions ${packetForDraft.repoId}#${packetForDraft.issueNumber}. Proceeding — a human is at the keyboard; log the call in the ledger.`,
+        );
+      }
     }
     const result = applyAttachDraft(state, id, url, {
       draft: synced.meta.draft,

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -10,6 +10,7 @@ import {
   applyTick,
   bindingFromCompare,
   classifyCompetition,
+  findCompetingPull,
   hasInflight,
   INFLIGHT_STATUSES,
 } from "./engine.ts";
@@ -84,7 +85,12 @@ async function tickWithGithub(state: ReturnType<typeof mustLoad>) {
       (await fetchRepoFile(repo.id, ".github/CONTRIBUTING.md"));
     for (const issue of repo.firstIssues) {
       const key = `${repo.id}#${issue.number}`;
-      const crossRefs = await listCrossReferencingOpenPulls(repo.id, issue.number);
+      // Cheap path first: a closing-keyword hit in the already-fetched pulls settles "competing"
+      // without spending a timeline call per issue.
+      const keywordHit = findCompetingPull(pulls.pulls, issue.number, issue.url, repo.id);
+      const crossRefs = keywordHit
+        ? { ok: true as const, urls: [] as string[] }
+        : await listCrossReferencingOpenPulls(repo.id, issue.number);
       if (!crossRefs.ok) {
         console.error(crossRefs.error);
         process.exit(1);
@@ -168,6 +174,43 @@ async function main() {
     if (!id) {
       console.error("approve requires a packet id");
       process.exit(1);
+    }
+    const packetForFreeze = state.packets.find((p) => p.id === id);
+    if (packetForFreeze && (packetForFreeze.status === "gated" || packetForFreeze.status === "frozen")) {
+      const pulls = await listOpenPulls(packetForFreeze.repoId);
+      if (!pulls.ok) {
+        console.error(pulls.error);
+        process.exit(1);
+      }
+      const crossRefs = findCompetingPull(
+        pulls.pulls,
+        packetForFreeze.issueNumber,
+        packetForFreeze.issueUrl,
+        packetForFreeze.repoId,
+      )
+        ? { ok: true as const, urls: [] as string[] }
+        : await listCrossReferencingOpenPulls(packetForFreeze.repoId, packetForFreeze.issueNumber);
+      if (!crossRefs.ok) {
+        console.error(crossRefs.error);
+        process.exit(1);
+      }
+      const verdict = classifyCompetition(
+        { pulls: pulls.pulls, crossReferencedPullUrls: crossRefs.urls },
+        packetForFreeze.issueNumber,
+        packetForFreeze.issueUrl,
+        packetForFreeze.repoId,
+      );
+      if (verdict.kind === "competing") {
+        console.error(
+          `stand down: competing PR ${verdict.url} (${verdict.why}) appeared on ${packetForFreeze.repoId}#${packetForFreeze.issueNumber} since gating. Reject or park — do not approve.`,
+        );
+        process.exit(1);
+      }
+      if (verdict.kind === "adjacent") {
+        console.error(
+          `taste gate: adjacent PR ${verdict.url} (${verdict.why}) mentions ${packetForFreeze.repoId}#${packetForFreeze.issueNumber}. You are the freeze — approve only if it does not cover the issue.`,
+        );
+      }
     }
     const result = applyApprove(state, id, flag(rest, "--note") ?? "");
     if (result.error) {

--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -10,6 +10,7 @@ import {
   applyQueueLive,
   applyTick,
   bindingFromCompare,
+  branchMentionsIssue,
   classifyCompetition,
   evidenceIsReady,
   findCompetingPull,
@@ -17,6 +18,7 @@ import {
   isBoundSha,
   isPlaceholderSha,
   mentionsIssue,
+  referencesIssue,
   type EvidenceBinding,
 } from "./engine.ts";
 import { draftPullPayload } from "./github-pr.ts";
@@ -688,4 +690,40 @@ test("tick holds an adjacent-flagged issue for human triage instead of scouting 
     result.state.events.some((e) => e.message.includes("adjacent")),
     true,
   );
+});
+
+test("competition precedence and the direct reference helpers", () => {
+  const url = "https://github.com/ravidsrk/orca-fleet/issues/71";
+  const repo = "ravidsrk/orca-fleet";
+  assert.equal(referencesIssue("see also #71", 71, url, repo), true);
+  assert.equal(referencesIssue("PR #71 tracks this", 71, url, repo), true);
+  assert.equal(referencesIssue("other-owner/other-repo#71", 71, url, repo), false);
+  assert.equal(referencesIssue(`context: ${url}`, 71, url, repo), true);
+  assert.equal(branchMentionsIssue("fix/71-validator", 71), true);
+  assert.equal(branchMentionsIssue("high71", 71), false);
+  assert.equal(branchMentionsIssue("fix-710", 71), false);
+
+  const both = classifyCompetition(
+    {
+      pulls: [{ title: "wip", body: "see also #71", url: "https://github.com/ravidsrk/orca-fleet/pull/9", headRef: "fix/71-x" }],
+      crossReferencedPullUrls: ["https://github.com/ravidsrk/orca-fleet/pull/9"],
+    },
+    71,
+    url,
+    repo,
+  );
+  assert.equal(both.kind, "competing");
+  if (both.kind === "competing") assert.equal(both.why, "timeline-link");
+
+  const keywordBeatsTimeline = classifyCompetition(
+    {
+      pulls: [{ title: "fix", body: "Fixes #71", url: "https://github.com/ravidsrk/orca-fleet/pull/2" }],
+      crossReferencedPullUrls: ["https://github.com/ravidsrk/orca-fleet/pull/9"],
+    },
+    71,
+    url,
+    repo,
+  );
+  assert.equal(keywordBeatsTimeline.kind, "competing");
+  if (keywordBeatsTimeline.kind === "competing") assert.equal(keywordBeatsTimeline.why, "closing-keyword");
 });

--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -10,6 +10,7 @@ import {
   applyQueueLive,
   applyTick,
   bindingFromCompare,
+  classifyCompetition,
   evidenceIsReady,
   findCompetingPull,
   hasInflight,
@@ -607,4 +608,84 @@ test("a non-ahead compare cannot reach evidence attachment as fast-forward via t
     messages: [`Fixes #${packet.issueNumber}`],
   });
   assert.equal(derived.fastForward, true);
+});
+
+test("classifyCompetition: closing keyword is competing, plain mention is adjacent", () => {
+  const url = "https://github.com/ravidsrk/orca-fleet/issues/71";
+  const repo = "ravidsrk/orca-fleet";
+  const closing = classifyCompetition(
+    { pulls: [{ title: "fix", body: "Fixes #71", url: "https://github.com/ravidsrk/orca-fleet/pull/2" }] },
+    71,
+    url,
+    repo,
+  );
+  assert.equal(closing.kind, "competing");
+  if (closing.kind === "competing") assert.equal(closing.why, "closing-keyword");
+
+  const plain = classifyCompetition(
+    { pulls: [{ title: "refactor", body: "see also #71 for context", url: "https://github.com/ravidsrk/orca-fleet/pull/3" }] },
+    71,
+    url,
+    repo,
+  );
+  assert.equal(plain.kind, "adjacent");
+  if (plain.kind === "adjacent") assert.equal(plain.why, "plain-mention");
+});
+
+test("classifyCompetition: timeline-linked open PR competes with no textual mention", () => {
+  const url = "https://github.com/ravidsrk/orca-fleet/issues/71";
+  const verdict = classifyCompetition(
+    {
+      pulls: [{ title: "unrelated", body: "no mention at all", url: "https://github.com/ravidsrk/orca-fleet/pull/9" }],
+      crossReferencedPullUrls: ["https://github.com/ravidsrk/orca-fleet/pull/9"],
+    },
+    71,
+    url,
+    "ravidsrk/orca-fleet",
+  );
+  assert.equal(verdict.kind, "competing");
+  if (verdict.kind === "competing") assert.equal(verdict.why, "timeline-link");
+});
+
+test("classifyCompetition: branch name naming the issue is adjacent; foreign repo mention is clear", () => {
+  const url = "https://github.com/ravidsrk/orca-fleet/issues/71";
+  const branch = classifyCompetition(
+    { pulls: [{ title: "wip", body: "", url: "https://github.com/ravidsrk/orca-fleet/pull/4", headRef: "fix/71-validator" }] },
+    71,
+    url,
+    "ravidsrk/orca-fleet",
+  );
+  assert.equal(branch.kind, "adjacent");
+  if (branch.kind === "adjacent") assert.equal(branch.why, "branch-name");
+
+  const foreign = classifyCompetition(
+    { pulls: [{ title: "x", body: "Fixes other-owner/other-repo#71", url: "https://github.com/ravidsrk/orca-fleet/pull/5" }] },
+    71,
+    url,
+    "ravidsrk/orca-fleet",
+  );
+  assert.equal(foreign.kind, "clear");
+});
+
+test("tick holds an adjacent-flagged issue for human triage instead of scouting it", () => {
+  const state = blank();
+  const issue: ScoutIssue = {
+    repoId: "ravidsrk/orca-fleet",
+    number: 71,
+    title: "[P2] Validator: one unreadable SKILL.md must not abort the catalog",
+    url: "https://github.com/ravidsrk/orca-fleet/issues/71",
+    labels: ["documentation"],
+    daysOld: 1,
+    scout: { total: 0, parts: { wave: 0, labels: 0, size: 0, freshness: 0 } },
+  };
+  const result = applyTick(state, [issue], [], [
+    "ravidsrk/orca-fleet#71",
+    "ravidsrk/frontguard#195",
+  ]);
+  assert.equal(result.packet, null);
+  assert.equal(result.reason, "idle");
+  assert.equal(
+    result.state.events.some((e) => e.message.includes("adjacent")),
+    true,
+  );
 });

--- a/factory/engine.ts
+++ b/factory/engine.ts
@@ -367,7 +367,13 @@ export function findCompetingPull(
   return pulls.find((pull) => mentionsIssue(`${pull.title}\n${pull.body}`, issueNumber, issueUrl, repoId));
 }
 
-/** Plain reference without a closing keyword: bare #N (not repo-prefixed), this repo's owner/repo#N, or the issue URL. Foreign owner/repo#N does not count. */
+/**
+ * Plain reference without a closing keyword: bare #N (not repo-prefixed), this repo's
+ * owner/repo#N, or the issue URL. Foreign owner/repo#N does not count. Deliberately
+ * over-inclusive: "PR #71" (a pull's own number) also matches — over-inclusion only
+ * escalates to an adjacent hold a human clears, never a silent skip. Do not "fix" this
+ * into a false negative.
+ */
 export function referencesIssue(
   text: string,
   issueNumber: number,
@@ -381,7 +387,7 @@ export function referencesIssue(
   return Boolean(issueUrl) && text.includes(issueUrl);
 }
 
-/** Head branch names that conventionally carry an issue number: fix/71, issue-71, gh_71, bug/71-slug. */
+/** Head branch names that conventionally carry an issue number: fix/71, issue-71, gh_71, bug/71-slug. `bug` is a deliberate superset of the spec's fix|issue|gh seed list. */
 export function branchMentionsIssue(headRef: string | undefined, issueNumber: number): boolean {
   if (!headRef) return false;
   const n = String(issueNumber);

--- a/factory/engine.ts
+++ b/factory/engine.ts
@@ -62,28 +62,41 @@ export function applyTick(
   state: FactoryState,
   live: LiveIssue[] = [],
   competingKeys: readonly string[] = [],
+  adjacentKeys: readonly string[] = [],
 ): { state: FactoryState; packet: TaskPacket | null; reason: string } {
   if (hasInflight(state.packets)) {
     const next = appendEvent(state, ev("tick", "Tick aborted — a packet is already in flight. One at a time."));
     return { state: next, packet: null, reason: "in-flight" };
   }
 
-  const used = usedKeys(state.packets);
-  const candidate = pickCandidate(state, live, used, new Set(competingKeys));
+  let held = state;
+  if (adjacentKeys.length > 0) {
+    held = appendEvent(
+      held,
+      ev(
+        "tick",
+        `Tick held ${adjacentKeys.join(", ")} — adjacent PR activity mentions the issue; taste gate, human triage before scouting.`,
+      ),
+    );
+  }
+
+  const used = usedKeys(held.packets);
+  const blocked = new Set([...competingKeys, ...adjacentKeys]);
+  const candidate = pickCandidate(held, live, used, blocked);
   if (!candidate) {
     const next = appendEvent(
-      state,
+      held,
       ev("tick", "Tick idle — no named candidate. Factory will not invent work."),
     );
-    return { state: { ...next, ticksRun: state.ticksRun + 1, lastTickAt: now() }, packet: null, reason: "idle" };
+    return { state: { ...next, ticksRun: held.ticksRun + 1, lastTickAt: now() }, packet: null, reason: "idle" };
   }
 
   const packet = buildPacket(candidate);
   const next: FactoryState = {
-    ...state,
-    packets: [packet, ...state.packets],
-    events: [ev("tick", `Tick scouted ${packet.repoId}#${packet.issueNumber}`, packet.id), ...state.events].slice(0, 80),
-    ticksRun: state.ticksRun + 1,
+    ...held,
+    packets: [packet, ...held.packets],
+    events: [ev("tick", `Tick scouted ${packet.repoId}#${packet.issueNumber}`, packet.id), ...held.events].slice(0, 80),
+    ticksRun: held.ticksRun + 1,
     lastTickAt: now(),
   };
   return { state: next, packet, reason: packet.policy.allow ? "gated" : packet.policy.code };
@@ -352,6 +365,64 @@ export function findCompetingPull(
   repoId: string,
 ): { title: string; body: string; url: string } | undefined {
   return pulls.find((pull) => mentionsIssue(`${pull.title}\n${pull.body}`, issueNumber, issueUrl, repoId));
+}
+
+/** Plain reference without a closing keyword: bare #N (not repo-prefixed), this repo's owner/repo#N, or the issue URL. Foreign owner/repo#N does not count. */
+export function referencesIssue(
+  text: string,
+  issueNumber: number,
+  issueUrl: string,
+  repoId: string,
+): boolean {
+  const n = String(issueNumber);
+  const bare = new RegExp(String.raw`(?<![\w/])#${n}(?!\d)`);
+  const prefixed = new RegExp(`(?<![\\w/])${escapeRe(repoId)}#${n}(?!\\d)`, "i");
+  if (bare.test(text) || prefixed.test(text)) return true;
+  return Boolean(issueUrl) && text.includes(issueUrl);
+}
+
+/** Head branch names that conventionally carry an issue number: fix/71, issue-71, gh_71, bug/71-slug. */
+export function branchMentionsIssue(headRef: string | undefined, issueNumber: number): boolean {
+  if (!headRef) return false;
+  const n = String(issueNumber);
+  const re = new RegExp(String.raw`(?:^|[/_-])(?:fix|issue|bug|gh)[/_-]?0*${n}(?:$|[^0-9])`, "i");
+  return re.test(headRef);
+}
+
+export interface CompetitionPull {
+  title: string;
+  body: string;
+  url: string;
+  headRef?: string;
+}
+
+export type CompetitionVerdict =
+  | { kind: "competing"; url: string; why: "closing-keyword" | "timeline-link" }
+  | { kind: "adjacent"; url: string; why: "plain-mention" | "branch-name" }
+  | { kind: "clear" };
+
+/**
+ * Two-tier competing-work verdict per docs/02-good-neighbor.md rule 8.
+ * competing (stand down): a closing-keyword PR, or an open PR GitHub's issue timeline links.
+ * adjacent (taste gate, hold for a human): a plain textual mention or an issue-numbered branch.
+ */
+export function classifyCompetition(
+  input: { pulls: CompetitionPull[]; crossReferencedPullUrls?: readonly string[] },
+  issueNumber: number,
+  issueUrl: string,
+  repoId: string,
+): CompetitionVerdict {
+  const closing = findCompetingPull(input.pulls, issueNumber, issueUrl, repoId);
+  if (closing) return { kind: "competing", url: closing.url, why: "closing-keyword" };
+  const linked = (input.crossReferencedPullUrls ?? [])[0];
+  if (linked) return { kind: "competing", url: linked, why: "timeline-link" };
+  const mention = input.pulls.find((pull) =>
+    referencesIssue(`${pull.title}\n${pull.body}`, issueNumber, issueUrl, repoId),
+  );
+  if (mention) return { kind: "adjacent", url: mention.url, why: "plain-mention" };
+  const branch = input.pulls.find((pull) => branchMentionsIssue(pull.headRef, issueNumber));
+  if (branch) return { kind: "adjacent", url: branch.url, why: "branch-name" };
+  return { kind: "clear" };
 }
 
 function scopeOverflow(repoId: string, filesChanged: number, diffLines: number): string | undefined {

--- a/factory/github-pr.test.ts
+++ b/factory/github-pr.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { compareCommits, fetchRepoFile, listOpenPulls } from "./github-pr.ts";
+import { compareCommits, fetchRepoFile, listCrossReferencingOpenPulls, listOpenPulls } from "./github-pr.ts";
 
 const BASE = "251fe899c5bd843a7dad71d908c0af3bfcea79e1";
 const HEAD = "d91fe2f6725163fab8f9dd42e5c2b0c0c9f0f40d";
@@ -68,4 +68,57 @@ test("fetchRepoFile returns raw text or undefined on 404", async () => {
   assert.equal(ok, "Agents may open draft PRs.");
   const missing = await fetchRepoFile("ravidsrk/orca-fleet", "AGENTS.md", async () => jsonResponse(404, {}));
   assert.equal(missing, undefined);
+});
+
+test("listOpenPulls carries the head branch name", async () => {
+  const listed = await listOpenPulls("ravidsrk/orca-fleet", async () =>
+    jsonResponse(200, [
+      {
+        number: 74,
+        title: "wip",
+        body: "",
+        html_url: "https://github.com/ravidsrk/orca-fleet/pull/74",
+        head: { ref: "fix/71-validator" },
+      },
+    ]),
+  );
+  assert.equal(listed.ok, true);
+  if (listed.ok) assert.equal(listed.pulls[0]?.headRef, "fix/71-validator");
+});
+
+test("listCrossReferencingOpenPulls keeps only open cross-referenced pull requests", async () => {
+  const result = await listCrossReferencingOpenPulls("ravidsrk/orca-fleet", 71, async () =>
+    jsonResponse(200, [
+      {
+        event: "cross-referenced",
+        source: {
+          issue: {
+            state: "open",
+            pull_request: {},
+            html_url: "https://github.com/ravidsrk/orca-fleet/pull/9",
+          },
+        },
+      },
+      {
+        event: "cross-referenced",
+        source: {
+          issue: {
+            state: "closed",
+            pull_request: {},
+            html_url: "https://github.com/ravidsrk/orca-fleet/pull/5",
+          },
+        },
+      },
+      {
+        event: "cross-referenced",
+        source: { issue: { state: "open", html_url: "https://github.com/ravidsrk/orca-fleet/issues/3" } },
+      },
+      { event: "labeled" },
+    ]),
+  );
+  assert.equal(result.ok, true);
+  if (result.ok) assert.deepEqual(result.urls, ["https://github.com/ravidsrk/orca-fleet/pull/9"]);
+
+  const failed = await listCrossReferencingOpenPulls("ravidsrk/orca-fleet", 71, async () => jsonResponse(500, {}));
+  assert.equal(failed.ok, false);
 });

--- a/factory/github-pr.ts
+++ b/factory/github-pr.ts
@@ -47,6 +47,7 @@ export interface OpenPull {
   title: string;
   body: string;
   url: string;
+  headRef: string;
 }
 
 export async function listOpenPulls(
@@ -60,7 +61,13 @@ export async function listOpenPulls(
       headers: githubApiHeaders(),
     });
     if (!res.ok) return { ok: false, error: `GitHub ${res.status} listing pulls on ${repoId}` };
-    const body = (await res.json()) as { number: number; title?: string; body?: string | null; html_url: string }[];
+    const body = (await res.json()) as {
+      number: number;
+      title?: string;
+      body?: string | null;
+      html_url: string;
+      head?: { ref?: string };
+    }[];
     return {
       ok: true,
       pulls: body.map((p) => ({
@@ -68,8 +75,44 @@ export async function listOpenPulls(
         title: p.title ?? "",
         body: p.body ?? "",
         url: p.html_url,
+        headRef: p.head?.ref ?? "",
       })),
     };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : "fetch failed" };
+  }
+}
+
+/** Open pull requests GitHub's issue timeline links to the issue (`cross-referenced` events). Issues and closed PRs are dropped. */
+export async function listCrossReferencingOpenPulls(
+  repoId: string,
+  issueNumber: number,
+  fetchImpl: typeof fetch = fetch,
+): Promise<{ ok: true; urls: string[] } | { ok: false; error: string }> {
+  const [owner, repo] = repoId.split("/");
+  if (!owner || !repo) return { ok: false, error: `bad repo id ${repoId}` };
+  try {
+    const res = await fetchImpl(
+      `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}/timeline?per_page=100`,
+      { headers: githubApiHeaders() },
+    );
+    if (!res.ok) {
+      return { ok: false, error: `GitHub ${res.status} reading timeline for ${repoId}#${issueNumber}` };
+    }
+    const body = (await res.json()) as {
+      event?: string;
+      source?: { issue?: { state?: string; html_url?: string; pull_request?: unknown } };
+    }[];
+    const urls = body
+      .filter(
+        (e) =>
+          e.event === "cross-referenced" &&
+          e.source?.issue?.pull_request !== undefined &&
+          e.source.issue.state === "open" &&
+          typeof e.source.issue.html_url === "string",
+      )
+      .map((e) => e.source!.issue!.html_url as string);
+    return { ok: true, urls: [...new Set(urls)] };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : "fetch failed" };
   }


### PR DESCRIPTION
## Summary

Competing-work detection now sees past closing keywords (issue #8): `classifyCompetition` distinguishes **competing** (closing-keyword PR, or an open PR the issue's GitHub timeline cross-references → stand down) from **adjacent** (plain #N mention or issue-numbered head branch → held for human triage with a logged taste gate). All three enforcement points consult it: tick, **freeze** (approve refuses a competitor that appeared since gating), and attach-draft. The timeline call short-circuits when a keyword hit already settles the verdict; over-inclusion tradeoffs are documented in code; precedence is pinned by dedicated tests. Duplicates are a top rejection cause for agent PRs — 79% run concurrent with another agent PR.

## Evidence (unit u8)

- base eded713 → head cbf4d0c (feat + review round)
- Failing-first: 4 classify/tick tests + 2 adapter tests red before implementation
- Negative control: reviewer independently reverted engine/github-pr → both test files fail at import binding; restored → green
- Full suite **50/50**, exit 0; cli help exits 0
- Build-blind review: R1 **REQUEST_CHANGES** (freeze-time re-check missing + 4 NITs) → R2 **APPROVE** at reviewed_sha `cbf4d0c` with execution-order and data-flow verification

## Sweep

Unit u8 of the field-report clean-sweep (landing=direct-to-default).

Closes #8

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces two-tier competing-work classification and applies it during scouting, approval, and draft attachment.
- Classifies closing-keyword and timeline-linked PRs as competing.
- Treats plain issue mentions and issue-numbered branches as adjacent work requiring human triage.
- Adds GitHub timeline retrieval, branch metadata, tests, and workflow documentation.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until cross-repository PR exclusion and paginated timeline retrieval are fixed, because both can allow known competing work through enforcement.

Draft attachment can remove an unrelated repository's competitor by numeric collision, while all three enforcement points can miss timeline-linked PRs beyond the first 100 events.

**Files Needing Attention:** factory/cli.ts, factory/github-pr.ts
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| factory/cli.ts | Adds competition checks at all enforcement points, but draft exclusion can discard a cross-repository competitor sharing the attached PR number. |
| factory/github-pr.ts | Adds head-branch metadata and timeline cross-reference retrieval, but timeline detection is limited to the first 100 events. |
| factory/engine.ts | Adds clear two-tier classification and precedence helpers without an independently actionable defect in the classifier itself. |
| factory/engine.test.ts | Covers classification precedence and adjacent tick behavior but not cross-repository number collisions in attach-draft. |
| factory/github-pr.test.ts | Covers filtering of one timeline response but does not exercise paginated timelines. |
| docs/04-stations.md | Documents the new competing and adjacent workflow across scout, freeze, and draft stages. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Tick, approve, or attach-draft] --> B[List open pull requests]
  B --> C{Closing-keyword match?}
  C -- Yes --> D[Competing: stand down]
  C -- No --> E[Read issue timeline cross-references]
  E --> F{Open linked PR?}
  F -- Yes --> D
  F -- No --> G{Plain mention or issue branch?}
  G -- Yes --> H[Adjacent: human taste gate]
  G -- No --> I[Clear: continue workflow]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20ravidsrk%2Foss-foundry%20PR%20%2321%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=ravidsrk%2Foss-foundry&pr=21&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Afactory%2Fcli.ts%3A377%0A**Repository-blind%20competitor%20exclusion**%0A%0AWhen%20the%20attached%20draft%20and%20a%20cross-referenced%20PR%20from%20another%20repository%20share%20a%20PR%20number%2C%20this%20filter%20removes%20the%20foreign%20PR%20before%20classification%2C%20causing%20known%20competing%20work%20to%20be%20ignored%20and%20allowing%20the%20draft%20to%20be%20attached.%0A%0A%23%23%23%20Issue%202%0Afactory%2Fgithub-pr.ts%3A96-97%0A**Timeline%20pagination%20drops%20competitors**%0A%0AIf%20an%20issue%20has%20more%20than%20100%20timeline%20events%20and%20an%20open-PR%20cross-reference%20is%20on%20a%20later%20page%2C%20this%20single%20request%20omits%20it%2C%20causing%20tick%2C%20approve%2C%20and%20attach-draft%20to%20proceed%20without%20detecting%20the%20competitor.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ravidsrk%2Foss-foundry&pr=21&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
factory/cli.ts:377
**Repository-blind competitor exclusion**

When the attached draft and a cross-referenced PR from another repository share a PR number, this filter removes the foreign PR before classification, causing known competing work to be ignored and allowing the draft to be attached.

### Issue 2
factory/github-pr.ts:96-97
**Timeline pagination drops competitors**

If an issue has more than 100 timeline events and an open-PR cross-reference is on a later page, this single request omits it, causing tick, approve, and attach-draft to proceed without detecting the competitor.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["review: freeze-time competing-work re-ch..."](https://github.com/ravidsrk/oss-foundry/commit/cbf4d0cda8e58ed46841e9649378ed84dc491afe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57936860)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->