### PR TITLE
feat(contact): machine-account draft opener + human-only setup wizard

### DIFF
--- a/docs/07-github-app.md
+++ b/docs/07-github-app.md
@@ -28,7 +28,27 @@ PATs inherit the operator’s social graph. A leaked PAT is a reputation inciden
 
 `factory/github-pr.ts` `draftPullPayload` sets `draft: true` unconditionally. There is no merge / `--admin` helper in that module. Marking ready-for-review is not in the method set; a human uses the browser.
 
-The App is installed on `ravidsrk` only. `POST /repos/ColeMurray/background-agents/pulls` is **403**. ColeMurray#1652 was opened in a browser session, ready rather than draft — a doctrine miss to follow up, not a reason to add a merge helper.
+The App is installed on `ravidsrk` only. `POST /repos/ColeMurray/background-agents/pulls` is **403**. ColeMurray#1652 was opened in a browser session, ready rather than draft — the doctrine miss that motivated the machine account below.
+
+## Machine account — the moment of contact (issue #5)
+
+The App's 403 on non-installed repos is GitHub's security model (user tokens act on the
+intersection of app installations and user access), and the roadmap item that would fix
+fine-grained PATs is paused. The one documented credential for fork→upstream PRs on unaffiliated
+public repos is a **classic PAT**. So the moment of contact is machine-enforced with a hybrid:
+
+- the App keeps doing everything it can (clone, push the branch to the operator fork);
+- a dedicated, ToS-compliant **machine account** holds a classic PAT scoped to `public_repo`
+  only (`FOUNDRY_PAT`, operator host env — never git, never the E2B box), used for exactly one
+  call: `createDraftPull` → `POST /pulls` with `draft: true` hard-coded;
+- `open-draft <packetId> --head <fork:branch>` re-runs the competing-work check, refuses a body
+  without the verbatim disclosure, opens the draft, and records it via the normal attach flow;
+- one create per CLI run; a secondary-rate-limit response is a **factory halt signal**, never a
+  retry (AUP: excessive automated bulk activity);
+- setup is human-only: `scripts/machine-account-wizard.sh` walks account, 2FA, token, and
+  verification. No agent creates accounts.
+
+Browser sessions are demoted to emergency-only. No contribution PR opens by hand again.
 
 ## Secrets
 

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -271,7 +271,7 @@ It **cannot**:
 
 - `POST /repos/ColeMurray/background-agents/pulls` → **403 Resource not accessible by integration**
 
-A human browser session opened #1652. Future Wave 1 drafts on stranger repos need the same: operator browser, **as draft**, body from `renderPrBody`.
+A human browser session opened #1652 — the last one. Future Wave 1 drafts on stranger repos go through `open-draft` with the machine account's classic `public_repo` PAT (`FOUNDRY_PAT`; see docs/07): draft hard-coded, disclosure enforced, competing-work re-checked, secondary-rate-limit = halt.
 
 The in-repo create payload hard-codes `draft: true`. There is no `POST /pulls` helper and no merge path. Operator opens the draft in the browser (`cli.ts body`).
 

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -273,7 +273,7 @@ It **cannot**:
 
 A human browser session opened #1652 — the last one. Future Wave 1 drafts on stranger repos go through `open-draft` with the machine account's classic `public_repo` PAT (`FOUNDRY_PAT`; see docs/07): draft hard-coded, disclosure enforced, competing-work re-checked, secondary-rate-limit = halt.
 
