### PR TITLE
feat(freeze): show the human the policy text the gate parsed (#37 legs 2-4)

### DIFF
--- a/docs/04-stations.md
+++ b/docs/04-stations.md
@@ -39,7 +39,37 @@ Input: candidate + `AGENTS.md` / `CONTRIBUTING` blob + the repo's committed poli
 
 The scanner matches policy **statements**, not topic words: a ban pairs an AI subject with a
 contribution object and a refusal verdict inside one sentence-sized window. A repo whose docs
-merely *discuss* autonomous agents is not banning them. Precedence: record `forbidden` → scanned
+merely *discuss* autonomous agents is not banning them.
+
+**The scanner is a high-recall suggester feeding a human gate, not a sufficient arbiter.** Its miss
+mode is real, and stated here rather than left to be inferred: a phrasing nobody has written a
+pattern for reads as silence. Nine paraphrases of real maintainer ban language were run through it
+and seven reached `ALLOW` (issue #37). The matcher work from that issue is **parked** — three review
+rounds failed on it and the unit hit its cap — so this page describes the scanner as it actually is,
+not as the fix would have left it.
+
+Be exact about what catches a miss, because the two guards cover different cases and only one of
+them covers this one. **Deny-by-default covers the no-evidence case, not the missed-ban case.** A
+repo with nothing fetched and no affirmative record is `DENY_UNKNOWN_POLICY` and never `ALLOW` — but
+`hasParsedEvidence` is satisfied by *any* fetched document, so a `CONTRIBUTING` whose refusal the
+scanner cannot read is evidence the gate counts, and **a missed ban on a fetched document reaches
+`ALLOW`.** Verified, not assumed, and pinned in `factory/policy.test.ts` ("deny-by-default covers the
+no-evidence case, not the missed-ban case"): three ban phrasings the scanner does not match, supplied
+as fetched docs, each returned `ALLOW`; the same packet with nothing fetched, and the same packet
+with a fetch that came back empty, both returned `DENY_UNKNOWN_POLICY`. The freeze (§3) is the only
+thing standing there. That is precisely why it is now shown the parsed text — the operator reading
+the maintainer's own words is the guard against a scanner miss, and the gate's default is not.
+
+The over-block direction is a real cost too, not a free safety margin. `DENY_FORBIDDEN` is terminal
+and there is no in-tool operator override, so a false positive is not a one-look correction at the
+freeze; it is an allowlisted repo the factory cannot work with until a human edits
+`factory/policy.ts`. Most of `allowlist.yaml` is agent and MCP infrastructure — `background-agents`,
+`awesome-copilot`, `e2b-cookbook`, `mcp-use`, `mastra`, `OpenHands`, `orca-fleet` — whose docs use
+`agent`, `bot` and the brand words as ordinary vocabulary rather than as the subject of a refusal.
+That is why broadening recall here is not the cheap change it looks like, and why it was parked
+rather than half-landed.
+
+Precedence: record `forbidden` → scanned
 ban statement → CLA/DCO (from scan or record conditions) → record conditions → unknown-without-
 evidence. A `silent` record ("parsed, found nothing") does **not** satisfy parse-policy-first for
 an `unknown` repo — absence is re-verified by a live fetch; affirmative records (welcome /
@@ -61,6 +91,21 @@ The gate is deterministic. Grok does not get a vote here. There is no demo CONTR
 ## 3. Freeze (human)
 
 The operator reads the packet: objective, non-goals, acceptance, abort, policy, scout.
+
+`approve` prints the policy text the gate parsed *before* it takes the attest, for whatever packet
+the operator names — each fetched document with its name and character count, the `policyNotes` and
+committed record that were also in the scan blob, and either the statement the scanner matched or
+an explicit "no ban statement matched in N chars from <source>". A packet with nothing fetched is
+told so as an absence and the scan line is withheld: "no ban statement matched" over zero characters
+of policy text is the most misleading thing this surface could say, and absence is therefore counted
+in **characters**, not in documents — a `CONTRIBUTING` that was fetched and came back empty produces
+a document record and would otherwise take the scanned branch. The print happens before the
+competing-work network reads, so a stand-down or an unreachable GitHub cannot swallow the one thing
+the human is there to read. The documents ride on the packet (`policyDocs`, excerpt-capped with the
+true size recorded), so what the operator reads is the text the verdict was actually computed from
+and not a re-fetch. Before issue #37 `buildPacket` forwarded those documents into `evaluatePolicy`
+and discarded them, which left the second layer of defence confirming a boolean about text it could
+not see.
 
 Actions: `approve` (attest) or `reject` (stand the packet down — it writes status `rejected`, not `parked`; see below). Denied, halted, and unlisted packets cannot be approved. Approve re-runs the competing-work check SPEC §4 requires, and reads the issue's own state alongside it: either a competitor that appeared since gating or an issue that closed since gating blocks the approval; an adjacent mention is shown to the approver. Neither *parks* the packet — the freeze is the human's, so a refusal hands the decision back rather than making it, and `reject` stays the operator's verb.
 

--- a/docs/10-schemas.md
+++ b/docs/10-schemas.md
@@ -19,6 +19,12 @@ status            scouted → gated → approved → implementing → reviewing 
 station           scout | policy | freeze | implement | review | draft | follow-up | terminal
 lighting          lit
 policy            PolicyVerdict
+policyDocs        [{ name: AGENTS.md | CONTRIBUTING, chars, excerpt, truncated }] — the fetched
+                  documents the verdict was computed from, kept so the freeze reads the words the
+                  scanner parsed rather than a boolean (04-stations §3). `excerpt` is capped;
+                  `chars` is always the true size and `truncated` is re-derived on load as
+                  `excerpt.length < chars`. Absent when nothing was fetched, which is a different
+                  fact from a document fetched and empty (`chars: 0`) and is displayed as one.
 scout             ScoutScore
 humanAttest       { by, at, note }  required before implement on Wave 1+
 evidence          EvidenceManifest

--- a/factory/cli.test.ts
+++ b/factory/cli.test.ts
@@ -1165,3 +1165,92 @@ test("an unreadable issue refuses at all three gates rather than proceeding blin
   assert.equal(packet?.status, "gated", "an unreadable issue must not move the packet");
   assert.equal(packet?.humanAttest, undefined, "an unreadable issue must not stamp an attestation");
 });
+
+/**
+ * Issue #37: the human freeze is the documented second layer of defence over a scanner with a
+ * known miss mode, and it was reading a verdict with the evidence discarded. `approve` now prints
+ * the policy text the gate actually parsed before the attest is taken, so the operator confirms
+ * against the maintainer's own words. This is the wiring test — the rendering itself is pinned in
+ * `packet.test.ts`, and this file exists to kill a mutation of the CALL SITE, which no test of
+ * `renderFreezeEvidence` can see.
+ */
+const FREEZE_CONTRIBUTING =
+  "Thanks for contributing! Run `pnpm test` before opening a pull request and open an issue first for anything large.";
+
+/** The seed with its in-flight slot given to a freshly gated Wave 1 packet, docs and all. */
+function gatedState(docs: { agentsMd?: string; contributing?: string }): FactoryState {
+  const seed = seedState();
+  const gated = buildPacket({
+    repoId: "mcp-use/mcp-use",
+    issueNumber: 999,
+    issueTitle: "docs typo",
+    issueUrl: "https://github.com/mcp-use/mcp-use/issues/999",
+    ...docs,
+  });
+  assert.equal(gated.status, "gated", "the fixture must actually reach the freeze station");
+  return {
+    ...seed,
+    packets: [gated, ...seed.packets.filter((p) => p.status !== "submitted")],
+  };
+}
+
+test("approve shows the operator the policy text the gate parsed", () => {
+  const state = gatedState({ contributing: FREEZE_CONTRIBUTING });
+  const path = writeState(state);
+  const stub = githubStub("record");
+  const run = runCli(
+    ["approve", state.packets[0].id, "--note", "read CONTRIBUTING myself", "--by", "ravidsrk", "--state", path],
+    tmpdir(),
+    { preload: stub.preload },
+  );
+  assert.equal(run.code, 0, run.out);
+  // The maintainer's own words, on the terminal, before the attest was written.
+  assert.match(run.stdout, /open an issue first for anything large/);
+  assert.match(run.stdout, new RegExp(`CONTRIBUTING[^\\n]*${FREEZE_CONTRIBUTING.length} chars`));
+  assert.match(run.stdout, /no ban statement matched/i);
+  assert.match(run.stdout, /approved /);
+  assert.equal(
+    JSON.parse(readFileSync(path, "utf8")).packets.find((p: { id: string }) => p.id === state.packets[0].id).status,
+    "approved",
+  );
+});
+
+test("approve prints the policy text before the competing-work reads, not after them", () => {
+  // Ordering is the whole point of where the call sits. The competing-work check is a network read
+  // that can fail and `process.exit(1)` — if the evidence printed after it, an operator hitting a
+  // stand-down or an unreadable issue would never see the words they are here to read. The stand
+  // down still refuses the approval; what is under test is that the evidence survived it.
+  const state = gatedState({ contributing: FREEZE_CONTRIBUTING });
+  const path = writeState(state);
+  const stub = githubStub("record", { "mcp-use/mcp-use#999": { state: "closed" } });
+  const run = runCli(["approve", state.packets[0].id, "--note", "n", "--state", path], tmpdir(), {
+    preload: stub.preload,
+  });
+  assert.equal(run.code, 1, "a closed issue must still stand the approval down");
+  assert.match(run.out, /stand down/i);
+  assert.match(run.stdout, /open an issue first for anything large/, "the evidence must survive the stand-down");
+  assert.equal(
+    JSON.parse(readFileSync(path, "utf8")).packets.find((p: { id: string }) => p.id === state.packets[0].id).status,
+    "gated",
+  );
+});
+
+test("approve names the absence when the gate parsed no policy text at all", () => {
+  // `mcp-use/mcp-use` is `aiPolicy: unknown` with a committed `silent` record, so a packet built
+  // with no fetched docs is DENY_UNKNOWN_POLICY and cannot be approved. The point is what the
+  // operator is told on the way to that refusal: not a clean scan, an absence.
+  const seed = seedState();
+  const blind = buildPacket({
+    repoId: "mcp-use/mcp-use",
+    issueNumber: 998,
+    issueTitle: "docs typo",
+    issueUrl: "https://github.com/mcp-use/mcp-use/issues/998",
+  });
+  const path = writeState({ ...seed, packets: [blind, ...seed.packets.filter((p) => p.status !== "submitted")] });
+  const run = runCli(["approve", blind.id, "--note", "n", "--state", path], tmpdir(), {
+    preload: githubStub("record").preload,
+  });
+  assert.match(run.stdout, /no policy text/i);
+  assert.equal(/no ban statement matched/i.test(run.stdout), false);
+  assert.equal(run.code, 1, "a packet the gate denied still cannot be approved");
+});

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -45,7 +45,7 @@ import {
 } from "./halt.ts";
 import { packetChecks, seedDivergences } from "./ledger-check.ts";
 import { DISCLOSURE } from "./neighbor.ts";
-import { renderEvidencePage, renderPrBody } from "./packet.ts";
+import { renderEvidencePage, renderFreezeEvidence, renderPrBody } from "./packet.ts";
 import { health } from "./scorecard.ts";
 import { seedState } from "./seed.ts";
 import { loadFactoryState, saveFactoryState } from "./state.ts";
@@ -372,6 +372,12 @@ async function main() {
       process.exit(1);
     }
     const packetForFreeze = state.packets.find((p) => p.id === id);
+    // The evidence first, and for any packet the operator names — not only the ones the gate will
+    // let through. The freeze is the documented second layer over a scanner with a known miss mode
+    // (docs/04-stations.md §2), and until issue #37 it was handed a verdict with the parsed text
+    // discarded. Printed before the competing-work reads, so a network failure below cannot swallow
+    // the one thing the human is here to read.
+    if (packetForFreeze) console.log(renderFreezeEvidence(packetForFreeze));
     if (packetForFreeze && (packetForFreeze.status === "gated" || packetForFreeze.status === "frozen")) {
       // SPEC.md §4: the approval step re-checks for competing upstream work and stands down rather
       // than proceed. An issue closed since gating is the strongest form of that — the work is

--- a/factory/packet.test.ts
+++ b/factory/packet.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { evidenceIsStale, needsRewitness, packetDivergences } from "./ledger-check.ts";
 import { DISCLOSURE } from "./neighbor.ts";
-import { renderEvidencePage } from "./packet.ts";
+import { buildPacket, POLICY_DOC_EXCERPT_LIMIT, renderEvidencePage, renderFreezeEvidence } from "./packet.ts";
 import { seedState } from "./seed.ts";
 
 /** Synthetic, and deliberately sharing no abbreviated prefix with any SHA in the seed. */
@@ -63,4 +63,120 @@ test("the evidence page and the divergence list agree about a terminal packet", 
     }),
     [],
   );
+});
+
+/**
+ * Issue #37, second half. `buildPacket` forwarded the fetched `AGENTS.md` / `CONTRIBUTING` text
+ * into `evaluatePolicy` and then dropped it on the floor, so the packet recorded a verdict and no
+ * evidence for it. The documented second layer of defence — the mandatory human freeze
+ * (docs/04-stations.md §3) — was therefore reading a boolean about text it could not see, and the
+ * only way to catch a scanner miss was to go and read the repo out of band, which is exactly the
+ * diligence this tool claims to systematize.
+ *
+ * Scope note: this landed without the matcher work from the same issue, which is parked. Nothing
+ * here asserts what the scanner catches; the ban fixture below is one `main` already matches,
+ * chosen so these tests move if the *display* breaks and stay still if recall changes.
+ */
+const CLEAN_CONTRIBUTING =
+  "Thanks for contributing! Run `pnpm test` before opening a pull request, keep the changeset entry short, and open an issue first for anything large.";
+/** A phrasing `main`'s scanner already matches — the display is under test here, not the matcher. */
+const BAN_AGENTS_MD = "AI-generated pull requests are not welcome in this repository.";
+
+function freezePacket(docs: { agentsMd?: string; contributing?: string }) {
+  return buildPacket({
+    repoId: "mcp-use/mcp-use",
+    issueNumber: 999,
+    issueTitle: "docs typo",
+    issueUrl: "https://github.com/mcp-use/mcp-use/issues/999",
+    ...docs,
+  });
+}
+
+test("the packet keeps the policy text the gate parsed", () => {
+  const packet = freezePacket({ agentsMd: "Agents may open draft PRs.", contributing: CLEAN_CONTRIBUTING });
+  const docs = packet.policyDocs ?? [];
+  assert.deepEqual(
+    docs.map((d) => [d.name, d.chars, d.truncated]),
+    [
+      ["AGENTS.md", 26, false],
+      ["CONTRIBUTING", CLEAN_CONTRIBUTING.length, false],
+    ],
+  );
+  assert.equal(docs[1].excerpt, CLEAN_CONTRIBUTING);
+
+  // A document that was never fetched is absent, not an empty string: "we read nothing" and "we
+  // read a blank file" are different facts and the freeze must not be shown the second one.
+  assert.deepEqual(freezePacket({ contributing: CLEAN_CONTRIBUTING }).policyDocs?.map((d) => d.name), [
+    "CONTRIBUTING",
+  ]);
+  assert.deepEqual(freezePacket({}).policyDocs, undefined);
+
+  // A document fetched and empty is a RECORD with `chars: 0` — the fact the packet must be able to
+  // tell apart from the absent one above, and the input the freeze's char-counted absence needs.
+  assert.deepEqual(freezePacket({ contributing: "" }).policyDocs, [
+    { name: "CONTRIBUTING", chars: 0, excerpt: "", truncated: false },
+  ]);
+});
+
+test("a long policy document is truncated on the packet but its true size is not", () => {
+  const long = `${CLEAN_CONTRIBUTING}\n${"filler prose. ".repeat(400)}`;
+  const doc = freezePacket({ contributing: long }).policyDocs![0];
+  assert.equal(doc.chars, long.length);
+  assert.equal(doc.truncated, true);
+  assert.ok(doc.excerpt.length < long.length, "a truncated excerpt must actually be shorter");
+  assert.equal(doc.excerpt.length, POLICY_DOC_EXCERPT_LIMIT);
+  // The head is kept, so the operator still reads the document from its beginning.
+  assert.ok(long.startsWith(doc.excerpt));
+  // `truncated` is a statement ABOUT the other two fields, and the loader re-derives it that way
+  // (state.ts `isPolicyDoc`). What is written must satisfy what is read back.
+  assert.equal(doc.truncated, doc.excerpt.length < doc.chars);
+});
+
+test("the freeze prints the words the scanner read, not a boolean", () => {
+  const packet = freezePacket({ contributing: CLEAN_CONTRIBUTING });
+  assert.equal(packet.policy.code, "ALLOW");
+  const out = renderFreezeEvidence(packet);
+
+  // The text itself, so the approver confirms against real words.
+  assert.match(out, /keep the changeset entry short/);
+  // Named source and size, so a truncated or suspiciously short fetch is visible as such.
+  assert.match(out, /CONTRIBUTING/);
+  assert.match(out, new RegExp(`${CLEAN_CONTRIBUTING.length} chars`));
+  // The miss mode stated out loud rather than left silent.
+  assert.match(out, /no ban statement matched/i);
+  assert.match(out, /AGENTS\.md.*not fetched/i);
+});
+
+test("the freeze prints the ban statement the scanner did match", () => {
+  const packet = freezePacket({ agentsMd: BAN_AGENTS_MD });
+  assert.equal(packet.policy.code, "DENY_FORBIDDEN");
+  const out = renderFreezeEvidence(packet);
+  assert.match(out, /are not welcome/i);
+  assert.equal(/no ban statement matched/i.test(out), false);
+});
+
+test("a freeze with nothing fetched says so instead of reporting a clean scan", () => {
+  // The fail-safe direction of the display: "the scanner found no ban" over zero characters of
+  // policy text is the single most misleading thing this surface could tell an approver.
+  const out = renderFreezeEvidence(freezePacket({}));
+  assert.match(out, /no policy text/i);
+  assert.equal(/no ban statement matched/i.test(out), false);
+});
+
+test("a document that was fetched but came back empty is an absence, not a clean scan", () => {
+  // Absence is counted in characters, not in documents. A present-and-empty CONTRIBUTING, or a
+  // truncated response, produced a `policyDocs` entry and therefore took the scanned branch —
+  // printing "no ban statement matched in 0 chars from CONTRIBUTING", which is the exact sentence
+  // the zero-document branch exists to prevent, with a source name attached to make it worse.
+  const out = renderFreezeEvidence(freezePacket({ contributing: "" }));
+  assert.equal(/no ban statement matched/i.test(out), false, out);
+  assert.match(out, /came back empty/i);
+  assert.match(out, /re-gate before you attest/i);
+
+  // Both empty is still an absence; one empty and one real is NOT — the real one gets scanned and
+  // the operator must still be shown the scan line for it.
+  const bothEmpty = renderFreezeEvidence(freezePacket({ agentsMd: "", contributing: "" }));
+  assert.equal(/no ban statement matched/i.test(bothEmpty), false, bothEmpty);
+  const oneReal = renderFreezeEvidence(freezePacket({ agentsMd: "", contributing: CLEAN_CONTRIBUTING }));
+  assert.match(oneReal, new RegExp(`no ban statement matched in ${CLEAN_CONTRIBUTING.length} chars`, "i"));
 });

