### PR TITLE
docs(spec): cite RepoComplianceBench, correct the AGENTS.md framing

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -78,3 +78,14 @@ An implementation conforms when every MUST above is machine-enforced or human-ga
 auditable record, and when its ledger — statuses, attestations, evidence, and quotes — survives
 an adversarial read against the platform's own record. The reference implementation's test suite
 and blind-review protocol are one acceptable demonstration.
+
+This split is not arbitrary: agents open a repository's separate policy file in 3.5% of runs (12
+of 347 non-anchor runs) and comply with refuse/hand-off rules 0% of the time unaided
+(RepoComplianceBench, arXiv 2607.26819). That 3.5% excludes AGENTS.md — auto-loaded by the
+benchmark harness and the one file agents reliably do see — and counts only whether an agent goes
+on to read a further file (CONTRIBUTING.md, a PR template, a standalone policy doc); the framing
+sharpens, not weakens, the case for control outside the agent. On enforcing refuse and hand-off
+rules, the benchmark's own conclusion is direct: "A project that means them must place the
+control outside the agent: a CI check that blocks the merge, a required human review, or a bot
+that closes AI-authored pull requests." That is exactly the machine-enforced or human-gated split
+this section requires.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -79,12 +79,14 @@ auditable record, and when its ledger — statuses, attestations, evidence, and 
 an adversarial read against the platform's own record. The reference implementation's test suite
 and blind-review protocol are one acceptable demonstration.
 
+## 9. Rationale (non-normative)
+
 This split is not arbitrary: agents open a repository's separate policy file in 3.5% of runs (12
 of 347 non-anchor runs) and comply with refuse/hand-off rules 0% of the time unaided
 (RepoComplianceBench, arXiv 2607.26819). That 3.5% excludes AGENTS.md — auto-loaded by the
 benchmark harness and the one file agents reliably do see — and counts only whether an agent goes
-on to read a further file (CONTRIBUTING.md, a PR template, a standalone policy doc); the framing
-sharpens, not weakens, the case for control outside the agent. On enforcing refuse and hand-off
+on to read a further file (CONTRIBUTING.md or the PR template); the framing sharpens, not
+weakens, the case for control outside the agent. On enforcing refuse and hand-off
 rules, the benchmark's own conclusion is direct: "A project that means them must place the
 control outside the agent: a CI check that blocks the merge, a required human review, or a bot
 that closes AI-authored pull requests." That is exactly the machine-enforced or human-gated split

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -81,13 +81,13 @@ and blind-review protocol are one acceptable demonstration.
 
 ## 9. Rationale (non-normative)
 
-This split is not arbitrary: agents open a repository's separate policy file in 3.5% of runs (12
+§8's split is not arbitrary: agents open a repository's separate policy file in 3.5% of runs (12
 of 347 non-anchor runs) and comply with refuse/hand-off rules 0% of the time unaided
 (RepoComplianceBench, arXiv 2607.26819). That 3.5% excludes AGENTS.md — auto-loaded by the
 benchmark harness and the one file agents reliably do see — and counts only whether an agent goes
 on to read a further file (CONTRIBUTING.md or the PR template); the framing sharpens, not
-weakens, the case for control outside the agent. On enforcing refuse and hand-off
-rules, the benchmark's own conclusion is direct: "A project that means them must place the
-control outside the agent: a CI check that blocks the merge, a required human review, or a bot
-that closes AI-authored pull requests." That is exactly the machine-enforced or human-gated split
-this section requires.
+weakens, the case for control outside the agent. On enforcing refuse and hand-off rules, the
+benchmark's own conclusion is direct: "A project that means them must place the control outside
+the agent: a CI check that blocks the merge, a required human review, or a bot that closes
+AI-authored pull requests." That is exactly the machine-enforced or human-gated split §8
+requires.

--- a/docs/adr/0005-positioning.md
+++ b/docs/adr/0005-positioning.md
@@ -10,10 +10,10 @@ Accepted (2026-08-28)
 governance" products govern your agents on your systems; nobody ships guest-side,
 pre-implementation gating against a target's own policy — while agents open policy files in 3.5%
 of runs (12 of 347 non-anchor runs) and comply with refuse/hand-off rules 0% of the time unaided
