### PR TITLE
fix(engine): reject guards merged status; wake respects the in-flight slot

### DIFF
--- a/docs/04-stations.md
+++ b/docs/04-stations.md
@@ -77,7 +77,9 @@ A draft PR is not done. The packet stays on this station until merged, closed, o
 Does:
 
 - Sync the live PR (draft/open/merged, head SHA, review comment count). User-initiated. Never on load.
-- Record bot-reconcile and review-reply notes against the current head.
+- Record bot-reconcile and review-reply notes against the current head. `review-reply` is a reply
+  that was **made**; a reply still **owed** — maintainer activity arriving while another packet
+  holds the in-flight slot — is a `note` prefixed `reply-owed:`, like `stale-intent`.
 - Mark quiet when threads are answered. **Never merge.**
 - When GitHub reports `merged`, write the scorecard `merged` row. When closed unmerged, write `closedUnmerged`.
 

--- a/docs/04-stations.md
+++ b/docs/04-stations.md
@@ -52,6 +52,8 @@ The operator reads the packet: objective, non-goals, acceptance, abort, policy, 
 
 Actions: `approve` (attest) or `reject` (park). Denied, halted, and unlisted packets cannot be approved. Approve re-runs the competing-work check live: a competitor that appeared since gating blocks the approval; an adjacent mention is shown to the approver.
 
+`reject` has its own scope. A `merged` packet **cannot** be rejected: it is terminal and already counted toward `mergedTotal` and the attested Wave 0 merges, so a late reject would desync the promotion gate from the ledger. A `submitted` packet **can** — that is the documented halt-everything path (`docs/08-operations.md`) — but reject does not close the PR, so when the packet names a live PR the CLI prints an `open pr:` warning naming it and the packet record says which PR was left open. Until a human closes it, `reconcile` keeps flagging it as an abandoned live PR.
+
 The first 20 factory-wide approvals decrement a visible counter. At zero, Wave 0 may auto-freeze only if policy is `owner` and lighting stays `lit`. Wave 1+ never auto-freeze.
 
 ## 4. Implementer
@@ -79,7 +81,8 @@ Does:
 - Sync the live PR (draft/open/merged, head SHA, review comment count). User-initiated. Never on load.
 - Record bot-reconcile and review-reply notes against the current head. `review-reply` is a reply
   that was **made**; a reply still **owed** — maintainer activity arriving while another packet
-  holds the in-flight slot — is a `note` prefixed `reply-owed:`, like `stale-intent`.
+  holds the in-flight slot — is a `note` prefixed `reply-owed:`, the same shape as `stale-intent`
+  (the shape only; `stale-intent` is deduped, a reply owed is not).
 - Mark quiet when threads are answered. **Never merge.**
 - When GitHub reports `merged`, write the scorecard `merged` row. When closed unmerged, write `closedUnmerged`.
 
@@ -90,7 +93,13 @@ Quiet-day rule (ADR 0002, enforced by `applyPrSync`, driven by the operator CLI:
 thread has a reply): once threads are answered and the PR has been quiet ≥ **14 days**, sync moves
 the packet to `followed-up` and the slot frees — the factory is bounded by discipline, not by
 maintainer latency. New maintainer activity on a `followed-up` packet moves it back to `submitted`
-(answer before any new tick). At ≥ **45 quiet days** sync records a `stale-intent` follow-up note;
+(answer before any new tick) — **unless a newer packet already holds the in-flight slot**, in which
+case the older packet stays `followed-up` and records a `reply-owed:` note rather than doubling the
+in-flight count. Nothing else nags about that reply — no tick was blocked and no thread was closed —
+so `status` prints it under the packet rather than leaving it buried in the ledger; answering is a
+human act and the note is a permanent record of the arrival, not a checkbox the engine clears. One
+note per arrival, not one per packet: each new maintainer comment owes its own reply. At ≥ **45 quiet days**
+sync records a `stale-intent` follow-up note (deduped — the staleness is one standing fact);
 the close itself is a human act, and the scorecard's `closedUnmerged` row is written once, on the
 actual open→closed transition — never for a still-open draft, which is not a terminal outcome
 (docs/08-operations.md). Quiet days derive from GitHub's `updated_at`, which any activity bumps —

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -133,7 +133,7 @@ There is **no** TanStack operator console in this repository. The freeze/tick/dr
 
 `hasInflight` gates: `gated`, `frozen`, `approved`, `implementing`, `reviewing`, `draft-ready`, **`submitted`**. `followed-up` is **not** in-flight.
 
-`submitted` → `followed-up` is bounded (ADR 0002, `applyPrSync`): threads answered + PR quiet ≥ 14 days releases the slot; maintainer activity on a `followed-up` packet re-blocks the tick until answered; ≥ 45 quiet days records a `stale-intent` note (`closedUnmerged` + polite close is a human act). Maintainer silence cannot idle the factory indefinitely.
+`submitted` → `followed-up` is bounded (ADR 0002, `applyPrSync`): threads answered + PR quiet ≥ 14 days releases the slot; maintainer activity on a `followed-up` packet re-blocks the tick until answered — unless a newer packet already holds the slot, in which case the older packet stays `followed-up` and records a `reply-owed:` note rather than doubling the count; ≥ 45 quiet days records a `stale-intent` note (`closedUnmerged` + polite close is a human act). Maintainer silence cannot idle the factory indefinitely.
 
 ### Scorecard halt
 

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -110,7 +110,7 @@ There is **no** TanStack operator console in this repository. The freeze/tick/dr
 |---|---|---|
 | 1 | Scout | Allowlist issues only. Drop denylist, RFC/meta, issues with an in-flight maintainer PR. Heuristic rank. Clock / CLI never invent issue numbers |
 | 2 | Policy | Deterministic. Grok has no vote |
-| 3 | Freeze | Operator `approve` (attest) or `reject` (park). Denied / halted packets cannot be approved |
+| 3 | Freeze | Operator `approve` (attest) or `reject` (park). Denied / halted packets cannot be approved. `merged` packets cannot be rejected — terminal, and a late reject desyncs the promotion-gate counters. Rejecting a `submitted` packet is the halt-everything path, but it never closes the PR: the CLI names the one left open |
 | 4 | Implement | One playbook pack. Failing-first. Wave 0 host / Wave 1+ E2B. Console/CLI dry-run does not fake a green harvest |
 | 5 | Review | Independent, lit. Negative control: revert goes red. Evidence attached by the operator, not invented |
 | 6 | Draft | Fork → upstream draft. Body from `renderPrBody`. Create helper sets `draft: true` |

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -14,7 +14,6 @@ import {
   isBoundSha,
   findCompetingPull,
   hasInflight,
-  INFLIGHT_STATUSES,
   QUIET_RELEASE_DAYS,
   quietDaysOf,
 } from "./engine.ts";