--- a/factory/packet.ts
+++ b/factory/packet.ts
@@ -3,10 +3,37 @@ import { evidenceIsStale, needsRewitness, witnessedSha } from "./ledger-check.ts
 import { ABORT_DEFAULT, commitTrailerLine, DISCLOSURE, FOUNDRY_REPO_URL, NON_GOALS_DEFAULT } from "./neighbor.ts";
 import { evaluatePolicy } from "./policy.ts";
 import { scoreIssue } from "./scout.ts";
-import type { PacketClass, TaskPacket } from "./types.ts";
+import type { PacketClass, PolicyDocSource, TaskPacket } from "./types.ts";
 
 function idFor(repoId: string, issue: number) {
   return `pkt_${repoId.replace("/", "_")}_${issue}`;
+}
+
+/**
+ * How much of each fetched document the packet keeps. Enough that a policy section is read whole —
+ * a real AI-contribution paragraph sits in the first page or two of a CONTRIBUTING — without
+ * turning the ledger into a mirror of every target's docs. The record's `chars` always states the
+ * true size, so a truncation is never mistaken for a short document.
+ */
+export const POLICY_DOC_EXCERPT_LIMIT = 4000;
+
+/**
+ * The documents that were fetched, in the order the scan blob concatenates them. A document that
+ * was never fetched is absent rather than empty: "we read nothing" and "we read a blank file" are
+ * different facts, and the freeze must not be shown the second one when the first is true.
+ */
+function policyDocsOf(input: { agentsMd?: string; contributing?: string }): PolicyDocSource[] | undefined {
+  const sources: [string, string | undefined][] = [
+    ["AGENTS.md", input.agentsMd],
+    ["CONTRIBUTING", input.contributing],
+  ];
+  const docs: PolicyDocSource[] = [];
+  for (const [name, text] of sources) {
+    if (text === undefined) continue;
+    const excerpt = text.slice(0, POLICY_DOC_EXCERPT_LIMIT);
+    docs.push({ name, chars: text.length, excerpt, truncated: excerpt.length < text.length });
+  }
+  return docs.length > 0 ? docs : undefined;
 }
 
 /**
@@ -76,11 +103,87 @@ export function buildPacket(input: {
     station: buildable ? "freeze" : "terminal",
     lighting: "lit",
     policy,
+    policyDocs: policyDocsOf(input),
     scout,
     createdAt: now,
     updatedAt: now,
     parkReason: buildable ? undefined : policy.reasons[0],
   };
+}
+
+/**
+ * What the operator reads at the freeze, before the attest is taken.
+ *
+ * The freeze is the documented second layer over a scanner whose miss mode is known and named
+ * (docs/04-stations.md §2), and a second layer that is handed a boolean is not a second layer. So
+ * this prints the text the gate actually parsed, names every source with its size, and states the
+ * scan result as a claim *about that text*.
+ *
+ * The absence branch is the load-bearing one. "No ban statement matched" over zero characters of
+ * policy text is the single most misleading thing this surface could say, so an empty fetch is
+ * reported as an absence and the scan line is withheld entirely — the same fail-safe direction as
+ * `DENY_UNKNOWN_POLICY` itself (AGENTS.md: "Unknown policy = deny").
+ *
+ * Absence is measured in CHARACTERS, not in documents. A fetch that returned a 0-byte
+ * `CONTRIBUTING` — a repository with the file present and empty, a truncated response — produces a
+ * `policyDocs` entry, so a document-counted branch would take the scanned path and print the exact
+ * sentence the branch exists to prevent: "no ban statement matched in 0 chars from CONTRIBUTING".
+ */
+export function renderFreezeEvidence(packet: TaskPacket): string {
+  const docs = packet.policyDocs ?? [];
+  const fetched = new Set(docs.map((d) => d.name));
+  const lines: string[] = [
+    `Policy text the gate parsed for ${packet.repoId}#${packet.issueNumber} — read it before you attest:`,
+    "",
+  ];
+
+  for (const doc of docs) {
+    lines.push(
+      `  ${doc.name} — ${doc.chars} chars${doc.truncated ? ` (first ${doc.excerpt.length} shown)` : ""}`,
+    );
+    for (const line of doc.excerpt.split("\n")) lines.push(`  | ${line}`);
+    lines.push("");
+  }
+  for (const name of ["AGENTS.md", "CONTRIBUTING"]) {
+    if (!fetched.has(name)) lines.push(`  ${name} — not fetched.`);
+  }
+
+  // `policyNotes` is concatenated into the scan blob (docs/10-schemas.md), so it is part of what
+  // the scanner read — but it is ours, not the repository's, and is labelled as such.
+  const notes = repoById(packet.repoId)?.policyNotes;
+  if (notes) {
+    lines.push("", `  allowlist.yaml policyNotes — ${notes.length} chars, written by us, not the repo:`, `  | ${notes}`);
+  }
+  const record = packet.policy.record;
+  if (record) {
+    lines.push(
+      "",
+      `  Committed policy record — ${record.source} (fetched ${record.fetchedAt}, stance ${record.stance}):`,
+      `  | ${record.quote}`,
+    );
+  }
+
+  lines.push("");
+  const total = docs.reduce((n, d) => n + d.chars, 0);
+  if (total === 0) {
+    lines.push(
+      docs.length === 0
+        ? "  No policy text was fetched for this packet, so any scan result would stand on nothing."
+        : `  ${docs.map((d) => d.name).join(" + ")} came back empty, so any scan result would stand on nothing.`,
+      "  Fetch AGENTS.md / CONTRIBUTING and re-gate before you attest.",
+    );
+  } else if (packet.policy.matchedPhrases.length > 0) {
+    lines.push("  Scanner matched — confirm these are the maintainer's words and mean what the verdict says:");
+    for (const phrase of packet.policy.matchedPhrases) lines.push(`    · ${phrase}`);
+  } else {
+    lines.push(`  Scanner: no ban statement matched in ${total} chars from ${docs.map((d) => d.name).join(" + ")}.`);
+  }
+  lines.push(
+    `  Verdict: ${packet.policy.code}${packet.policy.reasons.length > 0 ? ` — ${packet.policy.reasons.join(" ")}` : ""}`,
+    "  The scanner is a high-recall suggester with a known miss mode, not the arbiter. You are.",
+    "",
+  );
+  return lines.join("\n");
 }
 
 /** Written for the maintainer, not the factory: what changed, how it was verified, who prepared it. Internal vocabulary (policy codes, scout scores, lighting) stays in the packet record. */

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -268,3 +268,45 @@ test("the committed policy records parse under the quote guard", () => {
     assert.doesNotMatch(r.quote, /\d\s*(?:\/|of)\s*\d|\d\s*%/, `${r.repoId} quote: ${r.quote}`);
   }
 });
