### PR TITLE
feat(engine): bounded quiet-day transitions for submitted packets

### DIFF
--- a/docs/04-stations.md
+++ b/docs/04-stations.md
@@ -74,6 +74,13 @@ Does:
 
 Halt rules fire here. See `docs/06-v2.md`. `submitted` remains in-flight so a quiet-but-unmerged draft still blocks a new tick until `followed-up`.
 
+Quiet-day rule (ADR 0002, enforced by `applyPrSync`): once every review thread is answered and the
+PR has been quiet ≥ **14 days**, sync moves the packet to `followed-up` and the slot frees — the
+factory is bounded by discipline, not by maintainer latency. New maintainer activity on a
+`followed-up` packet moves it back to `submitted` (answer before any new tick). At ≥ **45 quiet
+days** sync records a `stale-intent` follow-up note: record `closedUnmerged` and close with a
+polite comment — a human decision; the engine never closes a PR.
+
 Live follow-up: [orca-fleet#70](https://github.com/ravidsrk/orca-fleet/pull/70) — Greptile future-dated the 0.5.0 heading; Foundry folded it to `2026-08-26` (`d91fe2f`) and resolved the thread. **Merged** by the maintainer 2026-08-27.
 
 In-flight: [ColeMurray/background-agents#1652](https://github.com/ColeMurray/background-agents/pull/1652).

--- a/docs/04-stations.md
+++ b/docs/04-stations.md
@@ -74,12 +74,16 @@ Does:
 
 Halt rules fire here. See `docs/06-v2.md`. `submitted` remains in-flight so a quiet-but-unmerged draft still blocks a new tick until `followed-up`.
 
-Quiet-day rule (ADR 0002, enforced by `applyPrSync`): once every review thread is answered and the
-PR has been quiet ≥ **14 days**, sync moves the packet to `followed-up` and the slot frees — the
-factory is bounded by discipline, not by maintainer latency. New maintainer activity on a
-`followed-up` packet moves it back to `submitted` (answer before any new tick). At ≥ **45 quiet
-days** sync records a `stale-intent` follow-up note: record `closedUnmerged` and close with a
-polite comment — a human decision; the engine never closes a PR.
+Quiet-day rule (ADR 0002, enforced by `applyPrSync`, driven by the operator CLI:
+`sync <packetId> [--threads-answered]` — the flag is the operator's attestation that every review
+thread has a reply): once threads are answered and the PR has been quiet ≥ **14 days**, sync moves
+the packet to `followed-up` and the slot frees — the factory is bounded by discipline, not by
+maintainer latency. New maintainer activity on a `followed-up` packet moves it back to `submitted`
+(answer before any new tick). At ≥ **45 quiet days** sync records a `stale-intent` follow-up note;
+the close itself is a human act, and the scorecard's `closedUnmerged` row is written once, on the
+actual open→closed transition — never for a still-open draft, which is not a terminal outcome
+(docs/08-operations.md). Quiet days derive from GitHub's `updated_at`, which any activity bumps —
+bot noise can defer a release but can never release early; conservative by design.
 
 Live follow-up: [orca-fleet#70](https://github.com/ravidsrk/orca-fleet/pull/70) — Greptile future-dated the 0.5.0 heading; Foundry folded it to `2026-08-26` (`d91fe2f`) and resolved the thread. **Merged** by the maintainer 2026-08-27.
 

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -133,6 +133,8 @@ There is **no** TanStack operator console in this repository. The freeze/tick/dr
 
 `hasInflight` gates: `gated`, `frozen`, `approved`, `implementing`, `reviewing`, `draft-ready`, **`submitted`**. `followed-up` is **not** in-flight.
 
+`submitted` → `followed-up` is bounded (ADR 0002, `applyPrSync`): threads answered + PR quiet ≥ 14 days releases the slot; maintainer activity on a `followed-up` packet re-blocks the tick until answered; ≥ 45 quiet days records a `stale-intent` note (`closedUnmerged` + polite close is a human act). Maintainer silence cannot idle the factory indefinitely.
+
 ### Scorecard halt
 
 Stop a repo when:

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -13,6 +13,8 @@ import {
   findCompetingPull,
   hasInflight,
   INFLIGHT_STATUSES,
+  QUIET_RELEASE_DAYS,
+  quietDaysOf,
 } from "./engine.ts";
 import {
   compareCommits,
@@ -55,10 +57,17 @@ function printStatus(state: ReturnType<typeof mustLoad>) {
   if (inflight.length) {
     console.log("in flight:");
     for (const p of inflight) {
-      console.log(`  ${p.id}  ${p.status}  ${p.repoId}#${p.issueNumber}  ${p.prUrl ?? ""}`);
+      const quiet = p.prMeta ? `  quiet=${quietDaysOf(p.prMeta, new Date().toISOString())}d/${QUIET_RELEASE_DAYS}` : "";
+      console.log(`  ${p.id}  ${p.status}  ${p.repoId}#${p.issueNumber}  ${p.prUrl ?? ""}${quiet}`);
     }
   } else {
     console.log("in flight: none — tick is allowed");
+  }
+  const following = state.packets.filter((p) => p.status === "followed-up" && p.prMeta?.state === "open");
+  for (const p of following) {
+    console.log(
+      `  following ${p.repoId}#${p.issueNumber}  quiet=${quietDaysOf(p.prMeta!, new Date().toISOString())}d  (maintainer activity re-blocks the tick)`,
+    );
   }
   console.log("scorecard:");
   for (const row of state.scorecard) {

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -7,6 +7,7 @@ import {
   applyAttachEvidence,
   applyHalt,
   applyReject,
+  applyPrSync,
   applyTick,
   bindingFromCompare,
   classifyCompetition,
@@ -150,6 +151,7 @@ if (!cmd || cmd === "help" || cmd === "-h" || cmd === "--help") {
   evidence <packetId> --base <sha> --head <sha> --test-exit <n> --negative <red-on-revert|pending|failed>
   body <packetId>
   attach-draft <packetId> <prUrl>
+  sync <packetId> [--threads-answered]
 
 State: ${STATE_FILE} (seed if missing; refuse if present but malformed). Foundry never merges.
 Disclosure:
@@ -354,6 +356,39 @@ async function main() {
     });
     console.log("---");
     console.log(`create payload draft=${payload.draft} (no merge helper)`);
+    return;
+  }
+
+  if (cmd === "sync") {
+    const id = rest[0];
+    if (!id) {
+      console.error("sync requires a packet id");
+      process.exit(1);
+    }
+    const packet = state.packets.find((p) => p.id === id);
+    if (!packet || !packet.prUrl) {
+      console.error(packet ? `packet ${id} has no PR to sync` : `unknown packet ${id}`);
+      process.exit(1);
+    }
+    const synced = await syncGithubPr({ url: packet.prUrl });
+    if (!synced.ok) {
+      console.error(synced.error);
+      process.exit(1);
+    }
+    // --threads-answered is the operator's attestation that every review thread has a reply.
+    // Without it, quiet days accrue but the slot is never released.
+    const result = applyPrSync(state, id, synced.meta, {
+      threadsAnswered: rest.includes("--threads-answered"),
+    });
+    if (result.error) {
+      console.error(result.error);
+      process.exit(1);
+    }
+    saveFactoryState(STATE_FILE, result.state);
+    const after = result.state.packets.find((p) => p.id === id);
+    console.log(
+      `synced ${id} → ${after?.status}  quiet=${quietDaysOf(synced.meta, new Date().toISOString())}d  draft=${synced.meta.draft} state=${synced.meta.state} merged=${synced.meta.merged}`,
+    );
     return;
   }
 

--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -7,6 +7,7 @@ import {
   applyAttachDraft,
   applyAttachEvidence,
   applyHalt,
+  applyPrSync,
   applyQueueLive,
   applyTick,
   bindingFromCompare,
@@ -726,4 +727,108 @@ test("competition precedence and the direct reference helpers", () => {
   );
   assert.equal(keywordBeatsTimeline.kind, "competing");
   if (keywordBeatsTimeline.kind === "competing") assert.equal(keywordBeatsTimeline.why, "closing-keyword");
+});
+
+function prMetaAt(updatedAt: string, over: Record<string, unknown> = {}) {
+  return {
+    url: "https://github.com/ColeMurray/background-agents/pull/1652",
+    title: "Differentiate the right sidebar toggle icon by state",
+    draft: true,
+    state: "open" as const,
+    merged: false,
+    mergeable: "blocked",
+    commits: 1,
+    reviewComments: 0,
+    issueComments: 1,
+    headSha: "48c2242683705b00503d3436575bf3c28b1b0c9b",
+    updatedAt,
+    syncedAt: updatedAt,
+    ...over,
+  };
+}
+
+test("answered threads plus 14 quiet days release the in-flight slot", () => {
+  const state = seedState();
+  const submitted = state.packets.find((p) => p.status === "submitted");
+  assert.ok(submitted);
+  const at = "2026-09-20T00:00:00.000Z";
+  const result = applyPrSync(state, submitted!.id, prMetaAt("2026-09-01T00:00:00.000Z"), {
+    threadsAnswered: true,
+    at,
+  });
+  assert.equal(result.error, undefined);
+  const after = result.state.packets.find((p) => p.id === submitted!.id);
+  assert.equal(after?.status, "followed-up");
+  assert.equal(hasInflight(result.state.packets), false);
+  assert.equal(after?.followUps?.some((f) => f.kind === "quiet"), true);
+});
+
+test("13 quiet days do not release the slot; unanswered threads never do", () => {
+  const state = seedState();
+  const submitted = state.packets.find((p) => p.status === "submitted");
+  const at = "2026-09-14T00:00:00.000Z";
+  const early = applyPrSync(state, submitted!.id, prMetaAt("2026-09-01T00:00:00.000Z"), {
+    threadsAnswered: true,
+    at,
+  });
+  assert.equal(early.state.packets.find((p) => p.id === submitted!.id)?.status, "submitted");
+  const unanswered = applyPrSync(state, submitted!.id, prMetaAt("2026-08-01T00:00:00.000Z"), {
+    threadsAnswered: false,
+    at: "2026-09-20T00:00:00.000Z",
+  });
+  assert.equal(unanswered.state.packets.find((p) => p.id === submitted!.id)?.status, "submitted");
+});
+
+test("maintainer activity on a followed-up packet re-blocks the factory", () => {
+  const state = seedState();
+  const submitted = state.packets.find((p) => p.status === "submitted");
+  const released = applyPrSync(state, submitted!.id, prMetaAt("2026-09-01T00:00:00.000Z"), {
+    threadsAnswered: true,
+    at: "2026-09-20T00:00:00.000Z",
+  });
+  const woken = applyPrSync(released.state, submitted!.id, prMetaAt("2026-09-21T08:00:00.000Z", { issueComments: 2 }), {
+    threadsAnswered: false,
+    at: "2026-09-21T09:00:00.000Z",
+  });
+  const after = woken.state.packets.find((p) => p.id === submitted!.id);
+  assert.equal(after?.status, "submitted");
+  assert.equal(hasInflight(woken.state.packets), true);
+});
+
+test("merged and closed syncs write the scorecard and end follow-up", () => {
+  const state = seedState();
+  const submitted = state.packets.find((p) => p.status === "submitted");
+  const merged = applyPrSync(state, submitted!.id, prMetaAt("2026-09-01T00:00:00.000Z", { merged: true, state: "closed" }), {
+    threadsAnswered: true,
+    at: "2026-09-02T00:00:00.000Z",
+  });
+  const mergedPacket = merged.state.packets.find((p) => p.id === submitted!.id);
+  assert.equal(mergedPacket?.status, "merged");
+  const mergedRow = merged.state.scorecard.find((r) => r.repoId === submitted!.repoId);
+  assert.equal(mergedRow?.merged, 1);
+
+  const closed = applyPrSync(state, submitted!.id, prMetaAt("2026-09-01T00:00:00.000Z", { state: "closed" }), {
+    threadsAnswered: true,
+    at: "2026-09-02T00:00:00.000Z",
+  });
+  const closedPacket = closed.state.packets.find((p) => p.id === submitted!.id);
+  assert.equal(closedPacket?.status, "followed-up");
+  const closedRow = closed.state.scorecard.find((r) => r.repoId === submitted!.repoId);
+  assert.equal(closedRow?.closedUnmerged, 1);
+});
+
+test("45 quiet days record a stale-intent note but never auto-close", () => {
+  const state = seedState();
+  const submitted = state.packets.find((p) => p.status === "submitted");
+  const result = applyPrSync(state, submitted!.id, prMetaAt("2026-08-28T00:00:00.000Z"), {
+    threadsAnswered: true,
+    at: "2026-10-20T00:00:00.000Z",
+  });
+  const after = result.state.packets.find((p) => p.id === submitted!.id);
+  assert.equal(after?.status, "followed-up");
+  assert.equal(
+    after?.followUps?.some((f) => f.kind === "note" && f.body.includes("stale-intent")),
+    true,
+  );
+  assert.equal(after?.prMeta?.state, "open");
 });

--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -832,3 +832,44 @@ test("45 quiet days record a stale-intent note but never auto-close", () => {
   );
   assert.equal(after?.prMeta?.state, "open");
 });
+
+test("re-syncing a closed PR writes closedUnmerged exactly once; merged bumps mergedTotal", () => {
+  const state = seedState();
+  const submitted = state.packets.find((p) => p.status === "submitted");
+  const closedMeta = prMetaAt("2026-09-01T00:00:00.000Z", { state: "closed" });
+  const once = applyPrSync(state, submitted!.id, closedMeta, { threadsAnswered: true, at: "2026-09-02T00:00:00.000Z" });
+  const twice = applyPrSync(once.state, submitted!.id, closedMeta, { threadsAnswered: true, at: "2026-09-03T00:00:00.000Z" });
+  const thrice = applyPrSync(twice.state, submitted!.id, closedMeta, { threadsAnswered: true, at: "2026-09-04T00:00:00.000Z" });
+  const row = thrice.state.scorecard.find((r) => r.repoId === submitted!.repoId);
+  assert.equal(row?.closedUnmerged, 1);
+
+  const merged = applyPrSync(state, submitted!.id, prMetaAt("2026-09-01T00:00:00.000Z", { merged: true, state: "closed" }), {
+    threadsAnswered: true,
+    at: "2026-09-02T00:00:00.000Z",
+  });
+  assert.equal(merged.state.mergedTotal, state.mergedTotal + 1);
+  const again = applyPrSync(merged.state, submitted!.id, prMetaAt("2026-09-05T00:00:00.000Z", { merged: true, state: "closed" }), {
+    threadsAnswered: true,
+    at: "2026-09-06T00:00:00.000Z",
+  });
+  assert.match(again.error ?? "", /cannot sync/);
+});
+
+test("quiet-day thresholds hold at their exact boundaries", () => {
+  const state = seedState();
+  const submitted = state.packets.find((p) => p.status === "submitted");
+  const at14 = applyPrSync(state, submitted!.id, prMetaAt("2026-09-01T00:00:00.000Z"), {
+    threadsAnswered: true,
+    at: "2026-09-15T00:00:00.000Z",
+  });
+  assert.equal(at14.state.packets.find((p) => p.id === submitted!.id)?.status, "followed-up");
+
+  const at45 = applyPrSync(state, submitted!.id, prMetaAt("2026-09-01T00:00:00.000Z"), {
+    threadsAnswered: true,
+    at: "2026-10-16T00:00:00.000Z",
+  });
+  const after45 = at45.state.packets.find((p) => p.id === submitted!.id);
+  assert.equal(after45?.followUps?.some((f) => f.kind === "note" && f.body.startsWith("stale-intent")), true);
+  const scorecardRow = at45.state.scorecard.find((r) => r.repoId === submitted!.repoId);
+  assert.equal(scorecardRow?.closedUnmerged, 0);
+});

--- a/factory/engine.ts
+++ b/factory/engine.ts
@@ -9,7 +9,9 @@ import type {
   EvidenceManifest,
   FactoryEvent,
   FactoryState,
+  FollowUpEntry,
   PacketStatus,
+  PrMeta,
   ScorecardRow,
   TaskPacket,
 } from "./types.ts";
@@ -679,5 +681,107 @@ export function bindingFromCompare(compared: {
     messages: compared.messages,
     filesChanged: compared.filesChanged,
     diffLines: compared.diffLines,
+  };
+}
+
+/** ADR 0002: answered threads + this many quiet days move `submitted` → `followed-up`, releasing the slot. */
+export const QUIET_RELEASE_DAYS = 14;
+/** ADR 0002: after this many quiet days an abandoned draft gets a closedUnmerged-intent note. A human closes; the engine never does. */
+export const STALE_INTENT_DAYS = 45;
+
+/** Whole days since the PR's last recorded activity. GitHub bumps updated_at on any activity, bots included — conservative: noise resets the clock, it never releases early. */
+export function quietDaysOf(meta: PrMeta, at: string): number {
+  const updated = Date.parse(meta.updatedAt);
+  const nowMs = Date.parse(at);
+  if (!Number.isFinite(updated) || !Number.isFinite(nowMs)) return 0;
+  return Math.max(0, Math.floor((nowMs - updated) / 86_400_000));
+}
+
+function followUpEntry(at: string, kind: FollowUpEntry["kind"], body: string, url?: string): FollowUpEntry {
+  return {
+    id: `fu_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`,
+    at,
+    kind,
+    body,
+    url,
+  };
+}
+
+/**
+ * Apply a live PR sync to a submitted/followed-up packet.
+ * merged → terminal + scorecard `merged`. closed unmerged → followed-up + scorecard `closedUnmerged`.
+ * open: answered threads + ≥QUIET_RELEASE_DAYS quiet releases the in-flight slot; new maintainer
+ * activity on a followed-up packet re-blocks the factory until answered; ≥STALE_INTENT_DAYS quiet
+ * records a stale-intent note — closing stays a human act.
+ */
+export function applyPrSync(
+  state: FactoryState,
+  id: string,
+  meta: PrMeta,
+  opts: { threadsAnswered: boolean; at?: string },
+): { state: FactoryState; error?: string } {
+  const packet = state.packets.find((p) => p.id === id);
+  if (!packet) return { state, error: `unknown packet ${id}` };
+  if (packet.status !== "submitted" && packet.status !== "followed-up") {
+    return { state, error: `cannot sync PR from status ${packet.status}` };
+  }
+  const at = opts.at ?? now();
+  const events: FactoryEvent[] = [];
+  let next: TaskPacket = bump(packet, { prMeta: meta });
+  let scorecard = state.scorecard;
+
+  if (meta.merged) {
+    next = bump(next, { status: "merged", station: "terminal" });
+    scorecard = applyPacketToScorecard(scorecard, packet, "merged");
+    events.push(ev("follow-up", `Merged by maintainers — ${meta.url}`, id));
+  } else if (meta.state === "closed") {
+    next = bump(next, { status: "followed-up" });
+    scorecard = applyPacketToScorecard(scorecard, packet, "closed");
+    events.push(ev("follow-up", `Closed unmerged — scorecard closedUnmerged written for ${packet.repoId}`, id));
+  } else {
+    const quiet = quietDaysOf(meta, at);
+    const woke =
+      packet.status === "followed-up" &&
+      packet.prMeta !== undefined &&
+      packet.prMeta.updatedAt !== meta.updatedAt;
+    if (woke) {
+      next = bump(next, { status: "submitted" });
+      events.push(ev("follow-up", `Maintainer activity on ${meta.url} — answer threads before any new tick`, id));
+    } else if (packet.status === "submitted" && opts.threadsAnswered && quiet >= QUIET_RELEASE_DAYS) {
+      next = bump(next, {
+        status: "followed-up",
+        followUps: [
+          ...(next.followUps ?? []),
+          followUpEntry(at, "quiet", `Threads answered; PR quiet ${quiet} days — slot released, follow-up continues.`, meta.url),
+        ],
+      });
+      events.push(ev("follow-up", `Quiet ${quiet}d ≥ ${QUIET_RELEASE_DAYS} — packet followed-up, slot released`, id));
+    }
+    if (quiet >= STALE_INTENT_DAYS) {
+      const already = (next.followUps ?? []).some((f) => f.kind === "note" && f.body.startsWith("stale-intent"));
+      if (!already) {
+        next = bump(next, {
+          followUps: [
+            ...(next.followUps ?? []),
+            followUpEntry(
+              at,
+              "note",
+              `stale-intent: quiet ${quiet} days ≥ ${STALE_INTENT_DAYS}. Record closedUnmerged and close with a polite note — a human decides; the engine does not close PRs.`,
+              meta.url,
+            ),
+          ],
+        });
+        events.push(ev("follow-up", `Stale ${quiet}d — closedUnmerged intent recorded; a human closes`, id));
+      }
+    }
+  }
+
+  return {
+    state: {
+      ...state,
+      packets: state.packets.map((p) => (p.id === id ? next : p)),
+      scorecard,
+      events: [...events.reverse(), ...state.events].slice(0, 80),
+    },
   };
 }

--- a/factory/engine.ts
+++ b/factory/engine.ts
@@ -730,14 +730,22 @@ export function applyPrSync(
   let next: TaskPacket = bump(packet, { prMeta: meta });
   let scorecard = state.scorecard;
 
+  let mergedNow = false;
   if (meta.merged) {
+    // Reachable only from submitted/followed-up; the merged status blocks re-entry, so this fires once.
     next = bump(next, { status: "merged", station: "terminal" });
     scorecard = applyPacketToScorecard(scorecard, packet, "merged");
+    mergedNow = true;
     events.push(ev("follow-up", `Merged by maintainers — ${meta.url}`, id));
   } else if (meta.state === "closed") {
     next = bump(next, { status: "followed-up" });
-    scorecard = applyPacketToScorecard(scorecard, packet, "closed");
-    events.push(ev("follow-up", `Closed unmerged — scorecard closedUnmerged written for ${packet.repoId}`, id));
+    // Edge-triggered: write closedUnmerged only on the open→closed transition. Re-syncing an
+    // already-closed PR must not inflate the terminal count (it feeds mergeRate and the halt).
+    const firstClose = packet.prMeta?.state !== "closed";
+    if (firstClose) {
+      scorecard = applyPacketToScorecard(scorecard, packet, "closed");
+      events.push(ev("follow-up", `Closed unmerged — scorecard closedUnmerged written for ${packet.repoId}`, id));
+    }
   } else {
     const quiet = quietDaysOf(meta, at);
     const woke =
@@ -757,6 +765,9 @@ export function applyPrSync(
       });
       events.push(ev("follow-up", `Quiet ${quiet}d ≥ ${QUIET_RELEASE_DAYS} — packet followed-up, slot released`, id));
     }
+    // Deliberately no scorecard write here: a still-open draft is not a terminal outcome, and
+    // closedUnmerged feeds mergeRate/halt (docs/08-operations.md). The row is written once, on the
+    // actual open→closed transition above. The note records the intent; a human performs the close.
     if (quiet >= STALE_INTENT_DAYS) {
       const already = (next.followUps ?? []).some((f) => f.kind === "note" && f.body.startsWith("stale-intent"));
       if (!already) {
@@ -781,6 +792,7 @@ export function applyPrSync(
       ...state,
       packets: state.packets.map((p) => (p.id === id ? next : p)),
       scorecard,
+      mergedTotal: mergedNow ? state.mergedTotal + 1 : state.mergedTotal,
       events: [...events.reverse(), ...state.events].slice(0, 80),
     },
   };


### PR DESCRIPTION
## Summary

ADR 0002's quiet-day rule is now enforced (issue #10): the new `sync <packetId> [--threads-answered]` command applies live PR state through `applyPrSync` — answered threads + ≥14 quiet days moves `submitted` → `followed-up` and frees the slot, so maintainer silence cannot idle the factory indefinitely; maintainer activity on a followed-up packet re-blocks the tick until answered; ≥45 quiet days records a stale-intent note (the close stays human). Terminal scorecard writes are edge-triggered — re-syncing a closed PR cannot inflate `closedUnmerged` (which feeds the halt) — and the merged path bumps `mergedTotal` exactly once. Status prints quiet-day counters.

One documented deviation from the issue's acceptance text: no scorecard row at 45 days — a still-open draft is not a terminal outcome per #4's definitions; the row is written once on the real open→closed transition. Rationale in code, docs/04 §7, and [an issue comment](https://github.com/ravidsrk/oss-foundry/issues/10#issuecomment-5454426367).

## Evidence (unit u10)

- base (post-u8 main) → head e727c9f (feat + review round)
- Failing-first: 5 applyPrSync tests red before implementation; reviewer independently reproduced the closed-path N-counting bug against the pre-fix code and confirmed the fix reproduces their repro
- Exact 14/45-day boundaries pinned by tests; full suite **57/57**, exit 0
- Build-blind review: R1 **REQUEST_CHANGES** (3 blockers: unreachable mechanism, N-counting, undocumented deviation) → R2 **APPROVE** at reviewed_sha `e727c9f` with live guard-branch verification

## Sweep

Unit u10 of the field-report clean-sweep (landing=direct-to-default).

Closes #10

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds live PR synchronization and bounded quiet-day transitions for submitted packets, including scorecard updates and operator-facing status output.
- Adds `sync <packetId> [--threads-answered]` to fetch and apply live GitHub PR state.
- Releases answered packets after 14 quiet days and records stale intent after 45 days.
- Handles activity wake-ups, merges, closed-unmerged scorecard accounting, documentation, and boundary tests.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until closed outcomes remain idempotent across reopen cycles and non-maintainer activity can no longer masquerade as maintainer activity.

Reopening and re-closing one PR can increment its terminal scorecard outcome repeatedly, while any actor's timestamp update can return a released packet to the in-flight state and block new work.

**Files Needing Attention:** factory/engine.ts, factory/cli.ts, factory/engine.test.ts
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| factory/engine.ts | Implements the synchronization state machine, but reopen/reclose cycles can double-count closed outcomes and actor-agnostic activity can incorrectly re-block the factory. |
| factory/cli.ts | Adds the sync command and quiet-day status output; its metadata contract provides no way to distinguish maintainer activity. |
| factory/engine.test.ts | Covers threshold boundaries and repeated unchanged closed syncs, but not reopen/reclose counting or non-maintainer wake activity. |
| docs/04-stations.md | Documents quiet-day operation, including broad `updated_at` semantics that expose the wake-transition mismatch. |
| docs/PRODUCT.md | Documents the intended maintainer-activity re-blocking contract and stale-intent behavior. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[sync packet] --> B{PR merged?}
  B -->|Yes| C[Merged terminal state<br/>increment merged once]
  B -->|No| D{PR closed?}
  D -->|Yes| E[Followed-up<br/>count closed-unmerged edge]
  D -->|No| F{Followed-up and updatedAt changed?}
  F -->|Yes| G[Submitted<br/>re-block tick]
  F -->|No| H{Submitted, threads answered,<br/>quiet at least 14 days?}
  H -->|Yes| I[Followed-up<br/>release slot]
  H -->|No| J[Keep current status]
  I --> K{Quiet at least 45 days?}
  J --> K
  K -->|Yes| L[Record stale-intent note once]
  K -->|No| M[Persist synchronized state]
  L --> M
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20ravidsrk%2Foss-foundry%20PR%20%2322%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=ravidsrk%2Foss-foundry&pr=22&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Afactory%2Fengine.ts%3A744-746%0A**Reopen%20resets%20close%20accounting**%0A%0AWhen%20a%20counted%20closed%20PR%20is%20reopened%20and%20synced%20before%20being%20closed%20again%2C%20the%20open%20sync%20replaces%20%60prMeta.state%60%2C%20so%20%60firstClose%60%20becomes%20true%20again%20and%20increments%20%60closedUnmerged%60%20twice%20for%20one%20packet%2C%20corrupting%20merge-rate%20and%20halt%20calculations.%0A%0A%23%23%23%20Issue%202%0Afactory%2Fengine.ts%3A751-756%0A**Any%20activity%20reblocks%20packets**%0A%0AWhen%20a%20bot%2C%20automation%2C%20or%20the%20PR%20author%20updates%20a%20followed-up%20PR%2C%20the%20aggregate%20%60updatedAt%60%20change%20is%20classified%20as%20maintainer%20activity%20and%20moves%20the%20packet%20back%20to%20in-flight%20%60submitted%60%2C%20blocking%20new%20ticks%20until%20another%20attested%20quiet%20period%20releases%20it.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ravidsrk%2Foss-foundry&pr=22&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
factory/engine.ts:744-746
**Reopen resets close accounting**

When a counted closed PR is reopened and synced before being closed again, the open sync replaces `prMeta.state`, so `firstClose` becomes true again and increments `closedUnmerged` twice for one packet, corrupting merge-rate and halt calculations.

### Issue 2
factory/engine.ts:751-756
**Any activity reblocks packets**

When a bot, automation, or the PR author updates a followed-up PR, the aggregate `updatedAt` change is classified as maintainer activity and moves the packet back to in-flight `submitted`, blocking new ticks until another attested quiet period releases it.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["review: wire sync into the CLI; edge-tri..."](https://github.com/ravidsrk/oss-foundry/commit/e727c9f44343483cca82f7d6e28a12e72ab4b851) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57944210)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->