### PR TITLE
feat(disclosure): per-repo commit trailers; PR body written for the maintainer

### DIFF
--- a/docs/02-good-neighbor.md
+++ b/docs/02-good-neighbor.md
@@ -31,6 +31,15 @@ A human reviewed the packet, the diff, and the tests before this draft was opene
 The factory does not merge. Maintainers own the merge.
 ```
 
+## Commit trailers
+
+Disclosure also speaks the target's dialect (`disclosureTrailer` in the allowlist):
+kernel-style `Assisted-by: Foundry`, ASF-style `Generated-by: Foundry`, or PR-body prose only
+(default). Two lines are never emitted, and the evidence gate refuses commit ranges that carry
+them: `Signed-off-by` (Foundry never certifies the DCO — a human signs outside the factory or the
+packet parks `needs-human`) and `Co-authored-by` naming an agent (Git reads that trailer as a
+person). The PR body names the trailer convention in use so maintainers see both halves.
+
 ## Lighting
 
 Every packet is `lit`: a reviewer who did not implement it reads the diff. `dark-eligible` is not representable in Foundry — the state loader refuses it at load, and the type no longer carries it. Upstream is not our default branch.

--- a/docs/10-schemas.md
+++ b/docs/10-schemas.md
@@ -45,7 +45,7 @@ A packet without `negativeControl=red-on-revert` and real (non-placeholder) `bas
 
 ## Allowlist repo
 
-See `allowlist.yaml`. Required fields: `id`, `wave`, `aiPolicy`, `testCommand`, `maxFiles`, `maxDiffLines`, `sandbox`, `preferredLabels`. Optional: `policyNotes` — a free-text provenance note (why a policy value was chosen, dated). It is appended to the policy-scan blob, so keep it free of gate phrases. Wave 1+ should name at least one `firstIssues` entry before the clock may select them.
+See `allowlist.yaml`. Required fields: `id`, `wave`, `aiPolicy`, `testCommand`, `maxFiles`, `maxDiffLines`, `sandbox`, `preferredLabels`. Optional: `policyNotes` — a free-text provenance note (why a policy value was chosen, dated). It is appended to the policy-scan blob, so keep it free of gate phrases. Optional: `disclosureTrailer` — `assisted-by` | `generated-by` | `pr-body-only` (default): the commit-disclosure convention the target follows; the evidence gate requires the matching trailer when set. Wave 1+ should name at least one `firstIssues` entry before the clock may select them.
 
 ## Policy record (`policy-records.json`)
 

--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -873,3 +873,52 @@ test("quiet-day thresholds hold at their exact boundaries", () => {
   const scorecardRow = at45.state.scorecard.find((r) => r.repoId === submitted!.repoId);
   assert.equal(scorecardRow?.closedUnmerged, 0);
 });