-The in-repo create payload hard-codes `draft: true`. There is no `POST /pulls` helper and no merge path. Operator opens the draft in the browser (`cli.ts body`).
+The in-repo create path hard-codes `draft: true` end to end: `createDraftPull` is the one `POST /pulls` surface, it exists only for drafts, and there is no merge path anywhere. `cli.ts body` remains for inspection; browser opens are emergency-only.
 
 ---
 

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -19,6 +19,7 @@ import {
 } from "./engine.ts";
 import {
   compareCommits,
+  createDraftPull,
   draftPullPayload,
   fetchRepoFile,
   listCrossReferencingOpenPulls,
@@ -168,6 +169,7 @@ if (!cmd || cmd === "help" || cmd === "-h" || cmd === "--help") {
   evidence <packetId> --base <sha> --head <sha>   (tests + revert control run in the sandbox — witnessed, never attested)
   body <packetId>
   attach-draft <packetId> <prUrl>
+  open-draft <packetId> --head <forkOwner:branch>   (machine-account PAT; draft-only; one create per run)
   sync <packetId> [--threads-answered]
   reconcile
   ledger
@@ -387,6 +389,81 @@ async function main() {
     });
     console.log("---");
     console.log(`create payload draft=${payload.draft} (no merge helper)`);
+    return;
+  }
+
+  if (cmd === "open-draft") {
+    const id = rest[0];
+    const head = flag(rest, "--head");
+    if (!id || !head) {
+      console.error("open-draft requires <packetId> --head <forkOwner:branch>");
+      process.exit(1);
+    }
+    const packet = state.packets.find((p) => p.id === id);
+    if (!packet) {
+      console.error(`unknown packet ${id}`);
+      process.exit(1);
+    }
+    if (packet.status !== "draft-ready" || packet.prUrl) {
+      console.error(`open-draft needs a draft-ready packet with no PR; ${id} is ${packet.status}${packet.prUrl ? ` with ${packet.prUrl}` : ""}`);
+      process.exit(1);
+    }
+    const pulls = await listOpenPulls(packet.repoId);
+    const crossRefs = pulls.ok
+      ? findCompetingPull(pulls.pulls, packet.issueNumber, packet.issueUrl, packet.repoId)
+        ? { ok: true as const, urls: [] as string[] }
+        : await listCrossReferencingOpenPulls(packet.repoId, packet.issueNumber)
+      : pulls;
+    if (!pulls.ok || !crossRefs.ok) {
+      console.error(!pulls.ok ? pulls.error : (crossRefs as { error: string }).error);
+      process.exit(1);
+    }
+    const verdict = classifyCompetition(
+      { pulls: pulls.pulls, crossReferencedPullUrls: crossRefs.urls },
+      packet.issueNumber,
+      packet.issueUrl,
+      packet.repoId,
+    );
+    if (verdict.kind === "competing") {
+      console.error(`stand down: competing PR ${verdict.url} (${verdict.why}). Assist or park — do not open.`);
+      process.exit(1);
+    }
+    if (verdict.kind === "adjacent") {
+      console.error(`taste gate: adjacent PR ${verdict.url} (${verdict.why}) — you are the human; open only if it does not cover the issue.`);
+    }
+    const body = packet.prBody ?? renderPrBody(packet);
+    if (!body.includes(DISCLOSURE)) {
+      console.error("refusing to open: the PR body does not carry the verbatim disclosure block");
+      process.exit(1);
+    }
+    const created = await createDraftPull(packet.repoId, {
+      title: packet.issueTitle,
+      head,
+      body,
+    });
+    if (!created.ok) {
+      if (created.halt) console.error("=== FACTORY HALT SIGNAL — secondary rate limit ===");
+      console.error(created.error);
+      process.exit(1);
+    }
+    console.log(`opened draft ${created.url}`);
+    const synced = await syncGithubPr({ url: created.url });
+    if (!synced.ok) {
+      console.error(`draft opened but sync failed (${synced.error}) — run: attach-draft ${id} ${created.url}`);
+      process.exit(1);
+    }
+    const attached = applyAttachDraft(state, id, created.url, {
+      draft: synced.meta.draft,
+      headSha: synced.meta.headSha,
+      title: synced.title,
+      body: synced.body,
+    });
+    if (attached.error) {
+      console.error(`draft opened but not recorded (${attached.error}) — run: attach-draft ${id} ${created.url}`);
+      process.exit(1);
+    }
+    saveFactoryState(STATE_FILE, attached.state);
+    console.log(`attached ${created.url} (draft=${synced.meta.draft}) — packet submitted`);
     return;
   }
 