+
+/**
+ * Issue #37, leg 4 — the assertion behind a sentence in docs/04-stations.md §2, not a claim about
+ * recall.
+ *
+ * The page used to leave a reader to infer that deny-by-default covers a scanner miss. It does
+ * not, and the two guards must not be conflated: `hasParsedEvidence` is satisfied by ANY fetched
+ * document, so a `CONTRIBUTING` whose refusal the scanner cannot read is evidence the gate counts,
+ * and the packet reaches `ALLOW`. Only the no-evidence case denies.
+ *
+ * This is a CHARACTERIZATION test of the gate as it stands, deliberately asserting `ALLOW` on
+ * phrasings the scanner misses. It is not a recall assertion and must not be read as endorsing the
+ * miss: the matcher work from the same issue is parked, and the freeze display (`renderFreezeEvidence`)
+ * is what stands between these strings and a PR. If the matchers are later broadened so that these
+ * DENY, this test is the thing that should be rewritten alongside the sentence it pins — that is
+ * what it is for.
+ */
+test("deny-by-default covers the no-evidence case, not the missed-ban case", () => {
+  // Paraphrases from the issue's own probe table that this tree's scanner does not match.
+  const missed = [
+    "we are not currently accepting AI-generated contributions",
+    "only human contributors may open pull requests",
+    "we don't want AI slop here",
+  ];
+  for (const text of missed) {
+    assert.equal(
+      evaluatePolicy({ repoId: "mcp-use/mcp-use", issueTitle: "docs typo", contributing: text }).code,
+      "ALLOW",
+      `a ban the scanner cannot read reaches ALLOW: ${text}`,
+    );
+  }
+  // The same packet with nothing fetched is the case deny-by-default actually covers...
+  assert.equal(
+    evaluatePolicy({ repoId: "mcp-use/mcp-use", issueTitle: "docs typo" }).code,
+    "DENY_UNKNOWN_POLICY",
+  );
+  // ...and so is a fetch that came back empty, which carries no evidence either.
+  assert.equal(
+    evaluatePolicy({ repoId: "mcp-use/mcp-use", issueTitle: "docs typo", contributing: "" }).code,
+    "DENY_UNKNOWN_POLICY",
+  );
+});

