### PR TITLE
feat(evidence): witnessed, never attested — the sandbox runs both proofs

### DIFF
--- a/docs/06-v2.md
+++ b/docs/06-v2.md
@@ -27,6 +27,16 @@ Hard rules:
 
 Wire `E2B_API_KEY` in the worker host (not this git tree) to make it live.
 
+### Witnessed evidence (issue #6)
+
+`factory/witness.ts` executes the evidence protocol instead of accepting operator claims: clone,
+tests green at `head`, revert the non-test production files to `base`, tests must go red. The CLI's
+`evidence` command runs it (host runner, Wave 0 only per ADR 0003) and the manifest carries a
+`witness` block — provider, both exit codes, sha256 of both logs. `evidenceIsReady` refuses
+manifests without one, so `draft-ready` is unreachable on attested exits. E2B/Daytona targets
+refuse in this CLI: without `E2B_API_KEY` the refusal says "cannot witness evidence in dry-run";
+with it, execution still belongs to the worker host — this repo never fakes a green harvest.
+
 ## Scorecard halt
 
 `factory/scorecard.ts`, consulted by `factory/engine.ts`.

--- a/docs/10-schemas.md
+++ b/docs/10-schemas.md
@@ -41,7 +41,9 @@ SHA-bound. Copied from orca-fleet `runtime/evidence-manifest.md`:
 - `filesChanged`, `diffLines` vs repo caps
 - `notes`
 
-A packet without `negativeControl=red-on-revert` and real (non-placeholder) `baseSha` / `headSha` cannot enter `draft-ready`. The engine does not invent SHAs.
+- `witness` (required for `draft-ready`): `{ provider: host|e2b, testExit, revertExit, testLogSha, revertLogSha, ranAt }` — the sandbox executed both runs itself; log hashes are sha256.
+
+A packet without `negativeControl=red-on-revert`, real (non-placeholder) `baseSha` / `headSha`, and a `witness` whose `testExit` is 0 and `revertExit` is non-zero cannot enter `draft-ready`. The engine does not invent SHAs, and it does not take the operator's word for an exit code.
 
 ## Allowlist repo
 

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -27,6 +27,7 @@ import {
   syncGithubPr,
 } from "./github-pr.ts";
 import type { LiveIssue } from "./github-scout.ts";
+import { execFile } from "node:child_process";
 import { packetDivergences } from "./ledger-check.ts";
 import { DISCLOSURE } from "./neighbor.ts";
 import { renderPrBody } from "./packet.ts";
@@ -34,6 +35,21 @@ import { health } from "./scorecard.ts";
 import { loadFactoryState, saveFactoryState } from "./state.ts";
 import { foundryAttestedWave0Merges } from "./status.ts";
 import type { EvidenceManifest } from "./types.ts";
+import { witnessEvidence, type WitnessRunner } from "./witness.ts";
+
+const hostRunner: WitnessRunner = (step, args, opts) =>
+  new Promise((resolveRun) => {
+    const [cmd, cmdArgs] =
+      step === "git"
+        ? ["git", args]
+        : step === "cleanup"
+          ? ["rm", ["-rf", ...args]]
+          : ["bash", ["-lc", args[0] ?? "false"]];
+    execFile(cmd, cmdArgs, { cwd: opts?.cwd, maxBuffer: 16 * 1024 * 1024 }, (err, stdout, stderr) => {
+      const exit = err && typeof (err as { code?: unknown }).code === "number" ? ((err as { code: number }).code) : err ? 1 : 0;
+      resolveRun({ exit, output: `${stdout}${stderr}` });
+    });
+  });
 
 const STATE_FILE = resolve(".foundry-state.json");
 