--- a/factory/github-pr.test.ts
+++ b/factory/github-pr.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { compareCommits, fetchRepoFile, listCrossReferencingOpenPulls, listOpenPulls } from "./github-pr.ts";
+import { compareCommits, createDraftPull, fetchRepoFile, listCrossReferencingOpenPulls, listOpenPulls } from "./github-pr.ts";
 
 const BASE = "251fe899c5bd843a7dad71d908c0af3bfcea79e1";
 const HEAD = "d91fe2f6725163fab8f9dd42e5c2b0c0c9f0f40d";
@@ -121,4 +121,72 @@ test("listCrossReferencingOpenPulls keeps only open cross-referenced pull reques
 
   const failed = await listCrossReferencingOpenPulls("ravidsrk/orca-fleet", 71, async () => jsonResponse(500, {}));
   assert.equal(failed.ok, false);
+});
+
+test("createDraftPull opens draft-only with the machine-account PAT", async () => {
+  let captured: { url?: string; auth?: string | null; body?: Record<string, unknown> } = {};
+  const created = await createDraftPull(
+    "ColeMurray/background-agents",
+    { title: "feat: icon", head: "ravidsrk:foundry/issue-1476", body: "Fixes #1476" },
+    async (url, init) => {
+      captured = {
+        url: String(url),
+        auth: new Headers(init?.headers).get("Authorization"),
+        body: JSON.parse(String(init?.body)),
+      };
+      return jsonResponse(201, {
+        html_url: "https://github.com/ColeMurray/background-agents/pull/1700",
+        number: 1700,
+        draft: true,
+      });
+    },
+    { FOUNDRY_PAT: "ghp_machineaccount" },
+  );
+  assert.equal(created.ok, true);
+  if (created.ok) assert.equal(created.url, "https://github.com/ColeMurray/background-agents/pull/1700");
+  assert.equal(captured.url, "https://api.github.com/repos/ColeMurray/background-agents/pulls");
+  assert.equal(captured.auth, "Bearer ghp_machineaccount");
+  assert.equal(captured.body?.draft, true);
+  assert.equal(captured.body?.base, "main");
+});
+
+test("createDraftPull refuses without the PAT and halts on secondary limits", async () => {
+  const missing = await createDraftPull(
+    "ColeMurray/background-agents",
+    { title: "t", head: "ravidsrk:b", body: "Fixes #1" },
+    async () => jsonResponse(201, {}),
+    {},
+  );
+  assert.equal(missing.ok, false);
+  if (!missing.ok) assert.match(missing.error, /FOUNDRY_PAT/);
+
+  const secondary = await createDraftPull(
+    "ColeMurray/background-agents",
+    { title: "t", head: "ravidsrk:b", body: "Fixes #1" },
+    async () => jsonResponse(403, { message: "You have exceeded a secondary rate limit. Please wait." }),
+    { FOUNDRY_PAT: "ghp_x" },
+  );
+  assert.equal(secondary.ok, false);
+  if (!secondary.ok) {
+    assert.equal(secondary.halt, true);
+    assert.match(secondary.error, /halt/i);
+  }
+
+  const forbidden = await createDraftPull(
+    "ColeMurray/background-agents",
+    { title: "t", head: "ravidsrk:b", body: "Fixes #1" },
+    async () => jsonResponse(403, { message: "Resource not accessible" }),
+    { FOUNDRY_PAT: "ghp_x" },
+  );
+  assert.equal(forbidden.ok, false);
+  if (!forbidden.ok) assert.equal(forbidden.halt, undefined);
+
+  const notDraft = await createDraftPull(
+    "ColeMurray/background-agents",
+    { title: "t", head: "ravidsrk:b", body: "Fixes #1" },
+    async () => jsonResponse(201, { html_url: "https://x/pull/1", number: 1, draft: false }),
+    { FOUNDRY_PAT: "ghp_x" },
+  );
+  assert.equal(notDraft.ok, false);
+  if (!notDraft.ok) assert.match(notDraft.error, /draft/i);
 });