--- a/factory/state.test.ts
+++ b/factory/state.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
+import { buildPacket } from "./packet.ts";
 import { emptyScorecard, health, mergeRate } from "./scorecard.ts";
 import { seedState } from "./seed.ts";
 import { loadFactoryState, saveFactoryState } from "./state.ts";
@@ -238,4 +239,81 @@ test("a state file at exactly the in-flight cap still loads", () => {
   writeFileSync(path, JSON.stringify(seed));
   const loaded = loadFactoryState(path);
   assert.equal(loaded.ok, true);
+});
+
+/**
+ * `policyDocs` is what the freeze renders to the operator as the maintainer's own words, so it is
+ * the one packet field whose whole purpose is to be read by a human making a terminal decision.
+ * Both the field types and their coherence are asserted, because `truncated` is not an independent
+ * fact — it is a claim about `excerpt` and `chars`, and a stored `truncated: false` over a
+ * shortened excerpt tells the approver they are reading the whole document.
+ */
+test("a stored policy document must be well-formed and internally consistent", () => {
+  const seed = seedState();
+  const base = seed.packets[0];
+  const doc = { name: "CONTRIBUTING", chars: 10, excerpt: "0123456789", truncated: false };
+  const write = (policyDocs: unknown): string => {
+    const path = join(mkdtempSync(join(tmpdir(), "foundry-")), "policydocs.json");
+    writeFileSync(path, JSON.stringify({ ...seed, packets: [{ ...base, policyDocs }] }));
+    return path;
+  };
+
+  // Loads: a well-formed pair, whole and truncated.
+  assert.equal(loadFactoryState(write([doc])).ok, true);
+  assert.equal(
+    loadFactoryState(write([{ name: "AGENTS.md", chars: 40, excerpt: "0123456789", truncated: true }])).ok,
+    true,
+  );
+  // ...and a packet with no documents at all, which is the common case.
+  assert.equal(loadFactoryState(write(undefined)).ok, true);
+  // ...and the fetched-but-empty document, which must survive the round trip as a record rather
+  // than being refused into the same shape as "never fetched".
+  assert.equal(loadFactoryState(write([{ name: "CONTRIBUTING", chars: 0, excerpt: "", truncated: false }])).ok, true);
+
+  for (const [why, bad] of [
+    ["not an array", doc],
+    ["missing name", [{ chars: 10, excerpt: "0123456789", truncated: false }]],
+    ["name not a string", [{ ...doc, name: 3 }]],
+    ["chars not an integer", [{ ...doc, chars: 10.5 }]],
+    // The row above is refused by the coherence clause, not by `Number.isInteger`: at chars 10.5 a
+    // ten-character excerpt IS shortened, so `truncated: false` is incoherent on its own and
+    // `Number.isInteger` could be deleted with the suite green. These two agree with the coherence
+    // clause and are refused only by the integer check, which is what pins it.
+    ["a fractional document size", [{ ...doc, chars: 10.5, truncated: true }]],
+    ["an infinite document size", [{ ...doc, chars: Infinity, truncated: true }]],
+    ["negative chars", [{ ...doc, chars: -1, excerpt: "" }]],
+    ["excerpt not a string", [{ ...doc, excerpt: null }]],
+    ["truncated not a boolean", [{ ...doc, truncated: "no" }]],
+    ["excerpt longer than the document it came from", [{ ...doc, chars: 4 }]],
+    ["a shortened excerpt reported as whole", [{ ...doc, chars: 40 }]],
+    ["a whole excerpt reported as truncated", [{ ...doc, truncated: true }]],
+  ] as [string, unknown][]) {
+    assert.equal(loadFactoryState(write(bad)).ok, false, why);
+  }
+});
+
+/**
+ * The round trip proper: what `buildPacket` writes must be what `loadFactoryState` accepts and
+ * hands back. A validator and a producer that disagree fail in only one direction — the operator
+ * loses the freeze evidence at the moment a real packet is read back off disk.
+ */
+test("policy documents survive save and load unchanged", () => {
+  const seed = seedState();
+  const built = buildPacket({
+    repoId: "mcp-use/mcp-use",
+    issueNumber: 991,
+    issueTitle: "docs typo",
+    issueUrl: "https://github.com/mcp-use/mcp-use/issues/991",
+    agentsMd: "Agents may open draft PRs.",
+    contributing: `${"long contributing prose. ".repeat(400)}`,
+  });
+  assert.equal(built.policyDocs?.length, 2);
+  assert.equal(built.policyDocs?.[1].truncated, true);
+
+  const path = join(mkdtempSync(join(tmpdir(), "foundry-")), "roundtrip.json");
+  saveFactoryState(path, { ...seed, packets: [built, ...seed.packets.filter((p) => p.status !== "submitted")] });
+  const loaded = loadFactoryState(path);
+  assert.equal(loaded.ok, true, "a freshly built packet must load back");
+  if (!loaded.ok) return;
+  assert.deepEqual(loaded.state.packets.find((p) => p.id === built.id)?.policyDocs, built.policyDocs);
 });