@@ -36,7 +35,7 @@ import { renderEvidencePage, renderPrBody } from "./packet.ts";
 import { health } from "./scorecard.ts";
 import { loadFactoryState, saveFactoryState } from "./state.ts";
 import { foundryAttestedWave0Merges } from "./status.ts";
-import type { EvidenceManifest } from "./types.ts";
+import { INFLIGHT_STATUSES, type EvidenceManifest } from "./types.ts";
 import { witnessEvidence, type WitnessRunner } from "./witness.ts";
 
 const hostRunner: WitnessRunner = (step, args, opts) =>
@@ -272,6 +271,9 @@ async function main() {
       console.error(result.error);
       process.exit(1);
     }
+    // Reject still succeeds (it is the documented halt-everything path) but it does not go quiet:
+    // an abandoned live PR is named on the terminal, not only in parkReason and the event log.
+    if (result.warning) console.error(result.warning);
     saveFactoryState(STATE_FILE, result.state);
     console.log(`rejected ${id}`);
     return;

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -16,6 +16,7 @@ import {
   hasInflight,
   QUIET_RELEASE_DAYS,
   quietDaysOf,
+  repliesOwed,
 } from "./engine.ts";
 import {
   compareCommits,
@@ -83,10 +84,24 @@ function printStatus(state: ReturnType<typeof mustLoad>) {
     console.log("in flight: none — tick is allowed");
   }
   const following = state.packets.filter((p) => p.status === "followed-up" && p.prMeta?.state === "open");
+  // The re-block is conditional, so the line must be too: `applyPrSync` reclaims `submitted` only
+  // when the slot is free. While a newer packet holds it, maintainer activity records a reply owed
+  // and the packet stays `followed-up` — printing "re-blocks the tick" there is simply false.
+  const slotHeld = hasInflight(state.packets);
   for (const p of following) {
+    const rule = slotHeld
+      ? "(slot held — maintainer activity records a reply owed, it does not re-block the tick)"
+      : "(maintainer activity re-blocks the tick)";
     console.log(
-      `  following ${p.repoId}#${p.issueNumber}  quiet=${quietDaysOf(p.prMeta!, new Date().toISOString())}d  (maintainer activity re-blocks the tick)`,
+      `  following ${p.repoId}#${p.issueNumber}  quiet=${quietDaysOf(p.prMeta!, new Date().toISOString())}d  ${rule}`,
     );
+    // A reply owed re-blocks nothing and closes no thread, so nothing else nags about it: this is
+    // the operator-facing surface for it. Same "proceed but say so out loud" duty as reject.
+    for (const owed of repliesOwed(p)) {
+      console.log(
+        `    reply owed: ${owed.url ?? p.prUrl ?? ""} — maintainer activity ${owed.at.slice(0, 10)} arrived while another packet held the slot; answer it by hand`,
+      );
+    }
   }
   console.log("scorecard:");
   for (const row of state.scorecard) {

--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -12,6 +12,7 @@ import {
   applyHalt,
   applyPrSync,
   applyQueueLive,
+  applyReject,
   applyTick,
   bindingFromCompare,
   branchMentionsIssue,
@@ -20,6 +21,7 @@ import {
   evidenceIsReady,
   findCompetingPull,
   hasInflight,
+  inflightCount,
   isBoundSha,
   isPlaceholderSha,
   mentionsIssue,
@@ -198,6 +200,36 @@ test("approve cannot green-light a denied packet", () => {
   assert.match(result.error, /DENY_FORBIDDEN/);
   assert.equal(result.state.packets[0].status, "gated");
   assert.equal(result.state.packets[0].humanAttest, undefined);
+});
+
+test("reject refuses a merged packet instead of desyncing the promotion gate", () => {
+  const seed = seedState();
+  const merged = seed.packets.find((p) => p.status === "merged")!;
+  const before = seed.mergedTotal;
+  const result = applyReject(seed, merged.id, "typo'd reject");
+  assert.ok(result.error);
+  assert.match(result.error, /merged/i);
+  // Refused outright: state is untouched, not just the one packet.
+  assert.equal(result.state, seed);
+  assert.equal(result.state.packets.find((p) => p.id === merged.id)?.status, "merged");
+  assert.equal(result.state.mergedTotal, before);
+});
+
+test("reject stays legal on a submitted packet (the documented halt-everything path) but names the still-open PR", () => {
+  const seed = seedState();
+  const submitted = seed.packets.find((p) => p.status === "submitted")!;
+  assert.ok(submitted.prUrl);
+  const result = applyReject(seed, submitted.id, "operator halt");
+  assert.equal(result.error, undefined);
+  const after = result.state.packets.find((p) => p.id === submitted.id)!;
+  assert.equal(after.status, "rejected");
+  // Loud: the packet record itself names the abandoned PR...
+  assert.ok(after.parkReason?.includes(submitted.prUrl!));
+  // ...and so does the event a human or the ledger reads afterward.
+  assert.equal(result.state.events[0].packetId, submitted.id);
+  assert.ok(result.state.events[0].message.includes(submitted.prUrl!));
+  // Rejecting a still-open PR must not pretend it is closed.
+  assert.equal(hasInflight(result.state.packets), false);
 });
 
 test("advance does not stamp placeholder SHA or auto-harvest", () => {
@@ -823,6 +855,49 @@ test("maintainer activity on a followed-up packet re-blocks the factory", () => 
   assert.equal(hasInflight(woken.state.packets), true);
 });
 
+test("wake does not reclaim submitted when another packet already holds the in-flight slot", () => {
+  // Reproduces issue #34 vector (b): A quiet-releases, B gets ticked into the freed slot, then
+  // maintainer activity on A must not double the in-flight count.
+  const state = seedState();
+  const a = state.packets.find((p) => p.status === "submitted")!;
+  const released = applyPrSync(state, a.id, prMetaAt("2026-09-01T00:00:00.000Z"), {
+    threadsAnswered: true,
+    at: "2026-09-20T00:00:00.000Z",
+  });
+  assert.equal(released.state.packets.find((p) => p.id === a.id)?.status, "followed-up");
+  assert.equal(hasInflight(released.state.packets), false);
+
+  const b = buildPacket({
+    repoId: "github/awesome-copilot",
+    issueNumber: 2684,
+    issueTitle: "operator ticked this while A was quiet",
+    issueUrl: "https://github.com/github/awesome-copilot/issues/2684",
+  });
+  const withB: FactoryState = {
+    ...released.state,
+    packets: [{ ...b, status: "gated", station: "freeze" }, ...released.state.packets],
+  };
+  assert.equal(hasInflight(withB.packets), true);
+  assert.equal(inflightCount(withB.packets), 1);
+
+  const woken = applyPrSync(withB, a.id, prMetaAt("2026-09-21T08:00:00.000Z", { issueComments: 2 }), {
+    threadsAnswered: false,
+    at: "2026-09-21T09:00:00.000Z",
+  });
+  assert.equal(woken.error, undefined);
+  const afterA = woken.state.packets.find((p) => p.id === a.id)!;
+  const afterB = woken.state.packets.find((p) => p.id === b.id)!;
+  // A stays followed-up: the newer in-flight packet (B) keeps priority, the slot is not doubled.
+  assert.equal(afterA.status, "followed-up");
+  assert.equal(afterB.status, "gated");
+  assert.equal(inflightCount(woken.state.packets), 1);
+  // The maintainer activity is not silently dropped: it is recorded as a reply owed on A.
+  assert.equal(afterA.followUps?.some((f) => f.kind === "review-reply"), true);
+  assert.ok(
+    woken.state.events.some((e) => e.packetId === a.id && /reply|maintainer activity/i.test(e.message)),
+  );
+});
+
 test("merged and closed syncs write the scorecard and end follow-up", () => {
   const state = seedState();
   const submitted = state.packets.find((p) => p.status === "submitted");
@@ -1026,6 +1101,36 @@ test("an absorbed close is at rest: reconcile-style re-diff reports no divergenc
   assert.deepEqual(packetDivergences(after, live), []);
   const unabsorbed = packetDivergences(submitted, live);
   assert.equal(unabsorbed.some((d) => d.includes(`sync ${submitted.id}`)), true);
+});
+
+test("a rejected packet with a still-open PR never rots invisibly in the ledger check", () => {
+  const state = seedState();
+  const submitted = state.packets.find((p) => p.status === "submitted")!;
+  const rejected = applyReject(state, submitted.id, "operator mis-typed reject").state.packets.find(
+    (p) => p.id === submitted.id,
+  )!;
+  assert.equal(rejected.status, "rejected");
+  assert.equal(rejected.prUrl, submitted.prUrl);
+
+  const stillLive = packetDivergences(rejected, {
+    state: "open",
+    merged: false,
+    draft: submitted.prMeta?.draft ?? true,
+    headSha: submitted.prMeta?.headSha ?? "",
+  });
+  assert.equal(
+    stillLive.some((d) => d.includes(rejected.id) && d.includes(rejected.prUrl!)),
+    true,
+  );
+
+  // Once the abandoned PR is actually closed on GitHub, there is nothing left to flag.
+  const nowClosed = packetDivergences(rejected, {
+    state: "closed",
+    merged: false,
+    draft: submitted.prMeta?.draft ?? true,
+    headSha: submitted.prMeta?.headSha ?? "",
+  });
+  assert.deepEqual(nowClosed, []);
 });
 
 function fakeRunner(script: Record<string, { exit: number; output: string }>) {

--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -21,7 +22,6 @@ import {
   evidenceIsReady,
   findCompetingPull,
   hasInflight,
-  inflightCount,
   isBoundSha,
   isPlaceholderSha,
   mentionsIssue,
@@ -39,7 +39,7 @@ import { emptyScorecard, health } from "./scorecard.ts";
 import { seedState } from "./seed.ts";
 import { loadFactoryState } from "./state.ts";
 import type { LiveIssue as ScoutIssue } from "./github-scout.ts";
-import type { FactoryState } from "./types.ts";
+import { inflightCount, type FactoryState } from "./types.ts";
 
 function blank(): FactoryState {
   return {
@@ -892,7 +892,12 @@ test("wake does not reclaim submitted when another packet already holds the in-f
   assert.equal(afterB.status, "gated");
   assert.equal(inflightCount(woken.state.packets), 1);
   // The maintainer activity is not silently dropped: it is recorded as a reply owed on A.
-  assert.equal(afterA.followUps?.some((f) => f.kind === "review-reply"), true);
+  // `review-reply` means a reply that was made; a reply still owed is a prefixed note.
+  assert.equal(
+    afterA.followUps?.some((f) => f.kind === "note" && f.body.startsWith("reply-owed:")),
+    true,
+  );
+  assert.equal(afterA.followUps?.some((f) => f.kind === "review-reply"), false);
   assert.ok(
     woken.state.events.some((e) => e.packetId === a.id && /reply|maintainer activity/i.test(e.message)),
   );
@@ -1131,6 +1136,72 @@ test("a rejected packet with a still-open PR never rots invisibly in the ledger 
     headSha: submitted.prMeta?.headSha ?? "",
   });
   assert.deepEqual(nowClosed, []);
+});
+
+test("a parked packet with a still-open PR never rots invisibly in the ledger check", () => {
+  const state = seedState();
+  const submitted = state.packets.find((p) => p.status === "submitted")!;
+  assert.ok(submitted.prUrl);
+  // applyHalt parks whatever is in flight — including a submitted packet still holding a live
+  // draft. `parked` is the other half of the abandoned-PR surface; `rejected` alone is not enough.
+  const halted = applyHalt(state, submitted.repoId, "maintainer asked the factory to stop");
+  const parked = halted.state.packets.find((p) => p.id === submitted.id)!;
+  assert.equal(parked.status, "parked");
+  assert.equal(parked.prUrl, submitted.prUrl);
+
+  const stillLive = packetDivergences(parked, {
+    state: "open",
+    merged: false,
+    draft: submitted.prMeta?.draft ?? true,
+    headSha: submitted.prMeta?.headSha ?? "",
+  });
+  assert.equal(
+    stillLive.some(
+      (d) => d.includes(parked.id) && d.includes(parked.prUrl!) && d.includes("parked"),
+    ),
+    true,
+  );
+
+  // Once the abandoned PR is actually closed on GitHub, there is nothing left to flag.
+  const nowClosed = packetDivergences(parked, {
+    state: "closed",
+    merged: false,
+    draft: submitted.prMeta?.draft ?? true,
+    headSha: submitted.prMeta?.headSha ?? "",
+  });
+  assert.deepEqual(nowClosed, []);
+});
+
+test("the reject warning reaches the operator's terminal, not only the ledger", () => {
+  // The reducer-level assertions above all passed while the CLI printed nothing but `rejected <id>`
+  // — the exact silence issue #34 opens with. This drives the real binary and reads its streams.
+  const dir = mkdtempSync(join(tmpdir(), "foundry-cli-"));
+  const state = seedState();
+  const submitted = state.packets.find((p) => p.status === "submitted")!;
+  assert.ok(submitted.prUrl);
+  writeFileSync(join(dir, ".foundry-state.json"), JSON.stringify(state));
+
+  const cli = join(import.meta.dirname, "cli.ts");
+  const reject = (id: string) =>
+    spawnSync(
+      process.execPath,
+      ["--experimental-strip-types", cli, "reject", id, "--reason", "typo, meant a different id"],
+      { cwd: dir, encoding: "utf8" },
+    );
+
+  const loud = reject(submitted.id);
+  // Reject is the documented halt-everything path: it still succeeds and still exits 0.
+  assert.equal(loud.status, 0, `${loud.stdout}${loud.stderr}`);
+  assert.match(loud.stdout, new RegExp(`rejected ${submitted.id}`));
+  const seen = `${loud.stdout}${loud.stderr}`;
+  assert.ok(seen.includes(submitted.prUrl!), seen);
+  assert.match(seen, /still open on GitHub/);
+  assert.match(seen, /close it by hand/);
+
+  // ...and it is a warning, not boilerplate: a packet with no live PR rejects quietly.
+  const quiet = reject(state.packets.find((p) => !p.prUrl)!.id);
+  assert.equal(quiet.status, 0, `${quiet.stdout}${quiet.stderr}`);
+  assert.doesNotMatch(`${quiet.stdout}${quiet.stderr}`, /still open on GitHub/);
 });
 
 function fakeRunner(script: Record<string, { exit: number; output: string }>) {

--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -898,9 +898,16 @@ test("wake does not reclaim submitted when another packet already holds the in-f
     true,
   );
   assert.equal(afterA.followUps?.some((f) => f.kind === "review-reply"), false);
-  assert.ok(
-    woken.state.events.some((e) => e.packetId === a.id && /reply|maintainer activity/i.test(e.message)),
-  );
+  // The event must distinguish the held-slot wake from the ordinary one. A loose /reply|maintainer
+  // activity/ matched the pre-fix text too, so it proved nothing: both messages open with
+  // "Maintainer activity on <url>". Pin what changed — the reply is owed, the packet did NOT
+  // reclaim the slot — and forbid the pre-fix claim, which would be false here: no tick was blocked.
+  const wake = woken.state.events.find((e) => e.packetId === a.id && e.kind === "follow-up");
+  assert.ok(wake, "no follow-up event was recorded for the woken packet");
+  assert.match(wake.message, /reply owed/i);
+  assert.match(wake.message, /in-flight slot is held by another packet/i);
+  assert.match(wake.message, new RegExp(`${a.id} stays followed-up`));
+  assert.doesNotMatch(wake.message, /before any new tick/i);
 });
 
 test("merged and closed syncs write the scorecard and end follow-up", () => {
@@ -1202,6 +1209,86 @@ test("the reject warning reaches the operator's terminal, not only the ledger", 
   const quiet = reject(state.packets.find((p) => !p.prUrl)!.id);
   assert.equal(quiet.status, 0, `${quiet.stdout}${quiet.stderr}`);
   assert.doesNotMatch(`${quiet.stdout}${quiet.stderr}`, /still open on GitHub/);
+});
+
+test("the reject warning is scoped to submitted, not to every packet that names a PR", () => {
+  // The `prUrl` half of the condition is pinned both ways by the test above; this pins the `status`
+  // half, which was one-directional — widening `status === "submitted" && prUrl` to `prUrl` alone
+  // left the suite green. A `followed-up` packet still names a live PR, but it has already released
+  // the slot, so rejecting it is not the halt-everything path abandoning an in-flight draft.
+  // (`reconcile` still flags the open PR afterward via `packetDivergences` — that is unchanged.)
+  const seed = seedState();
+  const submitted = seed.packets.find((p) => p.status === "submitted")!;
+  const released = applyPrSync(seed, submitted.id, prMetaAt("2026-09-01T00:00:00.000Z"), {
+    threadsAnswered: true,
+    at: "2026-09-20T00:00:00.000Z",
+  });
+  const followedUp = released.state.packets.find((p) => p.id === submitted.id)!;
+  assert.equal(followedUp.status, "followed-up");
+  assert.ok(followedUp.prUrl, "the followed-up packet must still name a PR or this binds nothing");
+
+  const result = applyReject(released.state, submitted.id, "superseded upstream");
+  assert.equal(result.error, undefined);
+  assert.equal(result.warning, undefined);
+  const after = result.state.packets.find((p) => p.id === submitted.id)!;
+  assert.equal(after.status, "rejected");
+  // Nothing leaked into the stored record either: the park reason is the operator's reason, verbatim.
+  assert.equal(after.parkReason, "superseded upstream");
+  assert.equal(result.state.events[0].message, "superseded upstream");
+});
+
+test("status does not claim a re-block that the held slot already prevented", () => {
+  // Driven at the reducer level, the reply-owed note was recorded and nothing surfaced it: `status`
+  // printed "(maintainer activity re-blocks the tick)" for a packet whose maintainer activity had
+  // just re-blocked nothing, and `reconcile` reported divergences=0. Drive the real binary.
+  const dir = mkdtempSync(join(tmpdir(), "foundry-cli-status-"));
+  const cli = join(import.meta.dirname, "cli.ts");
+  const statusIn = (state: FactoryState) => {
+    writeFileSync(join(dir, ".foundry-state.json"), JSON.stringify(state));
+    const run = spawnSync(process.execPath, ["--experimental-strip-types", cli, "status"], {
+      cwd: dir,
+      encoding: "utf8",
+    });
+    assert.equal(run.status, 0, `${run.stdout}${run.stderr}`);
+    return `${run.stdout}${run.stderr}`;
+  };
+
+  const seed = seedState();
+  const a = seed.packets.find((p) => p.status === "submitted")!;
+  const released = applyPrSync(seed, a.id, prMetaAt("2026-09-01T00:00:00.000Z"), {
+    threadsAnswered: true,
+    at: "2026-09-20T00:00:00.000Z",
+  });
+
+  // Control: slot free, nothing owed — the original claim is true, and still printed.
+  const free = statusIn(released.state);
+  assert.match(free, /\(maintainer activity re-blocks the tick\)/);
+  assert.doesNotMatch(free, /reply owed:/);
+
+  // Now B takes the freed slot and maintainer activity lands on A.
+  const b = buildPacket({
+    repoId: "github/awesome-copilot",
+    issueNumber: 2684,
+    issueTitle: "operator ticked this while A was quiet",
+    issueUrl: "https://github.com/github/awesome-copilot/issues/2684",
+  });
+  const withB: FactoryState = {
+    ...released.state,
+    packets: [{ ...b, status: "gated", station: "freeze" }, ...released.state.packets],
+  };
+  const woken = applyPrSync(withB, a.id, prMetaAt("2026-09-21T08:00:00.000Z", { issueComments: 2 }), {
+    threadsAnswered: false,
+    at: "2026-09-21T09:00:00.000Z",
+  });
+  assert.equal(woken.state.packets.find((p) => p.id === a.id)?.status, "followed-up");
+
+  const held = statusIn(woken.state);
+  // The false claim is gone...
+  assert.doesNotMatch(held, /\(maintainer activity re-blocks the tick\)/);
+  assert.match(held, /does not re-block the tick/);
+  // ...and the reply the operator now owes is named, with the PR to answer.
+  assert.match(held, /reply owed:/);
+  assert.ok(held.includes(a.prUrl!), held);
 });
 
 function fakeRunner(script: Record<string, { exit: number; output: string }>) {

--- a/factory/engine.ts
+++ b/factory/engine.ts
@@ -195,13 +195,28 @@ export function applyReject(
 ): { state: FactoryState; error?: string } {
   const packet = state.packets.find((p) => p.id === id);
   if (!packet) return { state, error: `unknown packet ${id}` };
+  // A merged packet is terminal and already counted toward mergedTotal / attested Wave 0 merges;
+  // rejecting it now would desync those promotion-gate counters from the ledger (issue #34).
+  if (packet.status === "merged") {
+    return {
+      state,
+      error: `cannot reject ${id} from status merged — rejecting a merged packet would desync the promotion-gate counters (mergedTotal vs. attested Wave 0 merges)`,
+    };
+  }
+  // docs/08-operations.md: "to halt everything, reject in-flight packets" — submitted (with a live,
+  // still-open PR) must stay rejectable as the halt path. It must not be silent about it: an
+  // operator who mistypes `reject` on the one in-flight packet is about to abandon a real draft.
+  const abandonsOpenPr = packet.status === "submitted" && Boolean(packet.prUrl);
+  const message = abandonsOpenPr
+    ? `${reason} — WARNING: ${packet.prUrl} is still open on GitHub. Rejecting this packet does not close the PR; close it by hand or it stays live and unattended.`
+    : reason;
   const packets = state.packets.map((p) =>
     p.id === id
       ? bump(p, {
           status: "rejected",
           station: "terminal",
           class: p.class === "buildable" ? "out-of-scope" : p.class,
-          parkReason: reason,
+          parkReason: message,
         })
       : p,
   );
@@ -209,7 +224,7 @@ export function applyReject(
     state: {
       ...state,
       packets,
-      events: [ev("reject", reason, id), ...state.events].slice(0, 80),
+      events: [ev("reject", message, id), ...state.events].slice(0, 80),
     },
   };
 }
@@ -765,8 +780,33 @@ export function applyPrSync(
       packet.prMeta !== undefined &&
       packet.prMeta.updatedAt !== meta.updatedAt;
     if (woke) {
-      next = bump(next, { status: "submitted" });
-      events.push(ev("follow-up", `Maintainer activity on ${meta.url} — answer threads before any new tick`, id));
+      // The slot this packet released may already be occupied by a newer in-flight packet (issue
+      // #34 vector b). Reclaiming `submitted` here would put two packets in flight at once — the
+      // one-packet-in-flight invariant is central doctrine, so the newer packet keeps priority and
+      // this one records the reply owed instead of silently doubling the count.
+      if (hasInflight(state.packets)) {
+        next = bump(next, {
+          followUps: [
+            ...(next.followUps ?? []),
+            followUpEntry(
+              at,
+              "review-reply",
+              `Maintainer activity on ${meta.url} while another packet holds the in-flight slot — reply owed; not reclaiming submitted.`,
+              meta.url,
+            ),
+          ],
+        });
+        events.push(
+          ev(
+            "follow-up",
+            `Maintainer activity on ${meta.url} — reply owed, but the in-flight slot is held by another packet; ${id} stays followed-up`,
+            id,
+          ),
+        );
+      } else {
+        next = bump(next, { status: "submitted" });
+        events.push(ev("follow-up", `Maintainer activity on ${meta.url} — answer threads before any new tick`, id));
+      }
     } else if (packet.status === "submitted" && opts.threadsAnswered && quiet >= QUIET_RELEASE_DAYS) {
       next = bump(next, {
         status: "followed-up",

--- a/factory/engine.ts
+++ b/factory/engine.ts
@@ -6,30 +6,17 @@ import { buildPacket, renderPrBody } from "./packet.ts";
 import { planSandbox, runSandboxDry } from "./sandbox.ts";
 import { applyPacketToScorecard, health } from "./scorecard.ts";
 import { foundryAttestedWave0Merges } from "./status.ts";
-import type {
-  EvidenceManifest,
-  FactoryEvent,
-  FactoryState,
-  FollowUpEntry,
-  PacketStatus,
-  PrMeta,
-  ScorecardRow,
-  TaskPacket,
+import {
+  INFLIGHT_STATUSES,
+  inflightCount,
+  type EvidenceManifest,
+  type FactoryEvent,
+  type FactoryState,
+  type FollowUpEntry,
+  type PrMeta,
+  type ScorecardRow,
+  type TaskPacket,
 } from "./types.ts";
-
-export const INFLIGHT_STATUSES: PacketStatus[] = [
-  "gated",
-  "frozen",
-  "approved",
-  "implementing",
-  "reviewing",
-  "draft-ready",
-  "submitted",
-];
-
-export function inflightCount(packets: TaskPacket[]): number {
-  return packets.filter((p) => INFLIGHT_STATUSES.includes(p.status)).length;
-}
 
 export function hasInflight(packets: TaskPacket[]): boolean {
   return inflightCount(packets) >= CAPS.in_flight;
@@ -192,7 +179,7 @@ export function applyReject(
   state: FactoryState,
   id: string,
   reason: string,
-): { state: FactoryState; error?: string } {
+): { state: FactoryState; error?: string; warning?: string } {
   const packet = state.packets.find((p) => p.id === id);
   if (!packet) return { state, error: `unknown packet ${id}` };
   // A merged packet is terminal and already counted toward mergedTotal / attested Wave 0 merges;
@@ -200,16 +187,20 @@ export function applyReject(
   if (packet.status === "merged") {
     return {
       state,
-      error: `cannot reject ${id} from status merged — rejecting a merged packet would desync the promotion-gate counters (mergedTotal vs. attested Wave 0 merges)`,
+      error: `cannot reject ${id} from status ${packet.status} — rejecting a merged packet would desync the promotion-gate counters (mergedTotal vs. attested Wave 0 merges)`,
     };
   }
   // docs/08-operations.md: "to halt everything, reject in-flight packets" — submitted (with a live,
   // still-open PR) must stay rejectable as the halt path. It must not be silent about it: an
   // operator who mistypes `reject` on the one in-flight packet is about to abandon a real draft.
+  // `warning` is separate from `error` on purpose: `error` is the refusal path the CLI exits 1 on,
+  // while this one proceeds and prints — the same "proceed but say so out loud" shape the freeze
+  // taste gate uses for an adjacent PR. A warning that only reaches parkReason is not loud.
   const abandonsOpenPr = packet.status === "submitted" && Boolean(packet.prUrl);
-  const message = abandonsOpenPr
-    ? `${reason} — WARNING: ${packet.prUrl} is still open on GitHub. Rejecting this packet does not close the PR; close it by hand or it stays live and unattended.`
-    : reason;
+  const warning = abandonsOpenPr
+    ? `WARNING: ${packet.prUrl} is still open on GitHub. Rejecting this packet does not close the PR; close it by hand or it stays live and unattended.`
+    : undefined;
+  const message = warning ? `${reason} — ${warning}` : reason;
   const packets = state.packets.map((p) =>
     p.id === id
       ? bump(p, {
@@ -226,6 +217,7 @@ export function applyReject(
       packets,
       events: [ev("reject", message, id), ...state.events].slice(0, 80),
     },
+    warning,
   };
 }
 
@@ -788,10 +780,13 @@ export function applyPrSync(
         next = bump(next, {
           followUps: [
             ...(next.followUps ?? []),
+            // `kind: "note"` with a `reply-owed:` prefix, following `stale-intent` below.
+            // `review-reply` is reserved for a reply that was MADE (docs/04-stations.md,
+            // docs/10-schemas.md); this entry records one that is still owed.
             followUpEntry(
               at,
-              "review-reply",
-              `Maintainer activity on ${meta.url} while another packet holds the in-flight slot — reply owed; not reclaiming submitted.`,
+              "note",
+              `reply-owed: Maintainer activity on ${meta.url} while another packet holds the in-flight slot — reply owed; not reclaiming submitted.`,
               meta.url,
             ),
           ],

--- a/factory/engine.ts
+++ b/factory/engine.ts
@@ -190,17 +190,22 @@ export function applyReject(
       error: `cannot reject ${id} from status ${packet.status} — rejecting a merged packet would desync the promotion-gate counters (mergedTotal vs. attested Wave 0 merges)`,
     };
   }
-  // docs/08-operations.md: "to halt everything, reject in-flight packets" — submitted (with a live,
-  // still-open PR) must stay rejectable as the halt path. It must not be silent about it: an
-  // operator who mistypes `reject` on the one in-flight packet is about to abandon a real draft.
-  // `warning` is separate from `error` on purpose: `error` is the refusal path the CLI exits 1 on,
-  // while this one proceeds and prints — the same "proceed but say so out loud" shape the freeze
-  // taste gate uses for an adjacent PR. A warning that only reaches parkReason is not loud.
+  // docs/08-operations.md:23: "To halt everything, reject in-flight packets and stop pressing tick."
+  // So submitted (with a live, still-open PR) must stay rejectable as the halt path. It must not be
+  // silent about it: an operator who mistypes `reject` on the one in-flight packet is about to
+  // abandon a real draft. `warning` is separate from `error` on purpose: `error` is the refusal path
+  // the CLI exits 1 on, while this one proceeds and prints — the same "proceed but say so out loud"
+  // shape the freeze taste gate uses for an adjacent PR. A warning that only reaches parkReason is
+  // not loud. Lowercase `open pr:` matches the CLI's advisory prefixes (`stand down:`, `taste gate:`,
+  // `hold <key>:`); all-caps is reserved for the halt signal.
   const abandonsOpenPr = packet.status === "submitted" && Boolean(packet.prUrl);
   const warning = abandonsOpenPr
-    ? `WARNING: ${packet.prUrl} is still open on GitHub. Rejecting this packet does not close the PR; close it by hand or it stays live and unattended.`
+    ? `open pr: ${packet.prUrl} is still open on GitHub. Rejecting this packet does not close the PR; close it by hand or it stays live and unattended.`
     : undefined;
-  const message = warning ? `${reason} — ${warning}` : reason;
+  // Two shapes, not one string stored twice: the ledger records the fact (which PR was left open),
+  // the terminal gets the instruction. A stored field read back months later does not need "close it
+  // by hand" — `reconcile` re-derives that from the live PR every run (ledger-check.ts).
+  const message = abandonsOpenPr ? `${reason} — left ${packet.prUrl} open on GitHub` : reason;
   const packets = state.packets.map((p) =>
     p.id === id
       ? bump(p, {
@@ -716,6 +721,22 @@ export function quietDaysOf(meta: PrMeta, at: string): number {
   return Math.max(0, Math.floor((nowMs - updated) / 86_400_000));
 }
 
+/**
+ * Prefix on the follow-up note `applyPrSync` writes when maintainer activity lands on a
+ * `followed-up` packet while another packet holds the in-flight slot. Written here, read back by
+ * `repliesOwed` so the operator surface and the writer cannot drift apart on the literal.
+ */
+const REPLY_OWED_PREFIX = "reply-owed:";
+
+/**
+ * Replies the operator still owes a maintainer: activity arrived, the slot was held by a newer
+ * packet, so the tick was never re-blocked and nothing else will nag about it. One entry per
+ * arrival. `status` prints these — a note nobody reads is the same as no note (issue #34).
+ */
+export function repliesOwed(packet: TaskPacket): FollowUpEntry[] {
+  return (packet.followUps ?? []).filter((f) => f.kind === "note" && f.body.startsWith(REPLY_OWED_PREFIX));
+}
+
 function followUpEntry(at: string, kind: FollowUpEntry["kind"], body: string, url?: string): FollowUpEntry {
   return {
     id: `fu_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`,
@@ -780,13 +801,18 @@ export function applyPrSync(
         next = bump(next, {
           followUps: [
             ...(next.followUps ?? []),
-            // `kind: "note"` with a `reply-owed:` prefix, following `stale-intent` below.
-            // `review-reply` is reserved for a reply that was MADE (docs/04-stations.md,
-            // docs/10-schemas.md); this entry records one that is still owed.
+            // `kind: "note"` with a prefix — the same entry shape as `stale-intent` below, but
+            // deliberately NOT its dedupe: `stale-intent` is one standing fact about the PR (it has
+            // been quiet ≥ 45 days), while each arrival here is a distinct maintainer comment that
+            // genuinely owes its own reply. The branch is gated on `updatedAt` changing, so a
+            // re-sync of the same activity cannot duplicate a note.
+            // `review-reply` is reserved for a reply that was MADE — docs/04-stations.md, "Follow-up
+            // / scorecard": "`review-reply` is a reply that was **made**; a reply still **owed** ...
+            // is a `note` prefixed `reply-owed:`". This entry records one that is still owed.
             followUpEntry(
               at,
               "note",
-              `reply-owed: Maintainer activity on ${meta.url} while another packet holds the in-flight slot — reply owed; not reclaiming submitted.`,
+              `${REPLY_OWED_PREFIX} Maintainer activity on ${meta.url} while another packet holds the in-flight slot — reply owed; not reclaiming submitted.`,
               meta.url,
             ),
           ],

--- a/factory/ledger-check.ts
+++ b/factory/ledger-check.ts
@@ -20,6 +20,16 @@ export function packetDivergences(packet: TaskPacket, live: LivePrLite): string[
       `${packet.id}: ledger says merged but the PR is ${live.state} and unmerged — resolve by hand; the ledger never un-merges itself`,
     );
   }
+  // A rejected or parked packet is terminal in the ledger, but if it still names a PR that is
+  // open on GitHub the draft was abandoned, not closed — without this branch it never surfaces
+  // again (issue #34). Once the PR is actually closed, there is nothing left to flag.
+  if ((packet.status === "rejected" || packet.status === "parked") && packet.prUrl) {
+    if (!live.merged && live.state === "open") {
+      out.push(
+        `${packet.id}: packet is ${packet.status} but ${packet.prUrl} is still open on GitHub — an abandoned live PR; close it by hand or it stays invisible`,
+      );
+    }
+  }
   if (packet.status === "submitted" || packet.status === "followed-up") {
     if (live.merged) {
       out.push(`${packet.id}: PR merged upstream — mechanical: run \`sync ${packet.id}\` to record it`);

--- a/factory/state.test.ts
+++ b/factory/state.test.ts
@@ -164,3 +164,30 @@ test("stored packet with dark-eligible lighting is refused", () => {
   const loaded = loadFactoryState(path);
   assert.equal(loaded.ok, false);
 });
+
+test("a hand-edited state file with more in-flight packets than the cap is refused, not trusted", () => {
+  // issue #34: the loader validated shapes only, so a drifted file with two concurrent in-flight
+  // packets loaded happily even though the one-packet-in-flight invariant forbids it.
+  const seed = seedState();
+  assert.equal(seed.packets.filter((p) => p.status === "submitted").length, 1);
+  const secondInflightId = seed.packets.find((p) => p.status === "merged")!.id;
+  const packets = seed.packets.map((p) =>
+    p.id === secondInflightId ? { ...p, status: "gated" as const, station: "freeze" as const } : p,
+  );
+  const path = join(mkdtempSync(join(tmpdir(), "foundry-")), "overcap.json");
+  writeFileSync(path, JSON.stringify({ ...seed, packets }));
+  const loaded = loadFactoryState(path);
+  assert.equal(loaded.ok, false);
+  if (loaded.ok) return;
+  assert.match(loaded.error, /in.flight/i);
+  assert.match(loaded.error, /will not overwrite with seed/);
+});
+
+test("a state file at exactly the in-flight cap still loads", () => {
+  const seed = seedState();
+  assert.equal(seed.packets.filter((p) => p.status === "submitted").length, 1);
+  const path = join(mkdtempSync(join(tmpdir(), "foundry-")), "atcap.json");
+  writeFileSync(path, JSON.stringify(seed));
+  const loaded = loadFactoryState(path);
+  assert.equal(loaded.ok, true);
+});

--- a/factory/state.ts
+++ b/factory/state.ts
@@ -1,8 +1,7 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { CAPS } from "./allowlist.ts";
-import { inflightCount } from "./engine.ts";
 import { seedState } from "./seed.ts";
-import type { FactoryState } from "./types.ts";
+import { inflightCount, type FactoryState } from "./types.ts";
 
 const PACKET_STATUSES = new Set([
   "scouted",

--- a/factory/state.ts
+++ b/factory/state.ts
@@ -1,4 +1,6 @@
 import { readFileSync, writeFileSync } from "node:fs";
+import { CAPS } from "./allowlist.ts";
+import { inflightCount } from "./engine.ts";
 import { seedState } from "./seed.ts";
 import type { FactoryState } from "./types.ts";
 
@@ -361,6 +363,16 @@ export function loadFactoryState(
       return {
         ok: false,
         error: `refusing to load ${path}: not a Foundry v6 state file. Fix or remove it; will not overwrite with seed.`,
+      };
+    }
+    // Shape validation above says nothing about doctrine: a hand-edited or drifted file can still
+    // describe more packets in flight than CAPS.in_flight allows. The one-packet-in-flight
+    // invariant is the doctrine's central throttle (issue #34) — fail closed rather than load it.
+    const inflight = inflightCount(migrated.packets);
+    if (inflight > CAPS.in_flight) {
+      return {
+        ok: false,
+        error: `refusing to load ${path}: ${inflight} packets are in flight but CAPS.in_flight is ${CAPS.in_flight} — the one-packet-in-flight invariant is violated. Fix or remove it; will not overwrite with seed.`,
       };
     }
     return { ok: true, state: migrated, source: "file" };

--- a/factory/types.ts
+++ b/factory/types.ts
@@ -39,12 +39,17 @@ export type PacketStatus =
   | "rejected";
 
 /**
- * The statuses that occupy the one in-flight slot (docs/PRODUCT.md). `followed-up` is deliberately
- * absent: the slot releases once threads are answered and the PR goes quiet.
+ * The statuses that occupy the one in-flight slot. docs/PRODUCT.md, "Packet statuses": "`hasInflight`
+ * gates: `gated`, `frozen`, `approved`, `implementing`, `reviewing`, `draft-ready`, **`submitted`**.
+ * `followed-up` is **not** in-flight." `followed-up` is deliberately absent: the slot releases once
+ * threads are answered and the PR goes quiet.
  *
- * This lives on the shared leaf, not in `engine.ts`: `state.ts` enforces the same invariant when it
- * loads a ledger, and a primitive module must not reach up into the orchestration layer
- * (docs/01-architecture.md). `hasInflight` stays in `engine.ts` — it reads the allowlist cap.
+ * The list lives here rather than in `engine.ts` because `state.ts` needs the same set when it loads
+ * a ledger, and it needs a *different predicate* over it: `engine.ts`'s `hasInflight` asks "is the
+ * slot full?" — `inflightCount(packets) >= CAPS.in_flight` — while the loader asks "is this file
+ * over the cap?" — `> CAPS.in_flight`, because a ledger sitting exactly at the cap is legal and must
+ * still load. Different questions, so `hasInflight` was not reusable; the reusable piece is the
+ * count. Reading `CAPS` is not what divides them — `state.ts` imports it directly.
  */
 export const INFLIGHT_STATUSES: PacketStatus[] = [
   "gated",

--- a/factory/types.ts
+++ b/factory/types.ts
@@ -38,6 +38,28 @@ export type PacketStatus =
   | "parked"
   | "rejected";
 
+/**
+ * The statuses that occupy the one in-flight slot (docs/PRODUCT.md). `followed-up` is deliberately
+ * absent: the slot releases once threads are answered and the PR goes quiet.
+ *
+ * This lives on the shared leaf, not in `engine.ts`: `state.ts` enforces the same invariant when it
+ * loads a ledger, and a primitive module must not reach up into the orchestration layer
+ * (docs/01-architecture.md). `hasInflight` stays in `engine.ts` — it reads the allowlist cap.
+ */
+export const INFLIGHT_STATUSES: PacketStatus[] = [
+  "gated",
+  "frozen",
+  "approved",
+  "implementing",
+  "reviewing",
+  "draft-ready",
+  "submitted",
+];
+
+export function inflightCount(packets: TaskPacket[]): number {
+  return packets.filter((p) => INFLIGHT_STATUSES.includes(p.status)).length;
+}
+
 /** Every Foundry packet is independently reviewed. The historical `dark-eligible` value is not representable. */
 export type Lighting = "lit";
 


### PR DESCRIPTION
Closes #34.

Closes both vectors by which the one-packet-in-flight invariant (`CAPS.in_flight=1`, PRODUCT.md hard constraint 3) could be broken, plus the two abandonment paths that made the damage invisible.

### What changed
- **`applyReject` refuses `merged`** — rejecting a merged packet desynced the promotion-gate counters (`attestedWave0` 3→1 while `mergedTotal` stayed 3). `submitted` stays rejectable: it is the documented halt-everything path (`docs/08-operations.md:23`).
- **The reject warning reaches the operator.** Rejecting a `submitted` packet with a live PR now prints `open pr: <url> …` to stderr before proceeding, and records the fact in `parkReason`.
- **Wake respects an occupied slot.** Maintainer activity on a `followed-up` packet no longer reclaims `submitted` when another packet holds the slot; it stays `followed-up` and records a `reply-owed:` note. `status` surfaces the owed reply and no longer claims a re-block that did not happen.
- **`packetDivergences`** reports a `rejected` or `parked` packet with a still-open PR.
- **`loadFactoryState` refuses an over-cap ledger** rather than trusting it; exactly at cap still loads.

### Three review rounds, three isolated axes each, every round found something real
1. **`9b051e2`** — standards FAIL, spec FAIL. The warning was computed and stored but never printed; driving the CLI produced only `rejected <id>`, identical to the silent behaviour the issue opens with. `review-reply` was repurposed against its only documentation. `state.ts` reached up into `engine.ts`.
2. **`eab04ab`** — standards FAIL, spec FAIL. `docs/04-stations.md` contradicted shipped behaviour while `PRODUCT.md` had been fixed. `cli.ts` printed `(maintainer activity re-blocks the tick)` one line under `in flight: none — tick is allowed` — the operator told the opposite of what the engine does. And a comment cited `docs/01-architecture.md` for a layering rule **that exists nowhere in the repo** — a fabricated citation, traced to a coordinator brief that paraphrased a reviewer's interpretation as fact. Replaced with the real reason: `hasInflight` is `>= CAPS.in_flight` ("slot full"), the loader needs `> CAPS.in_flight` ("over cap").
3. **`05261e5`** — test-adequacy PASS, spec PASS, standards FAIL on two stale doc sentences.

### Verification at `05261e5`
- `npm test` exit 0 — **96/96** (86 at base; 10 added).
- Every claimed fix is mutation-caught: 13 assigned mutations plus 4 self-directed probes, each failing its own named test. Both conditionals pinned in **both** directions, so an over-fix is caught as well as an under-fix.
- Negative control independently re-derived: **8** real per-test failures. The two new tests that correctly stay green are guard/boundary controls, each proven discriminating under a targeted mutation.
- The two behaviours only verifiable end-to-end — the reject warning and the `status` render — are asserted against real spawned-process stdout/stderr, not a reducer return.
- All five Acceptance clauses driven against the real CLI and live GitHub.

### Known residual, disclosed
Two of four statements of the wake rule remain stale: `factory/engine.ts:753-754` (`applyPrSync`'s own docstring) and `docs/SPEC.md:67-68`. `docs/PRODUCT.md:136` and `docs/04-stations.md:96` were updated. Tracked as #51.

Under the sweep's round budget this unit should have been parked rather than merged. The operator was asked and chose to merge the verified fix and track the prose separately, since the residual has no behavioural effect while parking would leave the invariant breakable on `main`. Recorded as a deliberate exception, not an oversight.

`needsFollowUp` in `factory/status.ts` was deliberately left untouched — zero call sites, confirmed by two axes independently, so no failing test could precede a change to it.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR closes two paths that could violate the one-packet-in-flight invariant and makes abandoned or reply-owed work visible to operators.
- Prevents rejection of merged packets while preserving submitted-packet rejection with an open-PR warning.
- Keeps woken follow-up packets out of an occupied slot and records operator replies owed.
- Detects open PRs attached to rejected or parked packets.
- Refuses persisted ledgers whose in-flight count exceeds the configured cap.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| factory/engine.ts | Reject now protects merged-state accounting, while PR sync preserves the in-flight cap and records maintainer replies owed when the slot is occupied. |
| factory/cli.ts | The CLI prints reject warnings and accurately distinguishes whether maintainer activity can reclaim the in-flight slot. |
| factory/ledger-check.ts | Reconciliation now reports rejected or parked packets whose associated PR remains open. |
| factory/state.ts | State loading fails closed when a migrated ledger exceeds the configured in-flight cap. |
| factory/types.ts | Shared in-flight status definitions and counting logic were moved to a side-effect-free common module. |
| factory/engine.test.ts | Tests cover merged rejection, held-slot wake behavior, terminal warnings, status rendering, and abandoned live-PR detection. |
| factory/state.test.ts | Boundary tests verify that over-cap state is refused while state exactly at the cap remains loadable. |
| docs/PRODUCT.md | Product documentation now describes merged rejection constraints and occupied-slot wake behavior. |
| docs/04-stations.md | Station documentation now explains reject scope, reply-owed records, and conditional slot reclamation. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Maintainer activity on followed-up packet] --> B{In-flight slot occupied?}
  B -- No --> C[Move packet to submitted]
  C --> D[Re-block new ticks until answered]
  B -- Yes --> E[Keep packet followed-up]
  E --> F[Record reply-owed note]
  F --> G[Show owed reply in status]
  H[Operator rejects packet] --> I{Packet merged?}
  I -- Yes --> J[Refuse rejection]
  I -- No --> K[Mark rejected]
  K --> L{Submitted with PR URL?}
  L -- Yes --> M[Warn that PR remains open]
  M --> N[Reconcile reports live abandoned PR]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["review: 04-stations matches shipped beha..."](https://github.com/ravidsrk/oss-foundry/commit/05261e5ef973857ec836a0b09b0636d917e525dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58033990)</sub>

<!-- /greptile_comment -->