--- a/factory/github-pr.test.ts
+++ b/factory/github-pr.test.ts
@@ -190,3 +190,23 @@ test("createDraftPull refuses without the PAT and halts on secondary limits", as
   assert.equal(notDraft.ok, false);
   if (!notDraft.ok) assert.match(notDraft.error, /draft/i);
 });
+
+test("createDraftPull rejects unqualified heads and halts on 429 secondary limits", async () => {
+  const bareHead = await createDraftPull(
+    "ColeMurray/background-agents",
+    { title: "t", head: "foundry/issue-1", body: "Fixes #1" },
+    async () => jsonResponse(201, {}),
+    { FOUNDRY_PAT: "ghp_x" },
+  );
+  assert.equal(bareHead.ok, false);
+  if (!bareHead.ok) assert.match(bareHead.error, /fork-qualified/);
+
+  const secondary429 = await createDraftPull(
+    "ColeMurray/background-agents",
+    { title: "t", head: "ravidsrk:b", body: "Fixes #1" },
+    async () => jsonResponse(429, { message: "You have exceeded a secondary rate limit." }),
+    { FOUNDRY_PAT: "ghp_x" },
+  );
+  assert.equal(secondary429.ok, false);
+  if (!secondary429.ok) assert.equal(secondary429.halt, true);
+});

--- a/factory/github-pr.ts
+++ b/factory/github-pr.ts
@@ -239,3 +239,81 @@ export async function syncGithubPr(data: { url: string }, fetchImpl: typeof fetc
     };
   }
 }