--- a/factory/state.ts
+++ b/factory/state.ts
@@ -91,6 +91,30 @@ function isPolicy(value: unknown): boolean {
   );
 }
 
+/**
+ * The freeze reads these fields back and renders them to the operator as the maintainer's own
+ * words, so the shape check is also a coherence check: `chars` is the document's TRUE size and
+ * `excerpt` may be a prefix of it, which means `truncated` is not an independent fact but a
+ * statement about the other two. A stored record claiming `truncated: false` over an excerpt
+ * shorter than `chars` tells the approver they are reading the whole document when they are not,
+ * and a non-integer size describes no document at all.
+ */
+function isPolicyDoc(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  const o = value as Record<string, unknown>;
+  return (
+    typeof o.name === "string" &&
+    Number.isInteger(o.chars) &&
+    typeof o.excerpt === "string" &&
+    // No separate `chars >= 0`: a string's length is never negative, so `excerpt.length <= chars`
+    // already refuses every negative size. The clause could be deleted with the suite green, and a
+    // guard that cannot fail is a guard a reader trusts for a reason that is not there.
+    o.excerpt.length <= (o.chars as number) &&
+    typeof o.truncated === "boolean" &&
+    o.truncated === o.excerpt.length < (o.chars as number)
+  );
+}
+
 function isScout(value: unknown): boolean {
   if (!value || typeof value !== "object") return false;
   const o = value as Record<string, unknown>;
@@ -228,6 +252,7 @@ function isPacket(value: unknown): boolean {
     typeof o.createdAt === "string" &&
     typeof o.updatedAt === "string" &&
     isPolicy(o.policy) &&
+    optional(o.policyDocs, (v) => Array.isArray(v) && v.every(isPolicyDoc)) &&
     isScout(o.scout) &&
     optional(o.humanAttest, isAttest) &&
     optional(o.evidence, isEvidence) &&

--- a/factory/types.ts
+++ b/factory/types.ts
@@ -124,6 +124,31 @@ export interface PolicyVerdict {
   record?: PolicyRecord;
 }
 
+/**
+ * One document the gate actually read, kept on the packet so the human freeze can confirm the
+ * verdict against the maintainer's own words instead of a boolean.
+ *
+ * `buildPacket` used to forward `agentsMd` / `contributing` into `evaluatePolicy` and then drop
+ * them, which left the mandatory freeze (docs/04-stations.md §3) blind to the very text the
+ * scanner parsed — and the scanner is a high-recall suggester with a known miss mode, not an
+ * arbiter (issue #37). Catching a miss then meant going and reading the repo out of band, which is
+ * exactly the diligence the tool claims to systematize.
+ *
+ * `chars` is the size of the document as fetched, `excerpt` is what the ledger keeps of it: a
+ * truncated record still states the true size, so a short excerpt can never be misread as a short
+ * document.
+ */
+export interface PolicyDocSource {
+  /** The document as the fetcher named it: `AGENTS.md` or `CONTRIBUTING`. */
+  name: string;
+  /** Length of the fetched text in characters, BEFORE truncation. */
+  chars: number;
+  /** The head of the fetched text, capped at `POLICY_DOC_EXCERPT_LIMIT`. */
+  excerpt: string;
+  /** True exactly when `excerpt` is shorter than the document `chars` describes. */
+  truncated: boolean;
+}
+
 export interface ScoutScore {
   total: number;
   parts: {
@@ -172,6 +197,12 @@ export interface TaskPacket {
   station: Station;
   lighting: Lighting;
   policy: PolicyVerdict;
+  /**
+   * The fetched documents the verdict was computed from. Absent when nothing was fetched — which
+   * is a different fact from a document that was fetched and came back empty (`chars: 0`), and the
+   * freeze displays the two differently.
+   */
+  policyDocs?: PolicyDocSource[];
   scout: ScoutScore;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
Partial fix for #37 — **legs 2, 3 and 4. Leg 1 (the policy scanner's matcher set) is parked**; see the park record on #37. **This PR does not close #37.**

## The safety property first

`factory/policy.ts` is **byte-identical to `main`** — sha256 `047a711e8c7bc906f782cc333452512bdffb88d668508a1001466da1884776a8` on both sides, zero diff lines. It turned out no change was needed: `policyDocsOf` derives documents from `buildPacket`'s own inputs, and `renderFreezeEvidence` reads only fields that already exist. So none of the parked leg's fail-opens can reach `main` through this branch.

Proven differentially as well as by hash — independently by both the builder and the reviewer. The reviewer ran **166,120 full-verdict-object comparisons, 0 mismatches**, with corpus axes drawn from *outside* `policy.ts` (the issue's own probes, ~100 hand-written near-misses, paragraph-split prose from the repo's own docs), and **proved the harness non-vacuous before trusting that zero** — injecting a matcher, deleting one, changing only a `reasons` string with the verdict code untouched (6,999 mismatches), and shrinking the sentence window 90→40 (2 mismatches in 166,120).

## What lands

- **Leg 2** — the packet carries `policyDocs`: name, **true** pre-truncation `chars`, a size-limited excerpt, and `truncated === excerpt.length < chars` coherence-checked in both producer and loader. A document fetched-but-empty (`chars: 0`) round-trips distinctly from one never fetched.
- **Leg 3** — `approve` prints each document with source and byte count plus either the matched ban statement or an explicit no-match, with absence measured in **characters, not documents**, before the competing-work network reads so a human sees it even if those fail. The ordering is enforced, not incidental: moving the call after them kills exactly the test named for it.
- **Leg 4** — `docs/04-stations.md` corrected: deny-by-default covers the no-evidence case, **not** the missed-ban case.

A detail neither the builder nor I saw, found by review: across 72,216 `ALLOW` verdicts, `matchedPhrases` is never non-empty — the `HOLD` return intercepts every human-statement match first. So on the only path where a packet can actually be approved, the display always takes the explicit no-match branch. The requirement is met exactly where it matters.

## Verification

227 tests / 227 pass; `npm run validate` exit 0; `verify-ledger` exit 0. Reviewed at `a635868` on three isolated axes — **PASS on all three at round 1**. 19 consumer mutations killed, each by a test naming that consumer; negative control separates 11 behavioural reds from module-resolution breaks.

Follow-ups filed, not blocking: the truncated-document *render* path is unpinned though the packet-level guarantee is; two documented render blocks are deletable green; `docs/04-stations.md:53` overstates deny-by-default's reach.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR preserves fetched policy evidence on task packets and prints it during approval so operators can inspect what informed the policy verdict.
- Adds size-tracked, validated policy document excerpts to task packets.
- Renders policy evidence before approval-time network checks.
- Documents the scanner’s missed-ban behavior and clarifies deny-by-default scope.
- Adds packet, state, policy, and CLI coverage for the new evidence flow.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

This PR should not merge until the freeze can expose all policy text needed to catch scanner-missed prohibitions.

The scanner evaluates complete fetched documents, but the approval surface retains only a 4,000-character prefix, allowing a prohibition after that cutoff to be omitted from the human safety gate.

**Files Needing Attention:** factory/packet.ts
</details>


<details open><summary><h3>Security Review</h3></summary>

The fixed 4,000-character excerpt can omit a scanner-missed prohibition from the human approval surface even though the scanner evaluated the complete document. **How this was verified:** The complete fetched document reaches evaluatePolicy, but policyDocs and renderFreezeEvidence retain and display only its first 4,000 characters.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| factory/packet.ts | Adds policy-document storage and freeze rendering, but the fixed prefix can hide policy text that the human gate is intended to inspect. |
| factory/cli.ts | Prints freeze evidence before approval-time GitHub reads and then follows the existing approval flow. |
| factory/state.ts | Validates policy-document field types and coherence while retaining compatibility with packets that predate the field. |
| factory/types.ts | Defines the optional persisted policy-document shape and documents its intended semantics. |
| factory/policy.test.ts | Characterizes the distinction between missing evidence and fetched policy text whose prohibition the scanner misses. |
| docs/04-stations.md | Documents the scanner’s limitations and the human freeze, though the complete-text claim is undermined by excerpt truncation. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Fetch complete policy documents] --> B[Evaluate complete policy text]
  A --> C[Store first 4,000 characters]
  B --> D[Policy verdict]
  C --> E[Render freeze evidence]
  D --> E
  E --> F[Human approval]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20ravidsrk%2Foss-foundry%20PR%20%2370%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=ravidsrk%2Foss-foundry&pr=70&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Afactory%2Fpacket.ts%3A33-34%0A**Policy%20evidence%20truncates%20missed%20bans**%0A%0AWhen%20a%20fetched%20policy%20document%20has%20a%20scanner-missed%20prohibition%20after%20character%204%2C000%2C%20the%20scanner%20evaluates%20the%20complete%20document%20but%20the%20freeze%20displays%20only%20its%20prefix%2C%20allowing%20the%20operator%20to%20approve%20a%20prohibited%20contribution%20without%20seeing%20the%20relevant%20policy%20text.%0A%0A**How%20this%20was%20verified%3A**%20The%20complete%20fetched%20document%20reaches%20%60evaluatePolicy%60%2C%20while%20%60policyDocsOf%60%20stores%20and%20%60renderFreezeEvidence%60%20displays%20only%20its%20first%204%2C000%20characters.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ravidsrk%2Foss-foundry&pr=70&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
factory/packet.ts:33-34
**Policy evidence truncates missed bans**

When a fetched policy document has a scanner-missed prohibition after character 4,000, the scanner evaluates the complete document but the freeze displays only its prefix, allowing the operator to approve a prohibited contribution without seeing the relevant policy text.

**How this was verified:** The complete fetched document reaches `evaluatePolicy`, while `policyDocsOf` stores and `renderFreezeEvidence` displays only its first 4,000 characters.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(freeze): show the human the policy ..."](https://github.com/ravidsrk/oss-foundry/commit/a63586831022e709a15da80bb2f9320ae888f12f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58194503)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->