@@ -149,7 +165,7 @@ if (!cmd || cmd === "help" || cmd === "-h" || cmd === "--help") {
   reject <packetId> --reason <text>
   halt <repoId> --reason <text>
   advance <packetId>
-  evidence <packetId> --base <sha> --head <sha> --test-exit <n> --negative <red-on-revert|pending|failed>
+  evidence <packetId> --base <sha> --head <sha>   (tests + revert control run in the sandbox — witnessed, never attested)
   body <packetId>
   attach-draft <packetId> <prUrl>
   sync <packetId> [--threads-answered]
@@ -305,16 +321,9 @@ async function main() {
       console.error(`unknown packet ${id}`);
       process.exit(1);
     }
-    const testExitRaw = flag(rest, "--test-exit");
-    const negative = flag(rest, "--negative");
-    if (testExitRaw === undefined || negative === undefined) {
-      console.error(
-        "evidence requires --test-exit <n> and --negative <red-on-revert|pending|failed> (no success defaults)",
-      );
-      process.exit(1);
-    }
-    if (negative !== "red-on-revert" && negative !== "pending" && negative !== "failed") {
-      console.error("invalid --negative");
+    const repo = repoById(packet.repoId);
+    if (!repo?.testCommand) {
+      console.error("no testCommand for this repo");
       process.exit(1);
     }
     const compared = await compareCommits(packet.repoId, base, head);
@@ -322,20 +331,34 @@ async function main() {
       console.error(compared.error);
       process.exit(1);
     }
+    console.error(`witnessing ${packet.repoId} ${base.slice(0, 7)}..${head.slice(0, 7)} (${repo.sandbox}) — cloning and running \`${repo.testCommand}\` twice`);
+    const outcome = await witnessEvidence(
+      {
+        repoId: packet.repoId,
+        baseSha: base,
+        headSha: head,
+        testCommand: repo.testCommand,
+        sandbox: repo.sandbox,
+        wave: repo.wave,
+      },
+      hostRunner,
+      process.env,
+    );
+    if (!outcome.ok) {
+      console.error(outcome.error);
+      process.exit(1);
+    }
     const evidence: EvidenceManifest = {
       baseSha: base,
       headSha: head,
-      testCommand: repoById(packet.repoId)?.testCommand ?? packet.evidence?.testCommand ?? "",
-      testExit: Number(testExitRaw),
-      negativeControl: negative,
+      testCommand: repo.testCommand,
+      testExit: outcome.witness.testExit,
+      negativeControl: outcome.witness.revertExit !== 0 ? "red-on-revert" : "failed",
       filesChanged: compared.filesChanged,
       diffLines: compared.diffLines,
-      notes: ["attached via CLI"],
+      notes: [`witnessed via CLI (${outcome.witness.provider}); logs sha256 ${outcome.witness.testLogSha.slice(0, 12)}/${outcome.witness.revertLogSha.slice(0, 12)}`],
+      witness: outcome.witness,
     };
-    if (!evidence.testCommand) {
-      console.error("no testCommand for this repo");
-      process.exit(1);
-    }
     const result = applyAttachEvidence(state, id, evidence, bindingFromCompare(compared));
     if (result.error) {
       const parked = result.state.packets.find((p) => p.id === id)?.status === "parked";

--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -25,6 +25,7 @@ import {
 } from "./engine.ts";
 import { draftPullPayload } from "./github-pr.ts";
 import { packetDivergences } from "./ledger-check.ts";
+import { witnessEvidence } from "./witness.ts";
 import { DISCLOSURE } from "./neighbor.ts";
 import { buildPacket, renderPrBody } from "./packet.ts";
 import { evaluatePolicy } from "./policy.ts";
@@ -61,6 +62,17 @@ function bindingFor(
     filesChanged: 1,
     diffLines: 1,
     ...extra,
+  };
+}
+
+function witnessed() {
+  return {
+    provider: "host" as const,
+    testExit: 0,
+    revertExit: 1,
+    testLogSha: "c".repeat(64),
+    revertLogSha: "d".repeat(64),
+    ranAt: "2026-08-28T16:00:00.000Z",
   };
 }
 
@@ -288,6 +300,7 @@ test("advance does not stamp placeholder SHA or auto-harvest", () => {
     filesChanged: 1,
     diffLines: 1,
     notes: ["operator-harvested"],
+    witness: witnessed(),
   }, bindingFor(state.packets[0])).state;
   assert.equal(evidenceIsReady(state.packets[0].evidence), true);
   state = applyAdvance(state, id).state;
@@ -335,6 +348,7 @@ test("attach-draft rejects a non-PR URL, wrong repo, or ready PR", () => {
     filesChanged: 1,
     diffLines: 1,
     notes: [],
+    witness: witnessed(),
   }, bindingFor(state.packets[0])).state;
   state = applyAdvance(state, id).state;
   assert.equal(state.packets[0].status, "draft-ready");
@@ -445,6 +459,7 @@ function readyEvidence(
       filesChanged,
       diffLines,
       notes: [],
+      witness: witnessed(),
     },
     binding: bindingFor(packet, { filesChanged, diffLines }),
   };
@@ -1000,4 +1015,120 @@ test("an absorbed close is at rest: reconcile-style re-diff reports no divergenc
   assert.deepEqual(packetDivergences(after, live), []);
   const unabsorbed = packetDivergences(submitted, live);
   assert.equal(unabsorbed.some((d) => d.includes(`sync ${submitted.id}`)), true);
+});
+
+function fakeRunner(script: Record<string, { exit: number; output: string }>) {
+  const calls: string[] = [];
+  const runner = async (cmd: string, args: string[]) => {
+    const line = [cmd, ...args].join(" ");
+    calls.push(line);
+    const hit = Object.entries(script).find(([prefix]) => line.includes(prefix));
+    return hit ? hit[1] : { exit: 0, output: "" };
+  };
+  return { runner, calls };
+}
+
+test("host witness: green at head, red on revert, sha-bound logs", async () => {
+  const { runner } = fakeRunner({
+    "run-tests@head": { exit: 0, output: "42 passing" },
+    "run-tests@revert": { exit: 1, output: "3 failing" },
+  });
+  const outcome = await witnessEvidence(
+    {
+      repoId: "ravidsrk/orca-fleet",
+      baseSha: BASE,
+      headSha: HEAD,
+      testCommand: "python3 scripts/validate.py",
+      sandbox: "host",
+      wave: 0,
+    },
+    runner,
+    {},
+  );
+  assert.equal(outcome.ok, true);
+  if (outcome.ok) {
+    assert.equal(outcome.witness.provider, "host");
+    assert.equal(outcome.witness.testExit, 0);
+    assert.notEqual(outcome.witness.revertExit, 0);
+    assert.match(outcome.witness.testLogSha, /^[0-9a-f]{64}$/);
+    assert.match(outcome.witness.revertLogSha, /^[0-9a-f]{64}$/);
+  }
+});
+
+test("host witness fails when the control stays green or tests are red at head", async () => {
+  const greenRevert = await witnessEvidence(
+    { repoId: "ravidsrk/orca-fleet", baseSha: BASE, headSha: HEAD, testCommand: "true", sandbox: "host", wave: 0 },
+    fakeRunner({ "run-tests@head": { exit: 0, output: "ok" }, "run-tests@revert": { exit: 0, output: "still ok" } }).runner,
+    {},
+  );
+  assert.equal(greenRevert.ok, false);
+  if (!greenRevert.ok) assert.match(greenRevert.error, /negative control/i);
+
+  const redHead = await witnessEvidence(
+    { repoId: "ravidsrk/orca-fleet", baseSha: BASE, headSha: HEAD, testCommand: "true", sandbox: "host", wave: 0 },
+    fakeRunner({ "run-tests@head": { exit: 2, output: "boom" } }).runner,
+    {},
+  );
+  assert.equal(redHead.ok, false);
+  if (!redHead.ok) assert.match(redHead.error, /red at head/i);
+});
+
+test("witness refuses instead of degrading: e2b without a key, host outside Wave 0", async () => {
+  const noKey = await witnessEvidence(
+    { repoId: "mcp-use/mcp-use", baseSha: BASE, headSha: HEAD, testCommand: "pnpm test", sandbox: "e2b", wave: 1 },
+    fakeRunner({}).runner,
+    {},
+  );
+  assert.equal(noKey.ok, false);
+  if (!noKey.ok) assert.match(noKey.error, /cannot witness evidence in dry-run/i);
+
+  const hostWave1 = await witnessEvidence(
+    { repoId: "mcp-use/mcp-use", baseSha: BASE, headSha: HEAD, testCommand: "pnpm test", sandbox: "host", wave: 1 },
+    fakeRunner({}).runner,
+    {},
+  );
+  assert.equal(hostWave1.ok, false);
+  if (!hostWave1.ok) assert.match(hostWave1.error, /Wave 0/);
+});
+
+test("draft-ready requires a witnessed manifest, not an attested one", () => {
+  let state = applyTick(blank()).state;
+  const id = state.packets[0].id;
+  state = applyApprove(state, id, "attest").state;
+  state = applyAdvance(state, id).state;
+  state = applyAdvance(state, id).state;
+  const packet = state.packets[0];
+  const unwitnessed = {
+    baseSha: BASE,
+    headSha: HEAD,
+    testCommand: "true",
+    testExit: 0,
+    negativeControl: "red-on-revert" as const,
+    filesChanged: 1,
+    diffLines: 1,
+    notes: [],
+  };
+  state = applyAttachEvidence(state, id, unwitnessed, bindingFor(packet)).state;
+  const blocked = applyAdvance(state, id);
+  assert.match(blocked.error ?? "", /witness/i);
+
+  let state2 = applyTick(blank()).state;
+  state2 = applyApprove(state2, id, "attest").state;
+  state2 = applyAdvance(state2, id).state;
+  state2 = applyAdvance(state2, id).state;
+  const witnessed = {
+    ...unwitnessed,
+    witness: {
+      provider: "host" as const,
+      testExit: 0,
+      revertExit: 1,
+      testLogSha: "a".repeat(64),
+      revertLogSha: "b".repeat(64),
+      ranAt: "2026-08-28T16:00:00.000Z",
+    },
+  };
+  state2 = applyAttachEvidence(state2, id, witnessed, bindingFor(state2.packets[0])).state;
+  const advanced = applyAdvance(state2, id);
+  assert.equal(advanced.error, undefined);
+  assert.equal(state2.packets[0].evidence?.witness?.provider, "host");
 });