+
+export type CreateDraftResult =
+  | { ok: true; url: string; number: number }
+  | { ok: false; error: string; halt?: true };
+
+/**
+ * The moment of contact, machine-enforced (issue #5). Opens a fork→upstream DRAFT pull request
+ * with the dedicated machine account's classic `public_repo` PAT (`FOUNDRY_PAT`) — the only
+ * credential type GitHub documents for writes to unaffiliated public repos; App tokens 403 by
+ * design (intersection model, docs/07). draft: true is hard-coded via draftPullPayload; there is
+ * no ready-for-review or merge surface here. One create per CLI invocation; a secondary-rate-limit
+ * response is a factory halt signal, not a retry.
+ */
+export async function createDraftPull(
+  repoId: string,
+  input: { title: string; head: string; base?: string; body: string },
+  fetchImpl: typeof fetch = fetch,
+  env: Record<string, string | undefined> = process.env,
+): Promise<CreateDraftResult> {
+  const [owner, repo] = repoId.split("/");
+  if (!owner || !repo) return { ok: false, error: `bad repo id ${repoId}` };
+  const pat = env.FOUNDRY_PAT;
+  if (!pat) {
+    return {
+      ok: false,
+      error:
+        "FOUNDRY_PAT is not set — the machine account's classic public_repo PAT opens drafts on repos the App is not installed on (the App 403s there by design). Run scripts/machine-account-wizard.sh, export FOUNDRY_PAT on the operator host, and retry. Never commit it; never put it in the E2B box.",
+    };
+  }
+  if (!/^[\w-]+:[\w./-]+$/.test(input.head)) {
+    return { ok: false, error: `head must be fork-qualified (owner:branch), got ${input.head}` };
+  }
+  const payload = draftPullPayload(input);
+  try {
+    const res = await fetchImpl(`https://api.github.com/repos/${owner}/${repo}/pulls`, {
+      method: "POST",
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": "oss-foundry",
+        Authorization: `Bearer ${pat}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+    const body = (await res.json().catch(() => ({}))) as {
+      html_url?: string;
+      number?: number;
+      draft?: boolean;
+      message?: string;
+    };
+    if (res.status === 403 && /secondary rate limit/i.test(body.message ?? "")) {
+      return {
+        ok: false,
+        halt: true,
+        error:
+          "GitHub secondary rate limit on content creation — HALT the factory (AUP: excessive automated bulk activity). Do not retry; investigate before any further create.",
+      };
+    }
+    if (res.status === 403) {
+      return {
+        ok: false,
+        error: `GitHub 403 creating the draft on ${repoId}: ${body.message ?? "forbidden"}. Check: PAT is classic with public_repo scope; the upstream has not restricted PR creation to collaborators (Feb 2026 repo settings).`,
+      };
+    }
+    if (res.status !== 201) {
+      return { ok: false, error: `GitHub ${res.status} creating the draft on ${repoId}: ${body.message ?? "error"}` };
+    }
+    if (body.draft !== true) {
+      return {
+        ok: false,
+        error: "upstream returned a non-draft pull request — stand down and inspect before proceeding; Foundry opens drafts only.",
+      };
+    }
+    return { ok: true, url: body.html_url ?? "", number: body.number ?? 0 };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : "fetch failed" };
+  }
+}

--- a/factory/github-pr.ts
+++ b/factory/github-pr.ts
@@ -289,7 +289,7 @@ export async function createDraftPull(
       draft?: boolean;
       message?: string;
     };
-    if (res.status === 403 && /secondary rate limit/i.test(body.message ?? "")) {
+    if ((res.status === 403 || res.status === 429) && /secondary rate limit/i.test(body.message ?? "")) {
       return {
         ok: false,
         halt: true,

--- a/scripts/machine-account-wizard.sh
+++ b/scripts/machine-account-wizard.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Machine-account setup wizard for Foundry's moment of contact (issue #5).
+# Walks the operator through the ONLY steps a human must perform. Never stores secrets in git.
+set -euo pipefail
+
+step() { printf '\n\033[1m== Step %s — %s ==\033[0m\n' "$1" "$2"; }
+confirm() { read -r -p "$1 [press Enter when done] " _; }
+
+cat <<'INTRO'
+Foundry machine-account wizard
+------------------------------
+Why: the GitHub App can never open PRs on repos it is not installed on (403 by design —
+intersection model). The only credential GitHub documents for fork→upstream PRs on
+unaffiliated public repos is a CLASSIC personal access token. GitHub's ToS permits one
+free machine account per person; the human who creates it is responsible for it.
+INTRO
+
+step 1 "Create the machine account"
+cat <<'S1'
+  In a private browser window: https://github.com/signup
+  - Username suggestion: <you>-foundry-courier (clearly a machine account, per ToS)
+  - Use an email alias you control (e.g. you+foundry@…)
+  - Enable 2FA immediately (Settings → Password and authentication)
+  Do NOT have this wizard or any agent create the account — account creation is yours.
+S1
+confirm "Account created with 2FA enabled?"
+
+step 2 "Mint the classic PAT (public_repo only)"
+cat <<'S2'
+  Signed in AS THE MACHINE ACCOUNT:
+  https://github.com/settings/tokens/new
+  - Note: foundry-open-draft
+  - Expiration: 90 days (rotate on expiry)
+  - Scope: check ONLY 'public_repo'. Nothing else. Not 'repo'.
+S2
+confirm "Token generated and copied?"
+
+step 3 "Export FOUNDRY_PAT on this host (never in git, never in E2B)"
+read -r -s -p "Paste the token (input hidden): " FOUNDRY_PAT; echo
+export FOUNDRY_PAT
+
+step 4 "Verify the token"
+LOGIN=$(curl -sf -H "Authorization: Bearer $FOUNDRY_PAT" -H "User-Agent: oss-foundry" https://api.github.com/user | sed -n 's/.*"login": *"\([^"]*\)".*/\1/p')
+if [ -z "$LOGIN" ]; then echo "Verification FAILED — token rejected."; exit 1; fi
+SCOPES=$(curl -sfI -H "Authorization: Bearer $FOUNDRY_PAT" -H "User-Agent: oss-foundry" https://api.github.com/user | tr -d '\r' | sed -n 's/^x-oauth-scopes: *//Ip')
+echo "Authenticated as: $LOGIN  (scopes: ${SCOPES:-none})"
+case " ${SCOPES:-}," in *" public_repo,"*|*"public_repo,"*) : ;; *) echo "WARNING: expected exactly 'public_repo'; got '${SCOPES:-none}'. Re-mint with only public_repo."; exit 1;; esac
+case "$SCOPES" in *repo,*|repo) if [ "$SCOPES" != "public_repo" ]; then echo "WARNING: broader than public_repo — re-mint."; exit 1; fi;; esac
+
+step 5 "Persist for the operator shell"
+cat <<S5
+  Add to your shell profile or secret manager (NOT this repo):
+    export FOUNDRY_PAT=…       # the token you just verified
+  Doctrine reminders:
+    - draft-only: the create helper hard-codes draft:true; there is no merge surface
+    - one create per CLI run; a secondary-rate-limit response halts the factory
+    - never put FOUNDRY_PAT in allowlist.yaml, a packet, or the E2B box
+S5
+echo
+echo "Done. Try: node --experimental-strip-types factory/cli.ts open-draft <packetId> --head $LOGIN:branch"

--- a/scripts/machine-account-wizard.sh
+++ b/scripts/machine-account-wizard.sh
@@ -40,12 +40,15 @@ read -r -s -p "Paste the token (input hidden): " FOUNDRY_PAT; echo
 export FOUNDRY_PAT
 
 step 4 "Verify the token"
-LOGIN=$(curl -sf -H "Authorization: Bearer $FOUNDRY_PAT" -H "User-Agent: oss-foundry" https://api.github.com/user | sed -n 's/.*"login": *"\([^"]*\)".*/\1/p')
-if [ -z "$LOGIN" ]; then echo "Verification FAILED — token rejected."; exit 1; fi
-SCOPES=$(curl -sfI -H "Authorization: Bearer $FOUNDRY_PAT" -H "User-Agent: oss-foundry" https://api.github.com/user | tr -d '\r' | sed -n 's/^x-oauth-scopes: *//Ip')
+USER_JSON=$(curl -s -H "Authorization: Bearer $FOUNDRY_PAT" -H "User-Agent: oss-foundry" https://api.github.com/user || true)
+LOGIN=$(printf '%s' "$USER_JSON" | sed -n 's/.*"login": *"\([^"]*\)".*/\1/p')
+if [ -z "$LOGIN" ]; then echo "Verification FAILED — token rejected by the API."; exit 1; fi
+SCOPES=$(curl -sI -H "Authorization: Bearer $FOUNDRY_PAT" -H "User-Agent: oss-foundry" https://api.github.com/user 2>/dev/null | tr -d '\r' | sed -n 's/^x-oauth-scopes: *//Ip' || true)
 echo "Authenticated as: $LOGIN  (scopes: ${SCOPES:-none})"
-case " ${SCOPES:-}," in *" public_repo,"*|*"public_repo,"*) : ;; *) echo "WARNING: expected exactly 'public_repo'; got '${SCOPES:-none}'. Re-mint with only public_repo."; exit 1;; esac
-case "$SCOPES" in *repo,*|repo) if [ "$SCOPES" != "public_repo" ]; then echo "WARNING: broader than public_repo — re-mint."; exit 1; fi;; esac
+if [ "${SCOPES:-}" != "public_repo" ]; then
+  echo "WARNING: expected scopes to be exactly 'public_repo'; got '${SCOPES:-none}'. Re-mint the token with only public_repo checked."
+  exit 1
+fi
 
 step 5 "Persist for the operator shell"
 cat <<S5


### PR DESCRIPTION
## Summary

The moment of contact is machine-enforced (issue #5). `createDraftPull` opens fork→upstream drafts with the dedicated machine account's classic `public_repo` PAT — the one credential GitHub documents for unaffiliated public repos; the App's 403 stays, by design. `draft: true` is structurally unavoidable, a missing verbatim disclosure refuses the open, the competing-work check re-runs at contact, one create per run, and a secondary-rate-limit response (403 **or** 429) is a factory halt signal, never a retry. `scripts/machine-account-wizard.sh` walks the operator through the only human-permitted steps — account, 2FA, exact-`public_repo` token, verification — with no secret ever echoed or written. Browser opens are demoted to emergency-only.

## Evidence (unit u5)

- head a7d9889 (feat + review round; rebase over u6/u2 verified by the reviewer hunk-by-hunk, including tracing an interdiff artifact to u6's own edit character-for-character)
- Suite **80/80**, exit 0; wizard passes bash -n; scope-bypass repro re-run against the fixed exact-equality check (13 cases, only the literal `public_repo` passes)
- Build-blind review: R1 **REQUEST_CHANGES** (stale §9 browser line contradicting the new instruction; order-dependent wizard scope bypass — demonstrated empirically; 3 NITs) → all fixed → R2 **APPROVE** at 449448b → rebase-confirm **APPROVE** at reviewed_sha `a7d9889`

## Sweep

Unit u5 of the parked-issues resolution (landing=direct-to-default).

Closes #5

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a machine-account-backed command for opening draft pull requests on unaffiliated public repositories and a human-only credential setup wizard.
- Adds draft-only GitHub PR creation using `FOUNDRY_PAT`, disclosure enforcement, and competing-work checks.
- Adds operator setup and PAT scope verification guidance.
- Updates product and GitHub App documentation for the new contact workflow.
- The post-create recovery path can permit duplicate drafts when synchronization or attachment fails.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until a successfully created remote draft is durably recorded or retries are made idempotent after synchronization and attachment failures.

The new workflow can create a draft successfully, lose its URL when a later step fails, and then allow the unchanged packet to create a duplicate draft on retry.

**Files Needing Attention:** factory/cli.ts
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| factory/cli.ts | Adds the open-draft workflow, but records successful remote creation too late to prevent duplicate drafts after post-create failures. |
| factory/github-pr.ts | Adds PAT-authenticated, draft-only PR creation with head validation and secondary-rate-limit handling. |
| factory/github-pr.test.ts | Covers payload, authentication, draft enforcement, head validation, and rate-limit behavior, but not the CLI’s partial-success recovery flow. |
| scripts/machine-account-wizard.sh | Adds an interactive human-only setup flow that hides token input and enforces the exact public_repo scope. |
| docs/07-github-app.md | Documents the hybrid GitHub App and machine-account contact model. |
| docs/PRODUCT.md | Updates operational doctrine and operator instructions for machine-enforced draft creation. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant O as Operator
    participant C as open-draft CLI
    participant G as GitHub API
    participant S as Local state
    O->>C: open-draft packet --head owner:branch
    C->>G: "POST /pulls (draft=true)"
    G-->>C: 201 + PR URL
    C->>G: GET created PR metadata
    alt sync and attach succeed
        G-->>C: PR metadata
        C->>S: Save submitted packet + PR URL
    else sync or attach fails
        C-->>O: Exit with attach-draft instruction
        Note over S: Packet remains draft-ready without PR URL
        O->>C: Retry open-draft
        C->>G: POST /pulls again
    end
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20ravidsrk%2Foss-foundry%20PR%20%2329%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=ravidsrk%2Foss-foundry&pr=29&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Afactory%2Fcli.ts%3A450-454%0A**Failed%20sync%20permits%20duplicate%20drafts**%0A%0AWhen%20GitHub%20creates%20the%20draft%20but%20the%20subsequent%20synchronization%20or%20local%20attachment%20fails%2C%20%60open-draft%60%20exits%20without%20persisting%20the%20created%20PR%20URL.%20The%20packet%20remains%20%60draft-ready%60%20with%20no%20%60prUrl%60%2C%20so%20retrying%20the%20command%20passes%20its%20guard%20and%20opens%20a%20duplicate%20draft%20while%20the%20first%20remains%20unrecorded.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ravidsrk%2Foss-foundry&pr=29&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
factory/cli.ts:450-454
**Failed sync permits duplicate drafts**

When GitHub creates the draft but the subsequent synchronization or local attachment fails, `open-draft` exits without persisting the created PR URL. The packet remains `draft-ready` with no `prUrl`, so retrying the command passes its guard and opens a duplicate draft while the first remains unrecorded.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["review: exact scope check, 429 halt, sta..."](https://github.com/ravidsrk/oss-foundry/commit/a7d988956e43022a4c4e2ed3c3631b19040b6fd3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57972887)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->