-(RepoComplianceBench, arXiv 2607.26819; the 3.5% excludes AGENTS.md, which the harness auto-loads
-and which agents reliably do see — it counts only a further file such as CONTRIBUTING.md, a PR
-template, or a standalone policy doc), and burned projects (QEMU-class) are actively drafting how
-to safely re-admit AI contributions. Maintainers will not pay (CodeRabbit gives them its product
+(RepoComplianceBench, arXiv 2607.26819), and burned projects (QEMU-class) are actively drafting
+how to safely re-admit AI contributions. That 3.5% excludes AGENTS.md, which the harness
+auto-loads and which agents reliably do see; it counts only whether the agent goes on to read
+CONTRIBUTING.md or the PR template. Maintainers will not pay (CodeRabbit gives them its product
 free); operators, OSPOs, and agent vendors needing provable good citizenship might.
 
 ## Decision

--- a/docs/adr/0005-positioning.md
+++ b/docs/adr/0005-positioning.md
@@ -9,10 +9,12 @@ Accepted (2026-08-28)
 2026 field research: every commercial coding agent targets repos its operator controls; "agent
 governance" products govern your agents on your systems; nobody ships guest-side,
 pre-implementation gating against a target's own policy — while agents open policy files in 3.5%
-of runs and comply with refuse/hand-off rules 0% of the time unaided (RepoComplianceBench,
-arXiv 2607.26819), and burned projects (QEMU-class) are actively drafting how to safely re-admit
-AI contributions. Maintainers will not pay (CodeRabbit gives them its product free); operators,
-OSPOs, and agent vendors needing provable good citizenship might.
+of runs (12 of 347 non-anchor runs) and comply with refuse/hand-off rules 0% of the time unaided
+(RepoComplianceBench, arXiv 2607.26819; the 3.5% excludes AGENTS.md, which the harness auto-loads
+and which agents reliably do see — it counts only a further file such as CONTRIBUTING.md, a PR
+template, or a standalone policy doc), and burned projects (QEMU-class) are actively drafting how
+to safely re-admit AI contributions. Maintainers will not pay (CodeRabbit gives them its product
+free); operators, OSPOs, and agent vendors needing provable good citizenship might.
 
 ## Decision
 


### PR DESCRIPTION
Closes #45.

Cites RepoComplianceBench (arXiv 2607.26819) in `docs/SPEC.md` and corrects the AGENTS.md framing in both `SPEC.md` and ADR 0005.

Scope was **reduced by skeptic-triage** before build: the ADR citation had already landed at `e50f540` (~2h before #45 was filed), and two of the issue's asks were refuted against the repo — the pydantic characterization checks out against pydantic's live CONTRIBUTING.md (nothing to correct), and the "~40% of projects ban AI" figure appears nowhere in this repo. Only the SPEC citation + framing correction remained.

### Three review rounds, all three used

**Round 1 — the quote I handed the builder was altered.** Verified against the primary source: the text I supplied truncated "a CI check **that blocks the merge**" and swapped the paper's colon for an em-dash — a non-verbatim quote presented as verbatim, the same failure class as a fabricated citation. Blocked and corrected to character-exact.

**Round 2 — three-axis build-blind review, all PASS**, with two items:
- *standards (Required):* the new rationale paragraph had no `## N.` heading, so it read as a continuation of §8 and was invisible to heading navigation.
- *coordinator adjudication:* an axis flagged "a standalone policy doc" at soft confidence. Re-fetching the paper confirmed the defect and sharpened it — §3.5 states "The policy can reach the agent through three channels: the PR template, AGENTS.md, and CONTRIBUTING.md." A standalone policy doc was **not** a channel in the runs that produced 3.5%. The paper does say "separate policy files (e.g. AI_POLICY.md)", but in §1, describing where rules live generally. Promoted to Required and removed from both files.

**Round 3 — round 2's own fix introduced a defect.** Giving the paragraph its own `## 9. Rationale (non-normative)` heading left its prose pointing at itself: "the machine-enforced or human-gated split **this section** requires" now named §9, which by its own heading requires nothing. Both references repointed at §8 explicitly.

### Verified at `6299743`

- Quote byte-identical across all three rounds (whitespace-normalized SHA-256 match against the primary source and against the reviewed SHA).
- "12 of 347 non-anchor runs (3.5%)" — exact; AGENTS.md exclusion explicit in-paper.
- 0% refuse/hand-off scoped to **unaided**: the paper's DeepSeek 3/9 hand-off recovery occurs only under the separate Harness-feedback condition, so "unaided" is the qualification that makes the claim true.
- `npm test` exit 0 — 86/86. `npm run validate` exit 0. Diff touches only the two docs.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds RepoComplianceBench evidence to the specification and clarifies in both documents that the 3.5% statistic excludes auto-loaded AGENTS.md.
- Adds a clearly non-normative rationale section tied explicitly to §8’s enforcement model.
- Expands ADR 0005 with the benchmark denominator and channel framing.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/SPEC.md | Adds a non-normative, correctly cross-referenced rationale for §8 without changing the normative requirements. |
| docs/adr/0005-positioning.md | Clarifies the benchmark statistic and AGENTS.md harness behavior consistently with the specification. |

</details>

<sub>Reviews (2): Last reviewed commit: ["review: point §9&#39;s rationale prose back ..."](https://github.com/ravidsrk/oss-foundry/commit/62997431eff62f2063e36b68a2aeb6d32fb5bc7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58033206)</sub>

<!-- /greptile_comment -->