--- a/factory/engine.ts
+++ b/factory/engine.ts
@@ -329,6 +329,9 @@ export function evidenceIsReady(evidence: EvidenceManifest | undefined): boolean
   if (!isBoundSha(evidence.baseSha) || !isBoundSha(evidence.headSha)) return false;
   if (evidence.baseSha.toLowerCase() === evidence.headSha.toLowerCase()) return false;
   if (evidence.shaVerified !== true) return false;
+  // Witnessed, not attested: the sandbox must have executed both runs itself (issue #6).
+  if (!evidence.witness) return false;
+  if (evidence.witness.testExit !== 0 || evidence.witness.revertExit === 0) return false;
   return true;
 }
 
@@ -543,7 +546,7 @@ export function applyAdvance(
     if (!evidenceIsReady(packet.evidence)) {
       return {
         state,
-        error: `cannot enter draft-ready: attach SHA-bound evidence with red-on-revert first`,
+        error: `cannot enter draft-ready: attach SHA-bound, witnessed evidence (tests and the revert control executed by the sandbox) with red-on-revert first`,
       };
     }
     const overflow = scopeOverflow(

--- a/factory/state.ts
+++ b/factory/state.ts
@@ -118,7 +118,23 @@ function isEvidence(value: unknown): boolean {
     typeof o.diffLines === "number" &&
     isStringArray(o.notes) &&
     optional(o.reviewedSha, (v) => typeof v === "string") &&
-    optional(o.shaVerified, (v) => typeof v === "boolean")
+    optional(o.shaVerified, (v) => typeof v === "boolean") &&
+    optional(o.witness, isWitness)
+  );
+}
+
+function isWitness(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  const o = value as Record<string, unknown>;
+  return (
+    (o.provider === "host" || o.provider === "e2b") &&
+    typeof o.testExit === "number" &&
+    typeof o.revertExit === "number" &&
+    typeof o.testLogSha === "string" &&
+    /^[0-9a-f]{64}$/.test(o.testLogSha) &&
+    typeof o.revertLogSha === "string" &&
+    /^[0-9a-f]{64}$/.test(o.revertLogSha) &&
+    typeof o.ranAt === "string"
   );
 }
 

--- a/factory/types.ts
+++ b/factory/types.ts
@@ -149,6 +149,16 @@ export interface TaskPacket {
   sandboxSession?: SandboxSession;
 }
 
+/** Machine-executed proof: the sandbox ran the tests and the revert control itself. Attested exits are history; witnessed exits are the bar. */
+export interface EvidenceWitness {
+  provider: "host" | "e2b";
+  testExit: number;
+  revertExit: number;
+  testLogSha: string;
+  revertLogSha: string;
+  ranAt: string;
+}
+
 export interface EvidenceManifest {
   baseSha: string;
   headSha: string;
@@ -161,6 +171,7 @@ export interface EvidenceManifest {
   notes: string[];
   /** True only after a repo commit lookup succeeded for base and head. */
   shaVerified?: boolean;
+  witness?: EvidenceWitness;
 }
 
 export interface SandboxSession {

--- a/factory/witness.ts
+++ b/factory/witness.ts
@@ -1,0 +1,116 @@
+import { createHash } from "node:crypto";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { EvidenceWitness, SandboxKind, Wave } from "./types.ts";
+
+/**
+ * A witness step is one of: "git" (args passed to git), "run-tests@head" / "run-tests@revert"
+ * (args[0] is the repo's test command, executed by the runner), "cleanup" (args[0] is a scratch
+ * dir). The runner seam is what makes the protocol testable without a network or a shell.
+ */
+export type WitnessStep = "git" | "run-tests@head" | "run-tests@revert" | "cleanup";
+export type WitnessRunner = (
+  step: WitnessStep,
+  args: string[],
+  opts?: { cwd?: string },
+) => Promise<{ exit: number; output: string }>;
+
+export type WitnessOutcome = { ok: true; witness: EvidenceWitness } | { ok: false; error: string };
+
+const TEST_PATH_RE = /(^|\/)(tests?|__tests__|spec)(\/|$)|\.(test|spec)\.[jt]sx?$|(^|\/)test_[^/]+$/i;
+
+function sha256(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+/**
+ * Execute the evidence protocol instead of attesting it: clone, tests green at head, revert the
+ * non-test production change to base, tests must go red. Refusals are structured, never a
+ * degraded fake-green: E2B without a key is dry-run and says so; host execution outside Wave 0
+ * violates ADR 0003.
+ */
+export async function witnessEvidence(
+  input: {
+    repoId: string;
+    baseSha: string;
+    headSha: string;
+    testCommand: string;
+    sandbox: SandboxKind;
+    wave: Wave;
+  },
+  runner: WitnessRunner,
+  env: Record<string, string | undefined>,
+): Promise<WitnessOutcome> {
+  if (input.sandbox === "host" && input.wave !== 0) {
+    return { ok: false, error: "host witnessing is Wave 0 only (ADR 0003) — untrusted clones never run on the operator machine" };
+  }
+  if (input.sandbox !== "host") {
+    if (!env.E2B_API_KEY) {
+      return {
+        ok: false,
+        error:
+          "cannot witness evidence in dry-run — wire E2B_API_KEY on the worker host (docs/06-v2.md). The factory refuses rather than degrading to operator-claimed results.",
+      };
+    }
+    return {
+      ok: false,
+      error:
+        "E2B execution runs on the worker host, not in this repo's CLI (ADR 0003) — run the witness there and re-attach. This CLI refuses rather than faking a green harvest.",
+    };
+  }
+
+  const dir = join(tmpdir(), `foundry-witness-${input.repoId.replace("/", "_")}-${Date.now()}`);
+  const url = `https://github.com/${input.repoId}.git`;
+  const fail = async (error: string): Promise<WitnessOutcome> => {
+    await runner("cleanup", [dir]);
+    return { ok: false, error };
+  };
+
+  const clone = await runner("git", ["clone", url, dir]);
+  if (clone.exit !== 0) return fail(`clone failed for ${input.repoId}: ${clone.output.slice(0, 200)}`);
+  const fetched = await runner("git", ["-C", dir, "fetch", "origin", input.baseSha, input.headSha]);
+  if (fetched.exit !== 0) {
+    const full = await runner("git", ["-C", dir, "fetch", "origin"]);
+    if (full.exit !== 0) return fail(`fetch failed: ${full.output.slice(0, 200)}`);
+  }
+  for (const sha of [input.baseSha, input.headSha]) {
+    const has = await runner("git", ["-C", dir, "cat-file", "-e", sha]);
+    if (has.exit !== 0) return fail(`commit ${sha.slice(0, 7)} is not reachable in ${input.repoId}`);
+  }
+  const checkout = await runner("git", ["-C", dir, "checkout", "--detach", input.headSha]);
+  if (checkout.exit !== 0) return fail(`checkout failed: ${checkout.output.slice(0, 200)}`);
+
+  const headRun = await runner("run-tests@head", [input.testCommand], { cwd: dir });
+  if (headRun.exit !== 0) {
+    return fail(`tests are red at head ${input.headSha.slice(0, 7)} (exit ${headRun.exit}) — nothing to witness`);
+  }
+
+  const changed = await runner("git", ["-C", dir, "diff", "--name-only", input.baseSha, input.headSha]);
+  const files = changed.output.split("\n").map((f) => f.trim()).filter(Boolean);
+  const nonTest = files.filter((f) => !TEST_PATH_RE.test(f));
+  const revertPaths = nonTest.length > 0 ? nonTest : ["."];
+  const revert = await runner("git", ["-C", dir, "checkout", input.baseSha, "--", ...revertPaths]);
+  if (revert.exit !== 0) return fail(`revert to base failed: ${revert.output.slice(0, 200)}`);
+
+  const revertRun = await runner("run-tests@revert", [input.testCommand], { cwd: dir });
+  await runner("cleanup", [dir]);
+  if (revertRun.exit === 0) {
+    return {
+      ok: false,
+      error:
+        "negative control failed — tests stayed green with the production change reverted. The proof does not bind the change; park the packet.",
+    };
+  }
+
+  return {
+    ok: true,
+    witness: {
+      provider: "host",
+      testExit: headRun.exit,
+      revertExit: revertRun.exit,
+      testLogSha: sha256(headRun.output),
+      revertLogSha: sha256(revertRun.output),
+      ranAt: new Date().toISOString(),
+    },
+  };
+}


### PR DESCRIPTION
## Summary

The evidence protocol is executed, not claimed (issue #6). `witness.ts` clones the target, requires tests green at head, reverts the non-test production files to base, and requires red — through an injectable runner seam that makes the whole protocol testable. The CLI's `evidence` command drops the operator-claimed `--test-exit`/`--negative` flags and witnesses on the host for Wave 0; E2B targets refuse precisely (no key = dry-run and says so; with a key, execution still belongs to the worker host per ADR 0003). Manifests carry provider, both exit codes, and sha256 log hashes; `draft-ready` is unreachable without a witness whose revert went red.

## Evidence (unit u6)

- head deee54f; suite **77/77**, exit 0; validator green
- Failing-first: 4 witness tests red before implementation; reviewer independently re-ran the negative control and probed the test-path classifier and the checkout-revert failure direction against a scratch repo (fails closed, never open)
- Build-blind review: **APPROVE** first round at reviewed_sha `deee54f` — zero blocking findings, nine hardening NITs recorded as [follow-up #28](https://github.com/ravidsrk/oss-foundry/issues/28)

## Sweep

Unit u6 of the parked-issues resolution (landing=direct-to-default).

Closes #6


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces operator-attested evidence with a witness workflow that clones a target commit, runs its tests, restores non-test paths to base, and requires the negative control to fail.
- Adds host-based Wave-0 witness execution and refusal behavior for unsupported sandbox targets.
- Persists witness provider, exit codes, timestamps, and SHA-256 log hashes.
- Requires a successful witness before packets can advance to draft-ready.
- Updates state validation, tests, and protocol documentation for the new manifest shape.
</details>


<details open><summary><h3>Confidence Score: 2/5</h3></summary>

This PR is not safe to merge until host execution of contributor-controlled heads is isolated and test-only diffs cannot produce production-change evidence.

The new witness path exposes the operator host to code from the checked-out head and can also certify a test-only change by reverting its tests, undermining both the execution boundary and the evidence guarantee.

**Files Needing Attention:** factory/cli.ts and factory/witness.ts
</details>


<details open><summary><h3>Security Review</h3></summary>

The new host runner executes code from a selected repository head with the operator CLI process’s privileges. Because the selected head can contain contributor-controlled test or validation code and no trust check or isolation precedes execution, witnessing a malicious Wave-0 contribution can compromise host credentials or data.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| factory/witness.ts | Implements the witness protocol, but its test-only fallback can certify a negative control that reverted the tests rather than production code. |
| factory/cli.ts | Integrates witnessing into the evidence command, but executes repository-controlled head contents directly on the operator host. |
| factory/engine.ts | Adds the witness readiness gate, though it cannot detect a witness generated from the wrong reverted path set. |
| factory/state.ts | Adds structurally consistent runtime validation for optional witness manifests. |
| factory/types.ts | Defines the witness manifest shape used by state persistence and readiness checks. |
| factory/engine.test.ts | Covers successful and failed witness exits and readiness, but omits the test-only fallback and host trust-boundary cases. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CLI
    participant GitHub
    participant Host as Host scratch checkout
    participant Engine
    CLI->>GitHub: Compare base and head
    CLI->>Host: Clone repository and checkout head
    Host->>Host: Run configured tests at head
    Host->>Host: Restore non-test paths from base
    Host->>Host: Run negative-control tests
    Host-->>CLI: Exit codes and log hashes
    CLI->>Engine: Attach SHA-bound witness
    Engine->>Engine: Gate draft-ready on witness exits
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20ravidsrk%2Foss-foundry%20PR%20%2327%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=ravidsrk%2Foss-foundry&pr=27&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Afactory%2Fcli.ts%3A42-43%0A**Host%20witness%20executes%20untrusted%20code**%0A%0AWhen%20a%20Wave-0%20packet%20references%20a%20contributor-controlled%20head%2C%20the%20witness%20checks%20it%20out%20and%20runs%20its%20repository-controlled%20test%20or%20validation%20code%20through%20%60bash%60%20with%20the%20CLI%20user's%20host%20privileges%2C%20allowing%20the%20contribution%20to%20read%20credentials%20or%20modify%20host%20data.%20**How%20this%20was%20verified%3A**%20The%20selected%20head%20is%20checked%20out%20immediately%20before%20%60hostRunner%60%20executes%20its%20configured%20test%20command%20without%20isolation%20or%20a%20commit-trust%20check.%0A%0A%23%23%23%20Issue%202%0Afactory%2Fwitness.ts%3A90-93%0A**Test-only%20diffs%20forge%20negative%20proof**%0A%0AWhen%20every%20changed%20path%20is%20classified%20as%20a%20test%2C%20the%20%60%22.%22%60%20fallback%20restores%20the%20tests%20themselves%20from%20base%3B%20a%20resulting%20nonzero%20exit%20is%20then%20accepted%20as%20proof%20that%20reverting%20production%20code%20broke%20the%20suite%2C%20allowing%20a%20test-only%20change%20to%20enter%20%60draft-ready%60%20without%20demonstrating%20any%20necessary%20production%20change.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ravidsrk%2Foss-foundry&pr=27&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
factory/cli.ts:42-43
**Host witness executes untrusted code**

When a Wave-0 packet references a contributor-controlled head, the witness checks it out and runs its repository-controlled test or validation code through `bash` with the CLI user's host privileges, allowing the contribution to read credentials or modify host data. **How this was verified:** The selected head is checked out immediately before `hostRunner` executes its configured test command without isolation or a commit-trust check.

### Issue 2
factory/witness.ts:90-93
**Test-only diffs forge negative proof**

When every changed path is classified as a test, the `"."` fallback restores the tests themselves from base; a resulting nonzero exit is then accepted as proof that reverting production code broke the suite, allowing a test-only change to enter `draft-ready` without demonstrating any necessary production change.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(evidence): witnessed, never atteste..."](https://github.com/ravidsrk/oss-foundry/commit/deee54f86b6432641ebdd4bc94271c2007d2a8cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57971021)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->