+
+test("renderPrBody speaks to maintainers: no internal jargon, one closing reference", () => {
+  const packet = buildPacket({
+    repoId: "ravidsrk/orca-fleet",
+    issueNumber: 71,
+    issueTitle: "[P2] Validator: one unreadable SKILL.md must not abort the catalog",
+    issueUrl: "https://github.com/ravidsrk/orca-fleet/issues/71",
+    labels: ["documentation"],
+  });
+  const body = renderPrBody(packet);
+  assert.equal(/Policy:/.test(body), false);
+  assert.equal(/Scout score/.test(body), false);
+  assert.equal(/[Ll]ighting/.test(body), false);
+  assert.equal(body.includes(DISCLOSURE), true);
+  const closings = body.match(/close[sd]?\s+#\d+|fix(?:e[sd])?\s+#\d+|resolve[sd]?\s+#\d+/gi) ?? [];
+  assert.equal(closings.length, 1);
+  assert.equal(body.includes(packet.issueUrl), false);
+});
+
+test("evidence refuses agent sign-offs and agent co-author trailers in the commit range", () => {
+  let state = applyTick(blank()).state;
+  const id = state.packets[0].id;
+  state = applyApprove(state, id, "attest").state;
+  state = applyAdvance(state, id).state;
+  state = applyAdvance(state, id).state;
+  const packet = state.packets[0];
+  const evidence = {
+    baseSha: BASE,
+    headSha: HEAD,
+    testCommand: "true",
+    testExit: 0,
+    negativeControl: "red-on-revert" as const,
+    filesChanged: 1,
+    diffLines: 1,
+    notes: [],
+  };
+  const bad = applyAttachEvidence(state, id, evidence, bindingFor(packet, {
+    messages: [`fix: validator\n\nFixes #${packet.issueNumber}\n\nSigned-off-by: Foundry <bot@example.com>`],
+  }));
+  assert.match(bad.error ?? "", /signed-off-by/i);
+
+  const coauthored = applyAttachEvidence(state, id, evidence, bindingFor(packet, {
+    messages: [`fix: validator\n\nFixes #${packet.issueNumber}\n\nCo-authored-by: Claude <noreply@anthropic.com>`],
+  }));
+  assert.match(coauthored.error ?? "", /co-authored-by/i);
+
+  const clean = applyAttachEvidence(state, id, evidence, bindingFor(packet));
+  assert.equal(clean.error, undefined);
+});

--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -13,6 +13,7 @@ import {
   bindingFromCompare,
   branchMentionsIssue,
   classifyCompetition,
+  commitTrailerViolation,
   evidenceIsReady,
   findCompetingPull,
   hasInflight,
@@ -921,4 +922,20 @@ test("evidence refuses agent sign-offs and agent co-author trailers in the commi
 
   const clean = applyAttachEvidence(state, id, evidence, bindingFor(packet));
   assert.equal(clean.error, undefined);
+});
+
+test("commitTrailerViolation inspects every co-author line and the configured convention", () => {
+  const humanFirstAgentSecond = [
+    "fix: x\n\nCo-authored-by: Jane Doe <jane@example.com>\nCo-authored-by: Claude <noreply@anthropic.com>",
+  ];
+  assert.match(commitTrailerViolation(humanFirstAgentSecond, "pr-body-only") ?? "", /co-authored-by/i);
+
+  const humansOnly = ["fix: x\n\nCo-authored-by: Jane <jane@example.com>\nCo-authored-by: Sam <sam@example.com>"];
+  assert.equal(commitTrailerViolation(humansOnly, "pr-body-only"), undefined);
+
+  assert.match(commitTrailerViolation(["fix: y"], "assisted-by") ?? "", /missing/i);
+  assert.equal(commitTrailerViolation(["fix: y\n\nAssisted-by: Foundry"], "assisted-by"), undefined);
+  assert.match(commitTrailerViolation(["fix: y\n\nAssisted-by: SomeOtherTool"], "assisted-by") ?? "", /missing/i);
+  assert.equal(commitTrailerViolation(["docs: z\n\nGenerated-by: Foundry"], "generated-by"), undefined);
+  assert.match(commitTrailerViolation(["docs: z\n\nAssisted-by: Foundry"], "generated-by") ?? "", /missing/i);
 });

--- a/factory/engine.ts
+++ b/factory/engine.ts
@@ -1,6 +1,7 @@
 import { ALLOWLIST, CAPS, isDenied, repoById } from "./allowlist.ts";
 import { parsePrUrl } from "./github-pr.ts";
 import type { LiveIssue } from "./github-scout.ts";
+import { AGENT_NAME_RE, commitTrailerLine, type DisclosureTrailer } from "./neighbor.ts";
 import { buildPacket, renderPrBody } from "./packet.ts";
 import { planSandbox, runSandboxDry } from "./sandbox.ts";
 import { applyPacketToScorecard, health } from "./scorecard.ts";
@@ -483,6 +484,13 @@ export function applyAttachEvidence(
   if (!mentionsIssue(blob, packet.issueNumber, packet.issueUrl, packet.repoId)) {
     return { state, error: `commit range does not close ${packet.repoId}#${packet.issueNumber}` };
   }
+  const trailerViolation = commitTrailerViolation(
+    binding.messages,
+    repoById(packet.repoId)?.disclosureTrailer ?? "pr-body-only",
+  );
+  if (trailerViolation) {
+    return { state, error: trailerViolation };
+  }
   const bound: EvidenceManifest = { ...evidence, shaVerified: true };
   const packets = state.packets.map((p) => (p.id === id ? bump(p, { evidence: bound }) : p));
   return {
@@ -796,4 +804,28 @@ export function applyPrSync(
       events: [...events.reverse(), ...state.events].slice(0, 80),
     },
   };
+}
+
+/** Doctrine: Foundry never signs the DCO, and Co-authored-by names people, never agents (docs/02). */
+export function commitTrailerViolation(
+  messages: string[],
+  convention: DisclosureTrailer,
+): string | undefined {
+  const blob = messages.join("\n");
+  if (/^\s*signed-off-by:/im.test(blob)) {
+    return "commit range carries a Signed-off-by trailer — Foundry never signs the DCO. A human signs outside the factory, or the packet parks needs-human.";
+  }
+  const co = blob.match(/^\s*co-authored-by:(.*)$/im);
+  if (co && AGENT_NAME_RE.test(co[1] ?? "")) {
+    return "commit range credits an agent via Co-authored-by — Git reads that trailer as a person. Use the repo's disclosure trailer instead.";
+  }
+  const required = commitTrailerLine(convention);
+  if (required) {
+    const key = required.split(":")[0];
+    const re = new RegExp(`^\\s*${key}:`, "im");
+    if (!re.test(blob)) {
+      return `commit range is missing the repo's disclosure trailer (${required}).`;
+    }
+  }
+  return undefined;
 }

--- a/factory/engine.ts
+++ b/factory/engine.ts
@@ -815,14 +815,15 @@ export function commitTrailerViolation(
   if (/^\s*signed-off-by:/im.test(blob)) {
     return "commit range carries a Signed-off-by trailer — Foundry never signs the DCO. A human signs outside the factory, or the packet parks needs-human.";
   }
-  const co = blob.match(/^\s*co-authored-by:(.*)$/im);
-  if (co && AGENT_NAME_RE.test(co[1] ?? "")) {
-    return "commit range credits an agent via Co-authored-by — Git reads that trailer as a person. Use the repo's disclosure trailer instead.";
+  for (const co of blob.matchAll(/^\s*co-authored-by:(.*)$/gim)) {
+    if (AGENT_NAME_RE.test(co[1] ?? "")) {
+      return "commit range credits an agent via Co-authored-by — Git reads that trailer as a person. Use the repo's disclosure trailer instead.";
+    }
   }
   const required = commitTrailerLine(convention);
   if (required) {
-    const key = required.split(":")[0];
-    const re = new RegExp(`^\\s*${key}:`, "im");
+    const [key, value] = required.split(": ");
+    const re = new RegExp(`^\\s*${key}:\\s*${value}\\b`, "im");
     if (!re.test(blob)) {
       return `commit range is missing the repo's disclosure trailer (${required}).`;
     }

--- a/factory/load-allowlist.ts
+++ b/factory/load-allowlist.ts
@@ -98,6 +98,14 @@ function hydrateRepo(r: Record<string, unknown>): AllowlistedRepo {
   if (sandbox !== "host" && sandbox !== "e2b" && sandbox !== "daytona") {
     throw new Error(`allowlist.yaml: ${id} bad sandbox`);
   }
+  const disclosureTrailer = String(r.disclosureTrailer ?? "pr-body-only");
+  if (
+    disclosureTrailer !== "assisted-by" &&
+    disclosureTrailer !== "generated-by" &&
+    disclosureTrailer !== "pr-body-only"
+  ) {
+    throw new Error(`allowlist.yaml: ${id} bad disclosureTrailer`);
+  }
   const maxFiles = Number(r.maxFiles);
   const maxDiffLines = Number(r.maxDiffLines);
   if (!Number.isFinite(maxFiles) || !Number.isFinite(maxDiffLines)) {
@@ -128,6 +136,7 @@ function hydrateRepo(r: Record<string, unknown>): AllowlistedRepo {
     maxFiles,
     maxDiffLines,
     sandbox,
+    disclosureTrailer,
     preferredLabels,
     firstIssues,
   };

--- a/factory/neighbor.ts
+++ b/factory/neighbor.ts
@@ -2,6 +2,17 @@ export const DISCLOSURE = `This patch was prepared by Foundry, an operator-gated
 A human reviewed the packet, the diff, and the tests before this draft was opened.
 The factory does not merge. Maintainers own the merge.`;
 
+/** Per-repo commit-disclosure convention. `Co-authored-by` designates a person in Git's reading — never an agent. */
+export type DisclosureTrailer = "assisted-by" | "generated-by" | "pr-body-only";
+
+export function commitTrailerLine(convention: DisclosureTrailer): string | undefined {
+  if (convention === "assisted-by") return "Assisted-by: Foundry";
+  if (convention === "generated-by") return "Generated-by: Foundry";
+  return undefined;
+}
+
+export const AGENT_NAME_RE = /foundry|claude|copilot|cursor|devin|codex|gpt|openai|anthropic|\bbot\b/i;
+
 export const ABORT_DEFAULT = [
   "Policy gate flips to forbidden or unknown.",
   "An upstream PR already covers the issue.",

--- a/factory/packet.ts
+++ b/factory/packet.ts
@@ -1,5 +1,5 @@
 import { repoById } from "./allowlist.ts";
-import { ABORT_DEFAULT, DISCLOSURE, NON_GOALS_DEFAULT } from "./neighbor.ts";
+import { ABORT_DEFAULT, commitTrailerLine, DISCLOSURE, NON_GOALS_DEFAULT } from "./neighbor.ts";
 import { evaluatePolicy } from "./policy.ts";
 import { scoreIssue } from "./scout.ts";
 import type { PacketClass, TaskPacket } from "./types.ts";
@@ -73,31 +73,32 @@ export function buildPacket(input: {
   };
 }
 
+/** Written for the maintainer, not the factory: what changed, how it was verified, who prepared it. Internal vocabulary (policy codes, scout scores, lighting) stays in the packet record. */
 export function renderPrBody(packet: TaskPacket): string {
+  const repo = repoById(packet.repoId);
+  const scope = packet.evidence
+    ? `- Scope: ${packet.evidence.filesChanged} files, ${packet.evidence.diffLines} changed lines (caps ${repo?.maxFiles ?? "?"} / ${repo?.maxDiffLines ?? "?"}).`
+    : `- Scope caps: ${repo?.maxFiles ?? "?"} files, ${repo?.maxDiffLines ?? "?"} changed lines.`;
+  const trailer = commitTrailerLine(repo?.disclosureTrailer ?? "pr-body-only");
+  const trailerNote = trailer ? `\nCommits carry \`${trailer}\`.` : "";
   return `## Summary
-
-Fixes ${packet.issueUrl}
 
 ${packet.objective}
 
-## Acceptance
+## Verification
 
-${packet.acceptance.map((a) => `- [ ] ${a}`).join("\n")}
+- Test command: \`${repo?.testCommand ?? packet.evidence?.testCommand ?? ""}\`
+- A failing test existed before the change; reverting the change makes it fail again (negative control).
+${scope}
+- An independent reviewer read the diff and tests before this draft was opened.
 
 ## Non-goals
 
 ${packet.nonGoals.map((a) => `- ${a}`).join("\n")}
 
-## Evidence
-
-- Policy: \`${packet.policy.code}\`
-- Scout score: ${packet.scout.total}
-- Lighting: ${packet.lighting} (independent review required)
-- Tests: failing-first + revert negative control
-
 ## Disclosure
 
-${DISCLOSURE}
+${DISCLOSURE}${trailerNote}
 
 Closes #${packet.issueNumber}
 `;

--- a/factory/types.ts
+++ b/factory/types.ts
@@ -55,6 +55,8 @@ export interface AllowlistedRepo {
   maxFiles: number;
   maxDiffLines: number;
   sandbox: SandboxKind;
+  /** Commit-disclosure convention the target follows: kernel-style Assisted-by, ASF-style Generated-by, or PR-body prose only (default). */
+  disclosureTrailer: "assisted-by" | "generated-by" | "pr-body-only";
   contributingUrl?: string;
   agentsMdUrl?: string;
   preferredLabels: string[];


### PR DESCRIPTION
## Summary

Disclosure now speaks the ecosystem's dialects (issue #9). The allowlist gains `disclosureTrailer` (kernel-style `assisted-by` | ASF-style `generated-by` | `pr-body-only` default); the evidence gate requires the configured trailer — key **and** value — in the commit range, scans **every** `Co-authored-by` line for agent names (Git reads that trailer as a person), and always refuses `Signed-off-by` (Foundry never certifies the DCO). `renderPrBody` is rewritten for the maintainer as audience: summary, verification (test command, failing-first, negative control, scope vs caps), non-goals, verbatim disclosure, exactly one closing reference — no policy codes, scout scores, or lighting jargon.

## Evidence (unit u9)

- head 90b968a (feat + review round; rebase over u7/u10 verified add-only by numstat — zero deletions near landed code)
- Failing-first: renderPrBody + trailer-refusal tests red before implementation; the reviewer's human-first/agent-second bypass probe is now a committed test proven load-bearing by checkout-revert
- Full suite **70/70**, exit 0; cli + validator smoke green
- Build-blind review: R1 **REQUEST_CHANGES** (first-trailer-only scan bypass; untested convention branch) → R2 **APPROVE** at reviewed_sha `90b968a` with independent multi-trailer and wrong-value reprobes

## Sweep

Unit u9 of the field-report clean-sweep (landing=direct-to-default).

Closes #9

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds per-repository disclosure trailer conventions, validates commit ranges against those conventions, and rewrites generated PR bodies for maintainers.

- Adds allowlist parsing and types for `assisted-by`, `generated-by`, and `pr-body-only`.
- Rejects DCO sign-offs and agent-valued co-author trailers during evidence attachment.
- Reworks PR-body verification, disclosure, non-goals, and issue-closing sections.
- Adds tests and documentation for the new disclosure behavior.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until exact trailer validation and evidence-backed PR-body verification are enforced.

Malformed or non-trailer disclosure text can pass the evidence gate, while direct body rendering can present verification claims and test commands that are not supported by the packet's recorded evidence.

**Files Needing Attention:** factory/engine.ts, factory/packet.ts
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| factory/engine.ts | Adds disclosure validation to evidence attachment, but the required-trailer regex accepts non-exact values and body prose. |
| factory/packet.ts | Rewrites maintainer-facing PR bodies, but verification claims are not derived consistently from ready evidence. |
| factory/load-allowlist.ts | Parses and validates the new disclosure convention with a backward-compatible default. |
| factory/neighbor.ts | Defines disclosure convention types, canonical trailer lines, and recognizable agent names. |
| factory/engine.test.ts | Covers configured conventions and multi-co-author scanning, but omits malformed required-trailer suffixes and unverified body rendering. |
| factory/types.ts | Extends the allowlisted repository contract with the hydrated disclosure convention. |
| docs/02-good-neighbor.md | Documents commit disclosure conventions and prohibited trailers. |
| docs/10-schemas.md | Documents the optional allowlist field and its default. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[GitHub compare commit messages] --> B[Attach evidence]
  B --> C{Trailer policy satisfied?}
  C -- No --> D[Reject evidence]
  C -- Yes --> E[Store SHA-verified evidence]
  E --> F{Evidence ready?}
  F -- No --> G[Remain in review]
  F -- Yes --> H[Render maintainer PR body]
  H --> I[Draft-ready packet]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20ravidsrk%2Foss-foundry%20PR%20%2324%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=ravidsrk%2Foss-foundry&pr=24&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Afactory%2Fengine.ts%3A826%0A**Trailer%20matching%20accepts%20extra%20text**%0A%0AWhen%20a%20commit%20contains%20a%20line%20such%20as%20%60Assisted-by%3A%20Foundry-extra%60%20or%20%60Assisted-by%3A%20Foundry%20is%20the%20tool%20used%60%2C%20the%20word-boundary%20regex%20treats%20it%20as%20the%20configured%20exact%20trailer%2C%20causing%20evidence%20to%20be%20accepted%20without%20the%20required%20disclosure.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20re%20%3D%20new%20RegExp%28%60%5E%5C%5Cs*%24%7Bkey%7D%3A%5C%5Cs*%24%7Bvalue%7D%5C%5Cs*%24%60%2C%20%22im%22%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%0Afactory%2Fpacket.ts%3A90-91%0A**Verification%20claims%20bypass%20recorded%20evidence**%0A%0AWhen%20the%20body%20command%20renders%20a%20packet%20without%20ready%20evidence%2C%20this%20code%20unconditionally%20claims%20successful%20failing-first%2C%20revert%2C%20and%20review%20checks%3B%20it%20also%20prefers%20the%20current%20allowlist%20command%20over%20the%20recorded%20evidence%20command%2C%20causing%20the%20maintainer-facing%20body%20to%20misstate%20what%20was%20verified.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ravidsrk%2Foss-foundry&pr=24&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
factory/engine.ts:826
**Trailer matching accepts extra text**

When a commit contains a line such as `Assisted-by: Foundry-extra` or `Assisted-by: Foundry is the tool used`, the word-boundary regex treats it as the configured exact trailer, causing evidence to be accepted without the required disclosure.

```suggestion
    const re = new RegExp(`^\\s*${key}:\\s*${value}\\s*$`, "im");
```

### Issue 2
factory/packet.ts:90-91
**Verification claims bypass recorded evidence**

When the body command renders a packet without ready evidence, this code unconditionally claims successful failing-first, revert, and review checks; it also prefers the current allowlist command over the recorded evidence command, causing the maintainer-facing body to misstate what was verified.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["review: scan every co-author trailer; re..."](https://github.com/ravidsrk/oss-foundry/commit/90b968a81957c1a90816eda5221bd3c8cfb4583a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57951308)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->