### PR TITLE
harden: the six review comments the last sweep merged past

### DIFF
--- a/docs/08-operations.md
+++ b/docs/08-operations.md
@@ -182,9 +182,18 @@ Silence is the modal outcome for external agent PRs, so every KPI names its deno
     the base branch whose message says `This reverts commit <our merge commit>` inside the 30-day
     window — is found without a human: `verify-ledger` (the 6-hour clock) fails the run while the
     ledger still records no revert, and `reconcile` records it and stops the repo. The **prose**
-    half — a maintainer-stated rollback — is `revert <packetId> --reason <text>`, where the reason
-    is mandatory and stored verbatim. Nothing else can set `reverts`, and one revert is counted per
-    packet: `health()` already stops the repo at one, so a second would only inflate the number.
+    half — a maintainer-stated rollback — is `revert <packetId> --reason <text> [--at <iso>]`, where
+    the reason is mandatory and stored verbatim. Nothing else can set `reverts`, and one revert is
+    counted per packet: `health()` already stops the repo at one, so a second would only inflate the
+    number.
+  - **Both halves date the window from the EVENT.** "Within 30 days of merge" is a fact about when
+    the rollback happened, not about when anybody wrote it down, and the two halves share one
+    predicate (`revertWindow`) precisely so they cannot disagree about it — but a shared predicate
+    only agrees if it is handed the same subject. The mechanical half passes the reverting commit's
+    `committedAt`; the prose half passes `--at`, which defaults to now for an operator recording a
+    rollback as it happens. An operator writing up a day-10 rollback on day 35 passes `--at` with
+    day 10; without it the same rollback would be refused as out of window while `reconcile` would
+    have recorded it, which is the SPEC.md §7 MUST going unsatisfied with no path to satisfy it.
   - The mechanical half reads `GET /repos/{o}/{r}/commits?since=<mergedAt>&until=<mergedAt+30d>`
     **through GitHub's own `Link: rel="next"` cursor**, up to a cap of 10 pages (1000 commits).
     GitHub serves commits newest-first, so a single-page read hides the window that opens *at the

--- a/docs/08-operations.md
+++ b/docs/08-operations.md
@@ -194,6 +194,10 @@ Silence is the modal outcome for external agent PRs, so every KPI names its deno
     rollback as it happens. An operator writing up a day-10 rollback on day 35 passes `--at` with
     day 10; without it the same rollback would be refused as out of window while `reconcile` would
     have recorded it, which is the SPEC.md §7 MUST going unsatisfied with no path to satisfy it.
+    A `--at` typed with nothing after it is **refused**, not read as "now": `undefined` is what the
+    argument parser returns for both "no flag" and "flag at the end of the line", and defaulting the
+    second to the moment of typing would reach this exact failure through the flag that exists to
+    avoid it. Omit `--at` to mean now; say so by omitting it.
   - The mechanical half reads `GET /repos/{o}/{r}/commits?since=<mergedAt>&until=<mergedAt+30d>`
     **through GitHub's own `Link: rel="next"` cursor**, up to a cap of 10 pages (1000 commits).
     GitHub serves commits newest-first, so a single-page read hides the window that opens *at the

--- a/docs/12-ledger.md
+++ b/docs/12-ledger.md
@@ -212,14 +212,23 @@ scorecard read `0` forever, correct or not.
    that mutant.
 
 **The evidence for all of the above is re-runnable, not asserted.**
-`node --experimental-strip-types scripts/mutation-audit.ts` applies 27 single-line mutations to this
-surface, runs the full suite against each, restores the file from the bytes it read, and re-verifies
-the baseline. 26 must die and one — a local rebinding with no behavioural content — must survive, so
-a harness that had broken into always-reporting-killed fails its own control. It exits non-zero if
-any real mutant survives or if a mutant's anchor text has moved. Every line this round added or
-corrected is in that table with a one-sentence statement of what shipping the mutant would cost. A
-mutation score quoted in prose is not evidence; this is the same claim in a form a reviewer can
-re-derive in one command.
+`node --experimental-strip-types scripts/mutation-audit.ts` applies one single-line mutation per row
+of its table, runs the full suite against each, restores the file from the bytes it read, and
+re-verifies the baseline. It exits non-zero if any real mutant survives or if a mutant's anchor text
+has moved. Every line each round added or corrected is in that table with a one-sentence statement of
+what shipping the mutant would cost.
+
+**No count is quoted here, and that is the point.** This paragraph used to say "27 single-line
+mutations … 26 must die and one must survive". By the next round the table held 65 and the sentence
+still said 27 — a mutation score copied into prose, in the paragraph that calls a mutation score
+copied into prose worthless. So the count has one source and one reader:
+`scripts/mutation-audit.ts --list` prints the table and closes with its own tally, and a full run
+prints the same line before it starts. What is stated here instead is the invariant, which does not
+drift: **every mutant must reach the outcome its own row declares** — killed, unless the row carries
+`expect: "survives"`, and exactly one does. That one is a local rebinding with no behavioural
+content, so a harness that had broken into always-reporting-killed fails on it and the run exits
+non-zero. A mutation score quoted in prose is not evidence; this is the same claim in a form a
+reviewer re-derives in one command.
 
 **A correction to this section's own round-2 arithmetic.** The blind window `since`-only reads left
 on orca-fleet#72 was reported as ~39 minutes. That is wrong, and it understates it by a factor of

--- a/docs/12-ledger.md
+++ b/docs/12-ledger.md
@@ -119,9 +119,13 @@ scorecard read `0` forever, correct or not.
    on the base branch saying `This reverts commit <our merge commit>` within 30 days — is found
    without a human: `verify-ledger` (the 6-hour clock, the only unattended runner) fails the run
    while the ledger still records no revert, and `reconcile` records it and stops the repo. The prose
-   half — "a maintainer-stated rollback naming the PR" — is `revert <packetId> --reason <text>`,
-   reason mandatory and stored verbatim. Post-merge rework is excluded structurally: nothing but a
-   commit naming our merge commit can reach the counter.
+   half — "a maintainer-stated rollback naming the PR" — is
+   `revert <packetId> --reason <text> [--at <iso>]`, reason mandatory and stored verbatim, `--at`
+   the day the ROLLBACK happened (defaults to now). Both halves measure the 30-day window from the
+   event, through one shared predicate: the classifier passes the reverting commit's `committedAt`,
+   the verb passes `--at`. Without that flag an operator writing up a day-10 rollback on day 35 was
+   refused by the verb and recorded by `reconcile` — one rollback, two verdicts. Post-merge rework is
+   excluded structurally: nothing but a commit naming our merge commit can reach the counter.
 4. **`applyPrSync`'s status guard is untouched.** It has never seen a merged packet and still does
    not — the quiet-day and `closedUnmerged` semantics ADR 0002 describes are unchanged. The revert
    re-check went where merged packets were already being fetched: `reconcile`'s loop and the clock.

--- a/factory/cli.test.ts
+++ b/factory/cli.test.ts
@@ -6,6 +6,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { join, resolve } from "node:path";
 import { test } from "node:test";
 import { ALLOWLIST } from "./allowlist.ts";
+import { assertDisjointCounts } from "./fixture-counts.ts";
 import { applySecondaryLimitHalt } from "./halt.ts";
 import { packetChecks } from "./ledger-check.ts";
 import { DISCLOSURE } from "./neighbor.ts";
@@ -1386,7 +1387,9 @@ test("approve tells the operator, on the terminal, how much policy text it is no
   const total = long.length;
   const withheld = total - 4000;
   assert.deepEqual([total, withheld], [5234, 1234]);
-  assert.equal(String(total).includes(String(withheld)), false, "the withheld count must be assertable");
+  // The same rule `packet.test.ts` states, from the same place. It used to be written out again
+  // here, which is two copies of one precondition and therefore two things that can drift apart.
+  assertDisjointCounts(total, withheld);
   const path = writeState(state);
   const stub = githubStub("record");
   const run = runCli(
@@ -1858,6 +1861,26 @@ test("revert dates the window from the rollback the operator names, not from whe
   assert.equal(bad.code, 1, bad.out);
   assert.match(bad.out, /not a date this can parse/, bad.out);
   assert.equal(rowOf(badPath).reverts, 0);
+
+  // A TRAILING `--at`, with nothing after it, is not "now". `flag()` answers `undefined` for both
+  // "no flag" and "flag at the end of argv", so this typed the flag, got the default, and dated the
+  // window from the typing — the failure the flag exists to close, reached silently and by the
+  // operator who was trying hardest to avoid it. Refused, and the refusal says what omitting it
+  // would have meant.
+  const trailingPath = writeState(aged());
+  const trailing = runCli(["revert", id, "--reason", reason, "--state", trailingPath, "--at"], tmpdir());
+  assert.equal(trailing.code, 1, trailing.out);
+  assert.match(trailing.out, /--at was given no value/, trailing.out);
+  assert.match(trailing.out, /omitting it means the rollback is dated now/, trailing.out);
+  assert.equal(rowOf(trailingPath).reverts, 0);
+
+  // …and a `--at` whose "value" is the next FLAG is a different mistake with the same cause. It is
+  // caught by the parse check rather than by the guard above, and both must stay: neither one on
+  // its own covers the other.
+  const swallowedPath = writeState(aged());
+  const swallowed = runCli(["revert", id, "--reason", reason, "--at", "--state", swallowedPath], tmpdir());
+  assert.equal(swallowed.code, 1, swallowed.out);
+  assert.match(swallowed.out, /not a date this can parse/, swallowed.out);
 
   // And the flag is in `--help`: a verb whose behaviour depends on a flag nobody is told about is
   // the same defect as a refusal naming a command that does not exist.

--- a/factory/cli.test.ts
+++ b/factory/cli.test.ts
@@ -1043,6 +1043,79 @@ function gatedOn71(): FactoryState {
   };
 }
 
+/**
+ * Issue #79 — SPEC.md §6 is "a platform secondary rate limit MUST halt the factory, never retry",
+ * and requesting-then-refusing IS the retry.
+ *
+ * `open-draft` got this gate (`refusing to open a draft on …`, pinned above); `tick` and `approve`
+ * are its siblings and did not. With a persisted halt on disk, `tickWithGithub` walked the whole
+ * roster — open pulls, AGENTS.md, CONTRIBUTING, issue state, timeline — and only discovered the
+ * halt afterwards, inside `applyTick` → `maySelectRepo`. Measured on this tree before the fix: 20
+ * requests for `tick`, 3 for `approve`, every one of them against the very limit that caused the
+ * halt, and every re-run of the halted CLI spends them again.
+ *
+ * The assertion is therefore a COUNT, not a verdict. A refused verdict is exactly what the broken
+ * code already produced — it refused after spending the requests — so asserting on the refusal
+ * alone would have been green before the fix and green after it, and would have pinned nothing.
+ */
+test("a persisted halt stops tick and approve before a single GitHub request", () => {
+  const halt = (state: FactoryState) =>
+    applySecondaryLimitHalt(state, { repoId: DRAFT_READY_REPO, at: "2026-08-29T09:00:00.000Z" });
+  const requests = (log: string) =>
+    (existsSync(log) ? readFileSync(log, "utf8") : "").split("\n").filter(Boolean);
+
+  // tick: the read-only path, and the one that spends the most — every named row on the roster.
+  const tickStub = githubStub("record");
+  const tickPath = writeState(halt(emptyLedger()));
+  const ticked = runCli(["tick", "--state", tickPath], tmpdir(), { preload: tickStub.preload });
+  assert.equal(ticked.code, 1, `a halted tick must not report success:\n${ticked.out}`);
+  assert.deepEqual(
+    requests(tickStub.log),
+    [],
+    `a halted tick must contact GitHub zero times; it made:\n${requests(tickStub.log).join("\n")}`,
+  );
+  // …and says which halt, so the operator is not left reading `idle` on a bricked factory. `idle`
+  // is the specific wrong answer here: with the halt refusing every repo inside `pickCandidate`,
+  // a gate that merely returned no candidate would print "no named candidate" and exit 0.
+  assert.match(ticked.out, /Factory halted 2026-08-29T09:00:00\.000Z/, ticked.out);
+  assert.equal(/no named candidate/.test(ticked.stdout), false, ticked.out);
+  assert.deepEqual(
+    (JSON.parse(readFileSync(tickPath, "utf8")) as FactoryState).packets.map((p) => p.id),
+    [],
+    "a halted tick must scout nothing",
+  );
+
+  // approve: the freeze. The evidence render is local and must still print — the human's read is
+  // the point of the verb — but nothing may go out over the wire.
+  const approveStub = githubStub("record");
+  const approvePath = writeState(halt(gatedOn71()));
+  const approved = runCli(
+    ["approve", "pkt_ravidsrk_orca-fleet_71", "--note", "looks fine", "--by", "ravidsrk", "--state", approvePath],
+    tmpdir(),
+    { preload: approveStub.preload },
+  );
+  assert.equal(approved.code, 1, approved.out);
+  assert.deepEqual(
+    requests(approveStub.log),
+    [],
+    `a halted approve must contact GitHub zero times; it made:\n${requests(approveStub.log).join("\n")}`,
+  );
+  assert.match(approved.out, /Factory halted 2026-08-29T09:00:00\.000Z/, approved.out);
+  // The freeze evidence is not network work and is not skipped by the gate.
+  assert.match(approved.stdout, /Policy text the gate parsed/, approved.stdout);
+  const approveDisk = JSON.parse(readFileSync(approvePath, "utf8")) as FactoryState;
+  assert.equal(approveDisk.packets.find((p) => p.id === "pkt_ravidsrk_orca-fleet_71")?.humanAttest, undefined);
+
+  // The control: without the halt, both verbs DO reach GitHub. Otherwise "zero requests" would be
+  // satisfied by a CLI that had simply stopped working.
+  const liveStub = githubStub("record");
+  const liveTick = runCli(["tick", "--state", writeState(emptyLedger())], tmpdir(), { preload: liveStub.preload });
+  assert.ok(
+    requests(liveStub.log).length > 0,
+    `an unhalted tick must still contact GitHub, or the assertion above is vacuous:\n${liveTick.out}`,
+  );
+});
+
 test("tick stands down on a named first issue GitHub has already closed", () => {
   // The live case, not a hypothetical: `allowlist.yaml`'s first named row IS
   // ravidsrk/orca-fleet#71, and GitHub closed it (state_reason completed) on 2026-08-27. Before
@@ -1283,6 +1356,37 @@ test("approve shows the operator the policy text the gate parsed", () => {
   );
 });
 
+test("approve tells the operator, on the terminal, how much policy text it is not showing them", () => {
+  // The consumer half of issue #77. `renderFreezeEvidence` is pinned in `packet.test.ts`; this
+  // exists because a rendering nobody prints protects nobody, and the freeze reaches the human
+  // through exactly one call site. The scenario is the issue's: a >4,000-char CONTRIBUTING whose
+  // only ban sits past the excerpt limit and which the scanner misses, so the verdict is ALLOW and
+  // the operator is one keystroke from attesting over text they were never shown.
+  const missedBan = "Kindly refrain from opening pull requests that were authored by an AI assistant.";
+  const long = `${"Please read the guidelines below before opening a pull request.\n".repeat(200).slice(0, 4801)}\n${missedBan}\n`;
+  const state = gatedState({ contributing: long });
+  assert.equal(state.packets[0].policy.code, "ALLOW", "the scanner must miss this ban");
+  const path = writeState(state);
+  const stub = githubStub("record");
+  const run = runCli(
+    ["approve", state.packets[0].id, "--note", "read it", "--by", "ravidsrk", "--state", path],
+    tmpdir(),
+    { preload: stub.preload },
+  );
+  assert.equal(run.code, 0, run.out);
+  const withheld = long.length - 4000;
+  assert.match(run.stdout, new RegExp(`${withheld}[^\\n]*NOT shown`), run.stdout);
+  assert.match(run.stdout, /The scanner read them; you have not/, run.stdout);
+  // The ban really is invisible — that is the harm the notice exists to disclose, not to remove.
+  assert.equal(run.stdout.includes(missedBan), false, "precondition: the ban is past the limit");
+  // And the closing claim above the attest is qualified rather than a clean bill of health.
+  assert.equal(
+    run.stdout.includes(`no ban statement matched in ${long.length} chars from CONTRIBUTING.`),
+    false,
+    run.stdout.slice(-600),
+  );
+});
+
 test("approve prints the policy text before the competing-work reads, not after them", () => {
   // Ordering is the whole point of where the call sits. The competing-work check is a network read
   // that can fail and `process.exit(1)` — if the evidence printed after it, an operator hitting a
@@ -1512,6 +1616,51 @@ test("the revert verb records a maintainer-stated rollback, halts the repo, and 
   const refused = runCli(["revert", inflight.id, "--reason", reason, "--state", path], tmpdir());
   assert.equal(refused.code, 1, refused.out);
   assert.match(refused.out, /never merged/);
+});
+
+/**
+ * The `revert` VERB's half of issue #81 — named separately from the `applyRevert` unit on purpose.
+ *
+ * This repository's most-repeated defect is a well-tested function behind untested wiring, and a
+ * window enforced in the engine with a CLI that swallowed the refusal would be exactly that again:
+ * `revert` reads `result.error`, and a verb that printed the refusal but still persisted, or exited
+ * 0, or reported `reverts=1` from a state it never wrote, would keep the engine test green while the
+ * operator was told the repository had been halted when it had not.
+ */
+test("the revert verb refuses a rollback past the 30-day window and writes nothing", () => {
+  const seed = seedState();
+  const id = "pkt_ravidsrk_frontguard_195";
+  const packet = seed.packets.find((p) => p.id === id)!;
+  const repoId = packet.repoId;
+  // Age the merge past the deadline. Only this one fact changes, so the refusal can only come from
+  // the window: everything else is the state the in-window test above records against successfully.
+  const stale: FactoryState = {
+    ...seed,
+    packets: seed.packets.map((p) =>
+      p.id === id ? { ...p, prMeta: { ...p.prMeta!, mergedAt: "2025-06-01T00:00:00Z" } } : p,
+    ),
+  };
+  const path = writeState(stale);
+  const reason = "maintainer mentioned rolling it back in a thread from last year";
+
+  const run = runCli(["revert", id, "--reason", reason, "--state", path], tmpdir());
+  assert.equal(run.code, 1, `an out-of-window revert must refuse:\n${run.out}`);
+  assert.match(run.out, /30-day window/, run.out);
+  assert.match(run.out, /docs\/08-operations\.md/, run.out);
+
+  // The ledger is the assertion, not the exit code: a refusal that still wrote the counter would
+  // halt the repository behind a message saying it had not.
+  const after = JSON.parse(readFileSync(path, "utf8")) as FactoryState;
+  assert.equal(after.scorecard.find((r) => r.repoId === repoId)!.reverts, 0);
+  assert.equal(after.packets.find((p) => p.id === id)!.followUps?.some((f) => f.body.startsWith("revert:")) ?? false, false);
+
+  // And the repository stays selectable — the whole cost of the bug was a permanent stop.
+  const status = runCli(["status", "--state", path], tmpdir());
+  assert.doesNotMatch(
+    status.stdout,
+    new RegExp(`${repoId}\\s+opened=\\d+ merged=\\d+ tone=\\w+ health=stop`),
+    `an out-of-window revert must not stop the repo:\n${status.stdout}`,
+  );
 });
 
 test("sync folds the human review split into the scorecard when the PR reaches a terminal state", () => {

--- a/factory/cli.test.ts
+++ b/factory/cli.test.ts
@@ -1050,9 +1050,12 @@ function gatedOn71(): FactoryState {
  * `open-draft` got this gate (`refusing to open a draft on …`, pinned above); `tick` and `approve`
  * are its siblings and did not. With a persisted halt on disk, `tickWithGithub` walked the whole
  * roster — open pulls, AGENTS.md, CONTRIBUTING, issue state, timeline — and only discovered the
- * halt afterwards, inside `applyTick` → `maySelectRepo`. Measured on this tree before the fix: 20
- * requests for `tick`, 3 for `approve`, every one of them against the very limit that caused the
- * halt, and every re-run of the halted CLI spends them again.
+ * halt afterwards, inside `applyTick` → `maySelectRepo`. Measured on this tree before the fix: 24
+ * requests for `tick` — six per named roster row (open pulls, AGENTS.md, CONTRIBUTING.md,
+ * .github/CONTRIBUTING.md, the issue, its timeline) across the four rows — and 3 for `approve`,
+ * every one of them against the very limit that caused the halt, and every re-run of the halted CLI
+ * spends them again. (The `20` this comment carried through round 1 was never reproducible here; it
+ * is reachable only against live GitHub, where a row can answer in fewer requests.)
  *
  * The assertion is therefore a COUNT, not a verdict. A refused verdict is exactly what the broken
  * code already produced — it refused after spending the requests — so asserting on the refusal
@@ -1079,10 +1082,18 @@ test("a persisted halt stops tick and approve before a single GitHub request", (
   // a gate that merely returned no candidate would print "no named candidate" and exit 0.
   assert.match(ticked.out, /Factory halted 2026-08-29T09:00:00\.000Z/, ticked.out);
   assert.equal(/no named candidate/.test(ticked.stdout), false, ticked.out);
-  assert.deepEqual(
-    (JSON.parse(readFileSync(tickPath, "utf8")) as FactoryState).packets.map((p) => p.id),
-    [],
-    "a halted tick must scout nothing",
+  const tickLedger = JSON.parse(readFileSync(tickPath, "utf8")) as FactoryState;
+  assert.deepEqual(tickLedger.packets.map((p) => p.id), [], "a halted tick must scout nothing");
+  // …and the refusal is IN THE LEDGER, not only on the terminal. `applyTick`'s halt branch calls
+  // `appendEvent` before returning, and dropping that call leaves a tick that refused with no
+  // record it ever ran: the console line evaporates with the exit, and the next reader of the
+  // ledger sees a six-hour gap with no cause. Every other refusal in this file writes one.
+  assert.equal(
+    tickLedger.events.some(
+      (e) => e.kind === "tick" && /Tick refused — factory halted 2026-08-29T09:00:00\.000Z/.test(e.message),
+    ),
+    true,
+    `a halted tick must leave a ledger event: ${JSON.stringify(tickLedger.events)}`,
   );
 
   // approve: the freeze. The evidence render is local and must still print — the human's read is
@@ -1362,10 +1373,20 @@ test("approve tells the operator, on the terminal, how much policy text it is no
   // through exactly one call site. The scenario is the issue's: a >4,000-char CONTRIBUTING whose
   // only ban sits past the excerpt limit and which the scanner misses, so the verdict is ALLOW and
   // the operator is one keystroke from attesting over text they were never shown.
+  //
+  // The fixture is 5234 characters withholding 1234, matching `packet.test.ts`, and for the reason
+  // stated there: the previous 4883/883 pair made `883` a substring of `4883`, so every assertion
+  // below matched inside the total and the number an operator's decision rests on was pinned
+  // nowhere. All three renderings are asserted here too, on the real terminal, because this is the
+  // surface — `renderFreezeEvidence` being right does not mean `approve` printed it.
   const missedBan = "Kindly refrain from opening pull requests that were authored by an AI assistant.";
-  const long = `${"Please read the guidelines below before opening a pull request.\n".repeat(200).slice(0, 4801)}\n${missedBan}\n`;
+  const long = `${"Please read the guidelines below before opening a pull request.\n".repeat(200).slice(0, 5152)}\n${missedBan}\n`;
   const state = gatedState({ contributing: long });
   assert.equal(state.packets[0].policy.code, "ALLOW", "the scanner must miss this ban");
+  const total = long.length;
+  const withheld = total - 4000;
+  assert.deepEqual([total, withheld], [5234, 1234]);
+  assert.equal(String(total).includes(String(withheld)), false, "the withheld count must be assertable");
   const path = writeState(state);
   const stub = githubStub("record");
   const run = runCli(
@@ -1374,17 +1395,126 @@ test("approve tells the operator, on the terminal, how much policy text it is no
     { preload: stub.preload },
   );
   assert.equal(run.code, 0, run.out);
-  const withheld = long.length - 4000;
-  assert.match(run.stdout, new RegExp(`${withheld}[^\\n]*NOT shown`), run.stdout);
+  // 1. the header, 2. the marker where the text stops, 3. the closing claim above the attest.
+  assert.match(
+    run.stdout,
+    new RegExp(`CONTRIBUTING — ${total} chars \\(first 4000 shown, ${withheld} NOT shown\\)`),
+    run.stdout,
+  );
+  assert.match(
+    run.stdout,
+    new RegExp(`⟪ ${withheld} more characters of CONTRIBUTING are NOT shown above`),
+    run.stdout,
+  );
+  assert.match(
+    run.stdout,
+    new RegExp(`BUT ${withheld} of those ${total} characters are not shown above`),
+    run.stdout,
+  );
   assert.match(run.stdout, /The scanner read them; you have not/, run.stdout);
   // The ban really is invisible — that is the harm the notice exists to disclose, not to remove.
   assert.equal(run.stdout.includes(missedBan), false, "precondition: the ban is past the limit");
   // And the closing claim above the attest is qualified rather than a clean bill of health.
   assert.equal(
-    run.stdout.includes(`no ban statement matched in ${long.length} chars from CONTRIBUTING.`),
+    run.stdout.includes(`no ban statement matched in ${total} chars from CONTRIBUTING.`),
     false,
     run.stdout.slice(-600),
   );
+});
+
+/**
+ * ISSUE #78, AS A CLASS — the assertion round 1 of this sweep did not have.
+ *
+ * Round 1 closed two sinks (`runFailureDetail`, `resolveToolchain`) and its tests named those two
+ * sinks. A test that names call sites cannot see a third, and there were at least nine more: seven
+ * raw `fail()` sites in `witness.ts` interpolating a `setupCommand`'s output from inside the
+ * untrusted clone, the freeze excerpt (the target repository's own CONTRIBUTING/AGENTS.md, third
+ * -party text with LESS containment than witnessed stdout — nothing sandboxes a fetched document),
+ * and `policy.matchedPhrases`, which are substrings of that same text.
+ *
+ * The freeze one defeated the fix landed beside it. A hostile `CONTRIBUTING.md` placing `\x1b[8m`
+ * (SGR conceal, never reset) early in its text hides every line a terminal paints after it — which
+ * is every disclosure issue #77 added. On this tree before the boundary, with the conceal at index
+ * 178, the end-of-excerpt marker, the "scanner read them; you have not" line, the verdict and the
+ * "high-recall suggester, not the arbiter" line ALL fell after it. The only surviving disclosure was
+ * the header, which `packet.ts`'s own comment calls inadequate. A repository that did not want to be
+ * read could suppress the notice telling the operator it had not been read.
+ *
+ * So this asserts over the CLASS, not over sinks: whatever the verb, whatever the route the bytes
+ * took in, nothing a terminal ACTS on reaches the operator. The boundary is on the process's own
+ * streams (`terminal.ts`), so a tenth sink is behind it the day it is written; `terminal.test.ts`
+ * holds the other half — that every entry point installs it.
+ */
+const ACTIONABLE_BYTE = /[\x00-\x08\x0b-\x1f\x7f-\x9f]/;
+/** OSC 52 (clipboard write), SGR conceal, CR repaint, screen clear, and both 8-bit introducers. */
+const HOSTILE_BYTES = "\x1b]52;c;cm0gLXJmIH4=\x07\x1b[8m\r\x1b[2J\x9b31m\x9d0;pwned\x07";
+
+function hostilePacketState(): FactoryState {
+  const seed = seedState();
+  // Four independent third-party routes into the render, in one packet.
+  const packet = buildPacket({
+    repoId: "mcp-use/mcp-use",
+    issueNumber: 999,
+    // 1. the issue title — GitHub's bytes, rendered by `body`, `evidence-page`, `status`, `ledger`.
+    issueTitle: `docs typo ${HOSTILE_BYTES}`,
+    issueUrl: "https://github.com/mcp-use/mcp-use/issues/999",
+    // 2. the freeze excerpt, with the conceal placed early enough to hide every #77 disclosure, and
+    //    3. a document long enough that there IS something withheld to disclose.
+    contributing: `Thanks for contributing!${HOSTILE_BYTES}\n${"Please read the guidelines below before opening a pull request.\n".repeat(200).slice(0, 5000)}`,
+    // 4. a matched phrase — the scanner quotes the repository's own words back at the operator.
+    agentsMd: `AI-generated pull requests ${HOSTILE_BYTES} are not welcome in this repository.`,
+  });
+  assert.equal(packet.policy.code, "DENY_FORBIDDEN", "the fixture must reach the matched-phrase branch");
+  assert.ok(
+    packet.policy.matchedPhrases.some((q) => q.includes("52;c;")),
+    "precondition: the hostile bytes really are inside a quoted phrase",
+  );
+  return { ...seed, packets: [packet, ...seed.packets.filter((p) => p.status !== "submitted")] };
+}
+
+test("no byte a terminal acts on reaches the operator, whatever the verb and whatever the route", () => {
+  const state = hostilePacketState();
+  const id = state.packets[0].id;
+  const path = writeState(state);
+
+  // Every verb that renders a packet. `approve` refuses this one (the scanner matched a ban) but
+  // still prints the freeze first, which is the surface under test.
+  for (const args of [
+    ["approve", id, "--note", "n", "--by", "ravidsrk"],
+    ["body", id],
+    ["evidence-page", id],
+    ["status"],
+    ["ledger"],
+  ]) {
+    const stub = githubStub("record");
+    const run = runCli([...args, "--state", path], tmpdir(), { preload: stub.preload });
+    assert.equal(
+      ACTIONABLE_BYTE.test(run.out),
+      false,
+      `\`${args[0]}\` put a control byte on the operator's terminal: ${JSON.stringify(run.out.slice(0, 400))}`,
+    );
+    assert.equal(run.out.includes("52;c;"), false, `\`${args[0]}\` left an OSC 52 body one concatenation from working`);
+  }
+});
+
+test("a hostile CONTRIBUTING cannot conceal the disclosure that it was not fully shown", () => {
+  // The composed attack, named as its own test because it is the one that defeats issue #77 rather
+  // than merely being ugly: strip the conceal and every #77 disclosure is on the screen again.
+  const state = hostilePacketState();
+  const path = writeState(state);
+  const stub = githubStub("record");
+  const run = runCli(["approve", state.packets[0].id, "--note", "n", "--state", path], tmpdir(), {
+    preload: stub.preload,
+  });
+  assert.equal(run.code, 1, "a matched ban must still refuse the approval");
+
+  assert.equal(run.stdout.includes("\x1b[8m"), false, "the conceal must not reach the terminal");
+  for (const disclosure of [/NOT shown/, /The scanner read them; you have not/, /Verdict: DENY_FORBIDDEN/, /high-recall suggester/]) {
+    assert.match(run.stdout, disclosure, run.stdout.slice(0, 600));
+  }
+  // The removal is stated rather than tidied away in silence: a sanitiser that hands the operator a
+  // coherent transcript with no sign that the coherence was ours is itself a concealment channel.
+  assert.match(run.stdout, /byte\(s\) of terminal control sequence removed/, run.stdout.slice(-800));
 });
 
 test("approve prints the policy text before the competing-work reads, not after them", () => {
@@ -1661,6 +1791,77 @@ test("the revert verb refuses a rollback past the 30-day window and writes nothi
     new RegExp(`${repoId}\\s+opened=\\d+ merged=\\d+ tone=\\w+ health=stop`),
     `an out-of-window revert must not stop the repo:\n${status.stdout}`,
   );
+});
+
+/**
+ * The operator's path to the SPEC.md §7 MUST, which round 1 of #81 closed off (round 2).
+ *
+ * The window predicate was shared; the SUBJECT was not. `classifyRevert` passes the reverting
+ * commit's `committedAt`. `applyRevert` takes `at` — and this verb never supplied one, so it
+ * defaulted to `now()`, the moment the operator typed. There was no `--at`, and therefore no way at
+ * all to record a rollback that happened before today.
+ *
+ * The scenario below is the one that made it a defect rather than an inconvenience: a maintainer
+ * rolls our merge back on day 10 and says so in a thread; the operator reads the thread on day 35.
+ * `reconcile` would have recorded that rollback and stopped the repository. The verb refused it —
+ * "35 days after the merge" — and left `health()` reading `good`. Same rollback, opposite answers,
+ * in the safety-relevant direction, with the operator holding no verb that could satisfy the MUST.
+ */
+test("revert dates the window from the rollback the operator names, not from when they typed", () => {
+  const seed = seedState();
+  const id = "pkt_ravidsrk_frontguard_195";
+  const packet = seed.packets.find((p) => p.id === id)!;
+  const repoId = packet.repoId;
+  // Merged 35 days ago, so "now" — the default — is outside the window and the day-10 rollback is
+  // inside it. Anchored to the clock rather than to a literal, because the default IS the clock.
+  const mergedMs = Date.now() - 35 * 86_400_000;
+  const mergedAt = new Date(mergedMs).toISOString();
+  const rollbackAt = new Date(mergedMs + 10 * 86_400_000).toISOString();
+  const aged = (): FactoryState => ({
+    ...seed,
+    packets: seed.packets.map((p) => (p.id === id ? { ...p, prMeta: { ...p.prMeta!, mergedAt } } : p)),
+  });
+  const reason = "maintainer rolled it back on day 10 and said so in the thread";
+  const rowOf = (path: string) =>
+    (JSON.parse(readFileSync(path, "utf8")) as FactoryState).scorecard.find((r) => r.repoId === repoId)!;
+
+  // Undated: the operator is recording as of now, and now is out of window. Refused, nothing
+  // written — and the refusal names the flag that fixes it, which is the whole of issue #35's rule.
+  const undatedPath = writeState(aged());
+  const undated = runCli(["revert", id, "--reason", reason, "--state", undatedPath], tmpdir());
+  assert.equal(undated.code, 1, undated.out);
+  assert.match(undated.out, /30-day window/, undated.out);
+  assert.match(undated.out, /--at <iso>/, undated.out);
+  assert.equal(rowOf(undatedPath).reverts, 0);
+
+  // Dated by the event: recorded, and the repository is stopped — which is what `reconcile` would
+  // have done with the same rollback, and the disagreement this closes.
+  const datedPath = writeState(aged());
+  const dated = runCli(
+    ["revert", id, "--reason", reason, "--at", rollbackAt, "--state", datedPath],
+    tmpdir(),
+  );
+  assert.equal(dated.code, 0, dated.out);
+  assert.match(dated.stdout, /revert recorded on/, dated.stdout);
+  assert.equal(rowOf(datedPath).reverts, 1);
+  const status = runCli(["status", "--state", datedPath], tmpdir());
+  assert.match(
+    status.stdout,
+    new RegExp(`${repoId}\\s+opened=\\d+ merged=\\d+ tone=\\w+ health=stop`),
+    status.stdout,
+  );
+
+  // A date the CLI cannot parse is refused BEFORE anything is written — an unparseable `--at`
+  // silently falling back to now would be the original bug with a flag in front of it.
+  const badPath = writeState(aged());
+  const bad = runCli(["revert", id, "--reason", reason, "--at", "last Tuesday", "--state", badPath], tmpdir());
+  assert.equal(bad.code, 1, bad.out);
+  assert.match(bad.out, /not a date this can parse/, bad.out);
+  assert.equal(rowOf(badPath).reverts, 0);
+
+  // And the flag is in `--help`: a verb whose behaviour depends on a flag nobody is told about is
+  // the same defect as a refusal naming a command that does not exist.
+  assert.match(runCli(["--help"], tmpdir()).stdout, /revert <packetId> --reason <text> \[--at <iso>\]/);
 });
 
 test("sync folds the human review split into the scorecard when the PR reaches a terminal state", () => {

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -149,6 +149,29 @@ function flag(args: string[], name: string): string | undefined {
   return args[i + 1];
 }
 
+/**
+ * A flag written LAST, with nothing after it, refused instead of read as absent.
+ *
+ * `flag()` cannot tell `--at` at the end of argv from no `--at` at all: both are `undefined`. That
+ * is harmless for a flag whose absence is already an error — `revert requires --reason <text>`
+ * fires either way — and it is a silent wrong answer for a flag whose absence MEANS something.
+ *
+ * NOT GENERALISED into `flag()` itself, deliberately. `--state` and `--logs-root` have the same
+ * "absence means something" shape, but they are read during MODULE EVALUATION, so a refusal inside
+ * `flag()` would `process.exit` or throw inside whatever imported `cli.ts` — `engine.test.ts` does —
+ * rather than in front of the operator who mistyped. Applied at the one call site where a silent
+ * default is a safety verdict, and stated here so the next one is a decision rather than an
+ * oversight.
+ */
+function refuseValuelessFlag(args: string[], name: string, absenceMeans: string): void {
+  if (args.includes(name) && flag(args, name) === undefined) {
+    console.error(
+      `${name} was given no value. Pass one, or omit ${name} entirely — omitting it means ${absenceMeans}, and a trailing ${name} is not the same thing.`,
+    );
+    process.exit(1);
+  }
+}
+
 const ARGV = process.argv.slice(2);
 // The ledger belongs to the repository, not to whatever directory the operator happened to be in.
 // A cwd-relative path silently served the committed seed as live truth from anywhere else, and a
@@ -622,6 +645,12 @@ async function main() {
     // Opposite answers in the safety-relevant direction, with no operator path to the SPEC.md §7
     // MUST at all. The window dates from the EVENT on both paths now; the default is still now,
     // which is the right reading of an operator who does not say otherwise.
+    //
+    // …and a trailing `--at` with no value after it is not "now". `flag` returns `undefined` for
+    // both "no flag" and "flag at the end of argv", so `revert pkt --reason r --at` dated the
+    // window from the moment of typing — the exact failure this flag closes, reached in silence and
+    // by the operator who was trying hardest to avoid it.
+    refuseValuelessFlag(rest, "--at", "the rollback is dated now");
     const at = flag(rest, "--at");
     if (at !== undefined && !Number.isFinite(Date.parse(at))) {
       console.error(

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -1128,7 +1128,6 @@ async function main() {
         revert: reverted?.ok ? reverted.verdict : undefined,
         // Same fact the clock reads (issue #39 round 2): a page-capped commit read is not a clean
         // one, and both consumers must say so or the two verbs disagree about what was checked.
-        revertTruncated: reverted?.ok ? reverted.truncated : undefined,
       });
       doctrine.push(...checks.fatal);
       owed.push(...checks.advisory);

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -68,12 +68,34 @@ import {
  * The sha256 on the evidence page is only proof if the maintainer can recompute it. Write the two
  * run logs at the repo-root-relative paths the witness names, so the digest is checkable on disk.
  * `root` exists so this is drivable against a scratch tree instead of the operator's checkout.
+ *
+ * The default is `LOGS_ROOT`, not `"."` (issue #80). A cwd default made this the WRITE half of the
+ * same mismatch `readIfPresent` had on the read half: run the verb from outside the checkout and
+ * the logs land beside the operator's shell while the evidence page keeps naming
+ * `docs/evidence/logs/...` inside the repository — a recompute offer pointing at files that are not
+ * there. Read and write anchor to the same value, because they name the same two files.
  */
 export function persistWitnessLogs(
   witness: EvidenceWitness,
   logs: WitnessLogs,
-  root = ".",
+  root = LOGS_ROOT,
 ): void {
+  // The other half of anchoring, exactly as `persist` is for the ledger.
+  //
+  // Before this, a spawned-CLI test was isolated by its temp `cwd` for free. Anchoring `LOGS_ROOT`
+  // to the repo root takes that away, so a test that forgets `--logs-root` writes two run logs into
+  // the developer's real checkout — which is not hypothetical: an intermediate state of issue #80's
+  // own fix did precisely that, and the files were sitting in `docs/evidence/logs/` afterwards.
+  // Refused at the write and not at the resolve, because resolving the default path is a legitimate
+  // thing for a test to assert — that is how the anchoring itself is proven; it is the mutation that
+  // leaks. `NODE_TEST_CONTEXT` is set by `node --test` and inherited by spawned children, so this is
+  // inert for a real operator. An explicit `root` argument is a caller who has said where they mean.
+  if (root === LOGS_ROOT && !LOGS_ROOT_FLAG && process.env.NODE_TEST_CONTEXT) {
+    console.error(
+      `refusing to write the repo-root run logs under ${LOGS_ROOT} from a test run — pass \`--logs-root <tmpdir>\` to every spawned CLI so the test cannot write into the real checkout.`,
+    );
+    process.exit(1);
+  }
   for (const [path, text] of [
     [witness.testLogPath, logs.test],
     [witness.revertLogPath, logs.revert],
@@ -84,9 +106,37 @@ export function persistWitnessLogs(
   }
 }
 
-function readIfPresent(path: string): string | undefined {
+/**
+ * Read a path the OPERATOR typed on the command line. Cwd-relative, and that is correct: when
+ * someone types `--manifest ./witness.json`, the `./` is theirs and means their shell's directory.
+ *
+ * Deliberately NOT the reader for anything the ledger or a manifest names — see `readRepoRelative`.
+ * The two are separate functions with the anchor in the name because they were one function with
+ * two call sites and one right answer between them (issue #80), and a single `readIfPresent` is an
+ * invitation for the next call site to pick the wrong anchor silently.
+ */
+function readOperatorPath(path: string): string | undefined {
   try {
     return readFileSync(resolve(path), "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Read a path that is RELATIVE TO THE REPOSITORY, not to the operator (issue #80).
+ *
+ * Witness log paths are of this kind: `witnessLogPathViolation` refuses anything that is not
+ * exactly `docs/evidence/logs/<packetId>/{test,revert}.log`, and its refusal message says in so
+ * many words that "run logs are repo-root-relative". Resolving them with a bare `resolve()` made
+ * the schema's claim false from any directory but one, so `attach-witness` reported a perfectly
+ * good witness as a missing log — the same class #43 fixed for `STATE_FILE` and left in this
+ * sibling. `LOGS_ROOT` is the anchor, `--logs-root` is the override, exactly as `STATE_FILE` and
+ * `--state` are.
+ */
+function readRepoRelative(path: string): string | undefined {
+  try {
+    return readFileSync(resolve(LOGS_ROOT, path), "utf8");
   } catch {
     return undefined;
   }
@@ -105,6 +155,26 @@ const ARGV = process.argv.slice(2);
 const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const STATE_FILE_FLAG = flag(ARGV, "--state");
 const STATE_FILE = resolve(STATE_FILE_FLAG ?? resolve(REPO_ROOT, ".foundry-state.json"));
+
+/**
+ * Where `docs/evidence/logs/<packetId>/{test,revert}.log` is rooted (issue #80).
+ *
+ * The witness log paths are repo-root-relative by schema, so the tree they resolve against is a
+ * property of the CHECKOUT, not of the operator's shell — the identical argument #43 made for the
+ * ledger, and the identical shape of fix: an anchor plus one explicit override. Exported as a
+ * function of `argv` rather than read off the constant so a test can assert the DEFAULT, which is
+ * the half an override can hide and the half the bug was in.
+ *
+ * One value for both directions on purpose. A separate read root and write root would be two places
+ * that have to agree about where two named files are, and this issue is what disagreement looks
+ * like: the reader hunting one tree while the evidence page promises another.
+ */
+export function witnessLogRootFor(argv: string[]): string {
+  const override = flag(argv, "--logs-root");
+  return override ? resolve(override) : REPO_ROOT;
+}
+const LOGS_ROOT_FLAG = flag(ARGV, "--logs-root");
+const LOGS_ROOT = witnessLogRootFor(ARGV);
 
 /**
  * Every ledger write goes through here so a test can never make one to the repo root.
@@ -215,6 +285,19 @@ async function closingRefFor(
 
 async function tickWithGithub(state: FactoryState) {
   if (hasInflight(state.packets)) return applyTick(state);
+  // Before the first request, not after the last one (issue #79).
+  //
+  // SPEC.md §6: "a platform secondary rate limit MUST halt the factory, never retry." The halt was
+  // already consulted — inside `applyTick` → `maySelectRepo`, at the bottom of this function, after
+  // the loop below had spent a `pulls`, an `AGENTS.md`, a `CONTRIBUTING`, an issue read and a
+  // timeline read for every named row on the roster. Issuing those and then refusing IS the retry
+  // the rule forbids, and it aggravates the exact limit that wrote the halt; #43 made the halt
+  // durable so a re-run could not retry, and this ordering meant every re-run retried anyway.
+  //
+  // Two gates, and both earn their place: this one decides whether to spend requests, `applyTick`'s
+  // decides what the tick's verdict is. They cannot drift, because there is one `factoryHalt` and
+  // they both call it — and `applyTick` is left to phrase the outcome so this line never has to.
+  if (factoryHalt(state)) return applyTick(state);
   const competingKeys: string[] = [];
   const adjacentKeys: string[] = [];
   const closedIssues: { key: string; reason: string }[] = [];
@@ -327,7 +410,9 @@ function usage(): void {
   clear-halt --by <name> --note <text>   (a human lifts the factory-wide rate-limit halt — not the halt above)
 
 Any command takes --state <path> to point at a different ledger.
+Any command takes --logs-root <path> to root the witness run logs somewhere other than the checkout.
 State: ${STATE_FILE} (seed if missing; refuse if present but malformed). Foundry never merges.
+Witness logs: ${LOGS_ROOT}/docs/evidence/logs/<packetId>/ (read and written there, whatever your cwd).
 Disclosure:
 ${DISCLOSURE}
 `);
@@ -383,6 +468,21 @@ async function main() {
     // the one thing the human is here to read.
     if (packetForFreeze) console.log(renderFreezeEvidence(packetForFreeze));
     if (packetForFreeze && (packetForFreeze.status === "gated" || packetForFreeze.status === "frozen")) {
+      // The selection gate, moved ahead of the network reads (issue #79). `applyApprove` runs the
+      // identical `maySelectRepo` at the bottom of this verb, so the VERDICT is unchanged — what
+      // changes is that a halted or scorecard-stopped repository stops costing GitHub requests to
+      // discover. SPEC.md §6 says never retry; three reads and then a refusal is a retry. Same
+      // pre-flight, same wording, as `open-draft` below.
+      //
+      // Deliberately AFTER the freeze evidence above and INSIDE the status guard: the render is
+      // local, and it is the one thing the human came here to read (issue #37), so a refusal must
+      // not swallow it. Inside the guard, a wrong-status packet still gets `applyApprove`'s own
+      // "cannot approve … from status …" rather than being told about a halt it never reached.
+      const gate = maySelectRepo(state, packetForFreeze.repoId);
+      if (!gate.ok) {
+        console.error(`cannot approve ${id}: ${gate.reason}`);
+        process.exit(1);
+      }
       // SPEC.md §4: the approval step re-checks for competing upstream work and stands down rather
       // than proceed. An issue closed since gating is the strongest form of that — the work is
       // already done or explicitly unwanted — and it is invisible to the open-PR half of the
@@ -694,7 +794,8 @@ async function main() {
       console.error("no testCommand for this repo");
       process.exit(1);
     }
-    const raw = readIfPresent(manifestPath);
+    // Operator-typed, so operator-anchored: `--manifest ./witness.json` means their directory.
+    const raw = readOperatorPath(manifestPath);
     if (raw === undefined) {
       console.error(`cannot read witness manifest ${manifestPath}`);
       process.exit(1);
@@ -712,7 +813,8 @@ async function main() {
       process.exit(1);
     }
     // The hashes must cover logs that exist here, or the digest on the evidence page proves nothing.
-    const logs = verifyWitnessLogs(witness, readIfPresent);
+    // Repo-root-anchored, because these are the schema's paths and not the operator's (issue #80).
+    const logs = verifyWitnessLogs(witness, readRepoRelative);
     if (!logs.ok) {
       console.error(logs.error);
       process.exit(1);

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -53,6 +53,7 @@ import { health, scorecardRow } from "./scorecard.ts";
 import { seedState } from "./seed.ts";
 import { loadFactoryState, saveFactoryState } from "./state.ts";
 import { foundryAttestedWave0Merges, ledgerSections, quietLabel } from "./status.ts";
+import { installTerminalBoundary } from "./terminal.ts";
 import { INFLIGHT_STATUSES, type EvidenceManifest, type EvidenceWitness, type FactoryState } from "./types.ts";
 import {
   hostRunner,
@@ -171,7 +172,12 @@ const STATE_FILE = resolve(STATE_FILE_FLAG ?? resolve(REPO_ROOT, ".foundry-state
  */
 export function witnessLogRootFor(argv: string[]): string {
   const override = flag(argv, "--logs-root");
-  return override ? resolve(override) : REPO_ROOT;
+  // Both branches go through `resolve()`, and the default branch needs it as much as the override:
+  // `REPO_ROOT` comes from `new URL("..", …)` and therefore carries a trailing slash, which `--help`
+  // printed straight into `…/oss-foundry//docs/evidence/logs/…`. `STATE_FILE` already normalises for
+  // the same reason one line up; a doubled slash in the one line that tells the operator where the
+  // logs are is a small thing that makes the reader doubt the rest of the sentence.
+  return resolve(override ?? REPO_ROOT);
 }
 const LOGS_ROOT_FLAG = flag(ARGV, "--logs-root");
 const LOGS_ROOT = witnessLogRootFor(ARGV);
@@ -395,7 +401,7 @@ function usage(): void {
   approve <packetId> --note <text> [--by <name>]   (identity also via FOUNDRY_OPERATOR)
   reject <packetId> --reason <text>
   halt <repoId> --reason <text>   (per-repo scorecard stop — a maintainer asked; NOT cleared by clear-halt)
-  revert <packetId> --reason <text>   (a maintainer-stated rollback naming the PR — SPEC.md §7 stop; an explicit git revert of our merge commit is found by reconcile on its own)
+  revert <packetId> --reason <text> [--at <iso>]   (a maintainer-stated rollback naming the PR — SPEC.md §7 stop; an explicit git revert of our merge commit is found by reconcile on its own. --at is WHEN THE ROLLBACK HAPPENED, which is what the 30-day window is measured from; it defaults to now)
   advance <packetId>
   evidence <packetId> --base <sha> --head <sha>   (tests + revert control run in the sandbox — witnessed, never attested; host/Wave 0 only)
   witness-check [repoId]   (pre-flight: resolve the interpreter each allowlisted testCommand would really use here, before a packet is in flight)
@@ -604,7 +610,26 @@ async function main() {
       );
       process.exit(1);
     }
-    const result = applyRevert(state, id, { source: "operator", why: reason });
+    // WHEN THE ROLLBACK HAPPENED, not when the operator typed (issue #81, round 2).
+    //
+    // `applyRevert` and `classifyRevert` share one 30-day predicate so the two halves of
+    // docs/08-operations.md's single definition cannot disagree — but they were handing it two
+    // different SUBJECTS. `classifyRevert` passes the commit's `committedAt`; this verb passed
+    // nothing, so `applyRevert` defaulted to `now()`. A maintainer who rolled our merge back on
+    // day 10 and an operator who wrote it down on day 35 therefore produced OPPOSITE verdicts from
+    // the same predicate over the same rollback: the mechanical path recorded it and halted the
+    // repo, the operator's path refused it as out of window and left `health()` reading `good`.
+    // Opposite answers in the safety-relevant direction, with no operator path to the SPEC.md §7
+    // MUST at all. The window dates from the EVENT on both paths now; the default is still now,
+    // which is the right reading of an operator who does not say otherwise.
+    const at = flag(rest, "--at");
+    if (at !== undefined && !Number.isFinite(Date.parse(at))) {
+      console.error(
+        `revert --at ${at} is not a date this can parse — pass the rollback's own timestamp as ISO-8601 (e.g. 2026-08-19T14:00:00Z). Omit --at to date it now.`,
+      );
+      process.exit(1);
+    }
+    const result = applyRevert(state, id, { source: "operator", why: reason, at });
     if (result.error) {
       console.error(result.error);
       process.exit(1);
@@ -1277,5 +1302,16 @@ function isProcessEntryPoint(): boolean {
 // Guarded so the module can be imported (by a test, or another verb) without the whole CLI running
 // and calling `process.exit`. Spawning `cli.ts` as the entry point still runs `main()` unchanged.
 if (isProcessEntryPoint()) {
+  // BEFORE `main()`, and inside this guard rather than at module scope, because the boundary is a
+  // property of *being the process*: an importer (a test, another verb) owns its own streams and
+  // must not have them rewritten underneath it.
+  //
+  // Every verb below prints third-party text somewhere — a fetched CONTRIBUTING at the freeze, a
+  // phrase quoted out of one, an issue title, a witnessed repository's stdout, a `setupCommand`'s
+  // output from inside the untrusted clone. Sanitising those at each `console.*` is a list that has
+  // to stay complete, and issue #78 shipped an incomplete one: two sinks closed, nine open. This is
+  // the same fix applied where it cannot be forgotten — a `console.log` added tomorrow, in any verb,
+  // is already behind it.
+  installTerminalBoundary();
   await main();
 }

--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -3497,6 +3497,77 @@ test("witnessed run logs are written where the schema says, and land verifiable"
   assert.equal(verifyWitnessLogs(outcome.witness, read).ok, true);
 });
 
+/**
+ * "INERT FOR A REAL OPERATOR" — the sentence written at the guard, which nothing held it to.
+ *
+ * `persistWitnessLogs` refuses to write the repo-root run logs when three things are true together:
+ * the root is the default, no `--logs-root` was given, and `NODE_TEST_CONTEXT` is set. The third
+ * conjunct is the entire reason the guard is safe to ship — and dropping it was GREEN. Every test in
+ * this suite passes `--logs-root`, so `LOGS_ROOT_FLAG` is always set and the conjunction short-
+ * circuits before the environment is ever read; the operator half of the condition was reached by
+ * nothing. Under that mutant an operator running the documented
+ * `evidence <id> --base <sha> --head <sha>` — with no `--logs-root`, which is the only way the verb
+ * is documented — is refused with "refusing to write the repo-root run logs … from a test run", and
+ * the witness they just paid for is thrown away.
+ *
+ * Driven as a child process because `NODE_TEST_CONTEXT` is set for THIS process by `node --test` and
+ * inherited by everything it spawns. An operator's shell does not have it, and that difference is
+ * the guard; a child is the only place the absence can be staged. The witness names ABSOLUTE log
+ * paths so the write lands in a temp directory instead of the developer's checkout — what is under
+ * test here is whether the guard fires, and where the default root points is pinned separately, by
+ * `witnessLogRootFor` and by the `--help` drive above.
+ *
+ * Both directions, in one test: the operator half on its own is satisfied by deleting the guard.
+ */
+test("the repo-root log-write refusal is inert for an operator and fires for a test run", () => {
+  const dir = mkdtempSync(join(tmpdir(), "foundry-operator-logs-"));
+  const script = join(dir, "persist.mjs");
+  writeFileSync(
+    script,
+    `import { persistWitnessLogs } from ${JSON.stringify(pathToFileURL(join(import.meta.dirname, "cli.ts")).href)};\n` +
+      `const [testLog, revertLog] = process.argv.slice(2);\n` +
+      // No third argument, so `root` takes its default: the production `LOGS_ROOT`.
+      `persistWitnessLogs(\n` +
+      `  { testLogPath: testLog, revertLogPath: revertLog },\n` +
+      `  { test: "42 passing", revert: "3 failing" },\n` +
+      `);\n` +
+      `console.log("PERSISTED");\n`,
+  );
+
+  // Deliberately no `--logs-root` on the child's argv: that flag is the OTHER conjunct, and passing
+  // it is exactly what every existing test does — which is why this path was never reached.
+  const persist = (label: string, nodeTestContext: string | undefined) => {
+    const env: Record<string, string> = { ...process.env, NODE_NO_WARNINGS: "1" } as Record<string, string>;
+    if (nodeTestContext === undefined) delete env.NODE_TEST_CONTEXT;
+    else env.NODE_TEST_CONTEXT = nodeTestContext;
+    const testLog = join(dir, `${label}-test.log`);
+    const revertLog = join(dir, `${label}-revert.log`);
+    const run = spawnSync(process.execPath, ["--experimental-strip-types", script, testLog, revertLog], {
+      cwd: dir,
+      encoding: "utf8",
+      env,
+    });
+    return { ...run, seen: `${run.stdout}${run.stderr}`, testLog, revertLog };
+  };
+
+  const operator = persist("operator", undefined);
+  assert.equal(operator.status, 0, operator.seen);
+  assert.doesNotMatch(
+    operator.seen,
+    /refusing to write the repo-root run logs/,
+    "an operator running `evidence` with no --logs-root was refused by a guard whose only subject is this suite",
+  );
+  assert.equal(readFileSync(operator.testLog, "utf8"), "42 passing");
+  assert.equal(readFileSync(operator.revertLog, "utf8"), "3 failing");
+
+  const underTest = persist("under-test", "child");
+  assert.equal(underTest.status, 1, underTest.seen);
+  assert.match(underTest.seen, /refusing to write the repo-root run logs/, underTest.seen);
+  assert.match(underTest.seen, /--logs-root <tmpdir>/, underTest.seen);
+  assert.equal(existsSync(underTest.testLog), false, "the refusal must refuse BEFORE it writes");
+  assert.equal(existsSync(underTest.revertLog), false);
+});
+
 // --- The `evidence` verb, driven end to end (issue #36) ---
 //
 // The persist test above calls `persistWitnessLogs` directly, so it locks the function's body and

--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -50,6 +50,7 @@ import { DISCLOSURE, FOUNDRY_REPO_URL } from "./neighbor.ts";
 import { buildPacket, renderEvidencePage, renderPrBody } from "./packet.ts";
 import { evaluatePolicy } from "./policy.ts";
 import { runSandboxDry } from "./sandbox.ts";
+import { installTerminalBoundary, sanitizeTerminalText } from "./terminal.ts";
 import {
   applyPacketToScorecard,
   applyReviewToScorecard,
@@ -2048,6 +2049,115 @@ test("a witnessed repository's output cannot write control sequences to the oper
 });
 
 /**
+ * THE NEGATIVE CONTROL for the removal notice. #77 has one; #78 shipped without it.
+ *
+ * `if (scrubbed.removed > 0)` survived being widened to `>= 0` and `${scrubbed.removed}` survived
+ * being replaced by `0`, which means the suite could not tell "we removed 46 bytes" from "we removed
+ * 0 bytes" from "we print this line on every failure". A notice that fires on every run is one the
+ * operator learns to skip, and `0 byte(s) … removed` printed over output that WAS tampered with is
+ * an affirmative false statement — the same shape of harm as `0 characters not shown`.
+ */
+test("the removal notice fires only when something was removed, and states the real count", () => {
+  const clean = runFailureDetail("npm test", "FAIL src/a.test.js\n  expected 200, got 500", "npm 10.9.2");
+  assert.match(clean, /FAIL src\/a\.test\.js/);
+  assert.equal(/removed/.test(clean), false, `a clean run must carry no removal notice:\n${clean}`);
+  assert.equal(/0 byte\(s\)/.test(clean), false, clean);
+
+  // …and when it does fire, the number is the number. Derived from the fixture rather than written
+  // down twice: the assertion has to move when the input does, or it is pinning a constant.
+  const hostile = "FAIL src/a.test.js\x1b]52;c;aGVsbG8=\x07\x1b[2J\r";
+  const removed = hostile.length - sanitizeTerminalText(hostile).text.length;
+  assert.ok(removed > 0);
+  const dirty = runFailureDetail("npm test", hostile, "npm 10.9.2");
+  assert.match(dirty, new RegExp(`^ {2}${removed} byte\\(s\\) of terminal control sequence removed`, "m"), dirty);
+});
+
+/**
+ * ISSUE #78, AS A CLASS, at the witness protocol's own refusals.
+ *
+ * `witnessEvidence` refuses through a `fail()` helper at seven places, and every one of them
+ * interpolates a step's raw output. They are not theoretical: `allowlist.yaml` carries
+ * `setupCommand: npm ci`, run with `cwd` set to the UNTRUSTED CLONE, so that repository's lifecycle
+ * scripts author every byte of `setup command failed (exit 1) — …`. Round 1 of this sweep fixed
+ * `runFailureDetail` and `resolveToolchain` and left these; three of them leak an OSC 52 body intact.
+ *
+ * The fix is not a sanitise call at each of the seven — that is the list that keeps coming up short.
+ * It is the boundary on the process's terminal streams. So this test drives the STAGES rather than
+ * naming the source lines: fail each one in turn, put its refusal through the boundary the CLI
+ * installs, and require that nothing a terminal acts on comes out. A refusal added at an eighth
+ * stage tomorrow is covered by the same loop the day it exists.
+ */
+test("no refusal the witness protocol can produce reaches the terminal with control bytes in it", async () => {
+  const OSC52 = "\x1b]52;c;cm0gLXJmIH4=\x07";
+  const hostile = `${OSC52}\x1b[8mconcealed\r\x1b[2Jrepainted\x9b31m`;
+
+  /** Fail exactly one stage; everything else answers the way a healthy clone would. */
+  const stagedRunner = (fail: string) => {
+    let setups = 0;
+    return async (cmd: string, args: string[]) => {
+      const line = [cmd, ...args].join(" ");
+      if (cmd === "run-setup") {
+        setups += 1;
+        const which = setups === 1 ? "setup" : "setup-rerun";
+        return which === fail ? { exit: 1, output: hostile } : { exit: 0, output: "" };
+      }
+      if (cmd === "run-tests@head") return fail === "head" ? { exit: 1, output: hostile } : { exit: 0, output: "ok" };
+      // `control` is the negative control STAYING GREEN — the one refusal whose trigger is an
+      // exit 0 rather than an exit 1.
+      if (cmd === "run-tests@revert") return fail === "control" ? { exit: 0, output: hostile } : { exit: 1, output: hostile };
+      if (cmd === "probe") return { exit: 0, output: `${hostile}\nnpm 10.9.2` };
+      if (cmd === "cleanup") return { exit: 0, output: "" };
+      const stage =
+        line.includes(" clone ") ? "clone"
+        : line.includes(" fetch ") ? "fetch"
+        : line.includes("checkout --detach") ? "checkout"
+        : line.includes("clean -fdx") ? "clean"
+        : line.includes(`checkout ${BASE}`) ? "revert"
+        : line.includes("diff --name-only") ? "diff"
+        : "other";
+      if (stage === fail) return { exit: 1, output: hostile };
+      if (stage === "diff") return { exit: 0, output: "src/thing.ts\n" };
+      return { exit: 0, output: "" };
+    };
+  };
+
+  const stages = ["clone", "fetch", "checkout", "setup", "clean", "setup-rerun", "revert", "head", "control"];
+  for (const stage of stages) {
+    const outcome = await witnessEvidence(
+      { ...WAVE0, testCommand: "npm test", setupCommand: "npm ci" },
+      stagedRunner(stage),
+      {},
+    );
+    assert.equal(outcome.ok, false, `stage ${stage} was supposed to refuse`);
+    if (outcome.ok) continue;
+
+    // Through the boundary the CLI installs — the same code path, not a re-implementation of it.
+    const stream: { text: string; write(chunk: unknown): boolean } = {
+      text: "",
+      write(chunk: unknown) {
+        this.text += String(chunk);
+        return true;
+      },
+    };
+    installTerminalBoundary([stream]);
+    stream.write(`${outcome.error}\n`);
+
+    assert.equal(
+      /[\x00-\x08\x0b-\x1f\x7f-\x9f]/.test(stream.text),
+      false,
+      `the ${stage} refusal put a control byte on the terminal: ${JSON.stringify(stream.text.slice(0, 300))}`,
+    );
+    assert.equal(
+      stream.text.includes("52;c;"),
+      false,
+      `the ${stage} refusal left an OSC 52 body one concatenation from working: ${JSON.stringify(stream.text.slice(0, 300))}`,
+    );
+    // The diagnostic survives the sanitising — this must not be passing by printing nothing.
+    assert.ok(stream.text.trim().length > 20, `${stage}: ${JSON.stringify(stream.text)}`);
+  }
+});
+
+/**
  * The second sink, and the reason issue #78 says "check for OTHER sinks besides this one".
  *
  * `resolveToolchain` runs `command -v <tool> && <tool> --version` through the same runner as the
@@ -3242,18 +3352,97 @@ test("attach-witness resolves witness logs against the log root, not the operato
   assert.equal(ledgerAt(gone.dir).packets[0].evidence, undefined);
 });
 
+/**
+ * The OTHER half of #80's split, and the half every fixture was hiding.
+ *
+ * `readOperatorPath` (cwd-relative) and `readRepoRelative` (log-root-relative) are two functions
+ * with the anchor in the name because they were one function with two call sites and one right
+ * answer between them. That split is the fix's central design claim — and it was unfalsifiable,
+ * because every fixture passed an ABSOLUTE `--manifest`, and `resolve()` ignores its base for an
+ * absolute path. Swapping `readOperatorPath` for `readRepoRelative` at the manifest call site left
+ * the whole suite green.
+ *
+ * So: a RELATIVE `--manifest`, typed from a cwd that is not the log root, with the file present in
+ * only one of the two trees. `--manifest ./witness.json` means the operator's shell, and nothing
+ * else can make it resolve.
+ */
+test("a relative --manifest is the operator's path, resolved against their shell and not the log root", () => {
+  const { dir, id, manifestPath, stub } = ingestFixture();
+  // The operator's shell: a third directory, holding the manifest under a name the log root does
+  // not have. If the manifest call site ever anchors to the log root, this file is invisible.
+  const shell = mkdtempSync(join(tmpdir(), "foundry-shell-"));
+  writeFileSync(join(shell, "operator-witness.json"), readFileSync(manifestPath, "utf8"));
+  assert.equal(existsSync(join(dir, "operator-witness.json")), false, "the log root must NOT hold this name");
+
+  const run = runCli(
+    shell,
+    ["attach-witness", id, "--manifest", "operator-witness.json", "--logs-root", dir],
+    stub,
+    {},
+    dir,
+  );
+  assert.equal(run.status, 0, `a relative --manifest must resolve against the operator's cwd:\n${run.seen}`);
+  assert.ok(ledgerAt(dir).packets[0].evidence, "the witness must have reached the ledger");
+
+  // The negative half, from the same shell: a relative path that names nothing still refuses, so
+  // "read anything, anywhere" cannot satisfy the assertion above.
+  const gone = ingestFixture();
+  const absent = runCli(
+    shell,
+    ["attach-witness", gone.id, "--manifest", "no-such-witness.json", "--logs-root", gone.dir],
+    gone.stub,
+    {},
+    gone.dir,
+  );
+  assert.equal(absent.status, 1, absent.seen);
+  assert.match(absent.seen, /cannot read witness manifest/);
+  assert.equal(ledgerAt(gone.dir).packets[0].evidence, undefined);
+});
+
 test("the witness log root defaults to the repository root and the state file's own anchor", async () => {
   // The default is the half an override can hide. `--logs-root` above proves the plumbing; this
   // proves that an operator who passes nothing gets the checkout rather than their shell's cwd —
   // which is the whole defect. Asserted through the CLI's own resolver so it cannot be satisfied by
   // a test-local reimplementation of the rule.
   const { witnessLogRootFor } = await import("./cli.ts");
-  const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+  // `resolve()`d, and that is the assertion, not an incidental. `new URL("..", …)` yields a path
+  // with a TRAILING SLASH, and the default branch used to return it raw while the override branch
+  // resolved — so `--help` printed `…/oss-foundry//docs/evidence/logs/<packetId>/`, a doubled slash
+  // in the one line that tells the operator where the run logs are. `STATE_FILE` normalises for the
+  // same reason; the sibling did not.
+  const repoRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+  assert.equal(repoRoot.endsWith("/"), false, "the anchor must be normalised, not merely correct");
   assert.equal(witnessLogRootFor([]), repoRoot);
   assert.equal(witnessLogRootFor(["attach-witness", "pkt_x", "--manifest", "w.json"]), repoRoot);
-  // Not the cwd: this test's own process is started in the repo root by the runner, so the two
-  // would be indistinguishable if the assertion were `!== process.cwd()`. Name the value instead.
   assert.equal(witnessLogRootFor(["--logs-root", "/tmp/elsewhere"]), resolve("/tmp/elsewhere"));
+
+  // …AND FROM A CWD THAT IS NOT THE REPOSITORY, through a spawned CLI, because nothing above can
+  // tell the anchor from the cwd. This suite runs with cwd set to the repo root, so `resolve(".")`
+  // and the anchor are the same string, and "name the value instead" — what this test used to
+  // rely on — names a value both answers produce. That is not hypothetical: replacing the default
+  // with `resolve(".")` SURVIVED every assertion above once the anchor was normalised. It had only
+  // ever been killed by the trailing slash the normalisation removed, which is a coincidence, not
+  // a test.
+  //
+  // `--help` is the surface, and it is the one an operator reads to find their run logs. Deliberately
+  // no `--logs-root` and no `--state`: the DEFAULT is the half the bug was in and the half an
+  // override hides.
+  const elsewhere = realpathSync(mkdtempSync(join(tmpdir(), "foundry-help-")));
+  const help = spawnSync(
+    process.execPath,
+    ["--experimental-strip-types", join(import.meta.dirname, "cli.ts"), "--help"],
+    { cwd: elsewhere, encoding: "utf8", env: { ...process.env, NODE_NO_WARNINGS: "1" } },
+  );
+  assert.equal(help.status, 0, help.stderr);
+  assert.ok(
+    help.stdout.includes(`Witness logs: ${repoRoot}/docs/evidence/logs/<packetId>/`),
+    `--help must name the checkout, with one slash, whatever the cwd:\n${help.stdout}`,
+  );
+  assert.equal(
+    help.stdout.includes(elsewhere),
+    false,
+    `--help named the operator's shell as the log root:\n${help.stdout}`,
+  );
 });
 
 test("attach-witness refuses a manifest that names logs outside its own packet", () => {
@@ -4026,7 +4215,15 @@ test("classifyRevert names the reverting commit, and only inside the 30-day wind
     commits: [{ sha: "dddd444", message: `This reverts commit ${merge}.`, committedAt: "2026-09-27T09:00:00Z" }],
   });
   assert.equal(late.reverted, false);
-  if (!late.reverted) assert.match(late.why, /30-day/);
+  // The COUNT as well as the rule. `const days = window.known ? window.days : 0` survives being
+  // replaced by `const days = 0`, and `days:` can be dropped from `revertWindow`'s return
+  // altogether — strip-types erases the type that would have caught either — leaving the operator
+  // reading "landed 0 days after the merge" or "landed undefined days after the merge" about a
+  // rollback that landed 31 days out.
+  if (!late.reverted) {
+    assert.match(late.why, /30-day/);
+    assert.match(late.why, /landed 31 days after the merge/, late.why);
+  }
 
   // The merge commit cannot revert itself, and nothing before the merge can revert it.
   const self = classifyRevert({
@@ -4399,6 +4596,77 @@ test("applyRevert enforces the 30-day window on the operator's path, not only th
     const note = revertNote(blind.state.packets.find((p) => p.id === id)!);
     assert.match(note?.body ?? "", /window could not be checked/i, note?.body);
   }
+});
+
+/**
+ * ONE definition, ONE predicate — and the SAME SUBJECT (issue #81, round 2).
+ *
+ * Round 1 gave both halves the shared `revertWindow`. It did not give them the same date. The
+ * classifier passes the reverting commit's `committedAt`; `applyRevert` took `at`, and the `revert`
+ * verb never supplied one, so it defaulted to `now()` — WHEN THE OPERATOR TYPED. There was no
+ * `--at`. Reproduced: merge at T0, maintainer rollback on day 10, operator records it on day 35 —
+ * `classifyRevert` + `reconcile` said `reverted: true`, `reverts: 1`, `health(): stop`; the
+ * operator's verb refused with "35 days after the merge", `reverts: 0`, `health(): good`. Identical
+ * rollback, opposite answers, in the safety-relevant direction, with no operator path to the
+ * SPEC.md §7 MUST at all. docs/08-operations.md dates the window from the EVENT in so many words:
+ * "a maintainer-stated rollback naming the PR, within 30 days of merge".
+ *
+ * A shared predicate handed two different subjects is not a shared predicate; it is two rules that
+ * happen to be spelled once.
+ */
+test("both halves of the revert definition date the window from the rollback, not from the typing", () => {
+  const seed = seedState();
+  const id = "pkt_ravidsrk_orca-fleet_71";
+  const merged = seed.packets.find((p) => p.id === id)!;
+  const mergedAt = merged.prMeta!.mergedAt!;
+  const mergedMs = Date.parse(mergedAt);
+  const day = (n: number) => new Date(mergedMs + n * 86_400_000).toISOString();
+
+  // The mechanical half, on the maintainer's rollback: day 10, well inside the window.
+  const classified = classifyRevert({
+    mergeCommitSha: merged.prMeta!.mergeCommitSha!,
+    mergedAt,
+    commits: [
+      {
+        sha: "ffff1110000",
+        message: `Revert "the thing"\n\nThis reverts commit ${merged.prMeta!.mergeCommitSha}.`,
+        committedAt: day(10),
+      },
+    ],
+  });
+  assert.equal(classified.reverted, true, "precondition: the mechanical half records a day-10 rollback");
+
+  // The operator's half, writing the SAME day-10 rollback down on day 35. Dated by the event, it
+  // agrees with the classifier; dated by the typing, it used to contradict it.
+  const recorded = applyRevert(seed, id, {
+    source: "operator",
+    why: "maintainer rolled it back on day 10; noticed in the thread today",
+    at: day(10),
+  });
+  assert.equal(recorded.recorded, true, recorded.error);
+  assert.equal(scorecardRow(recorded.state.scorecard, merged.repoId)!.reverts, 1);
+  assert.equal(health(scorecardRow(recorded.state.scorecard, merged.repoId)!), "stop");
+
+  // …and the two halves now agree about this rollback, which is the property under test.
+  assert.equal(classified.reverted, recorded.recorded);
+
+  // The refusal, when it does fire, states the three facts an operator needs to act: how late, the
+  // deadline it passed, and the flag that dates it correctly. Each is asserted separately because
+  // `--experimental-strip-types` erases the types around them: `deadline:` and `days:` can both be
+  // dropped from `revertWindow`'s return and the refusal would read "closed undefined" /
+  // "undefined days after the merge" with nothing to notice.
+  const late = applyRevert(seed, id, { source: "operator", why: "rolled back", at: day(35) });
+  assert.equal(late.recorded, false);
+  const error = late.error ?? "";
+  assert.match(error, /the rollback is dated 2026-/, error);
+  assert.match(error, /\b35 days after the merge\b/, error);
+  assert.match(error, new RegExp(`closed ${day(30).replace(/[.]/g, "\\.")}`), error);
+  assert.match(error, /`--at <iso>`/, error);
+  assert.doesNotMatch(error, /undefined/, error);
+  // A refusal that names a command the operator cannot type is the defect issue #35 was filed
+  // against, and this message carried one: "Record it as a follow-up note instead" named a verb
+  // that does not exist — 18 verbs in `--help`, none of them records a note.
+  assert.doesNotMatch(error, /follow-up note/i, error);
 });
 
 test("a recorded revert points the operator at the seed, never at allowlist.yaml", () => {

--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -60,6 +60,7 @@ import {
   health,
   revertNote,
   scorecardRow,
+  revertWindow,
 } from "./scorecard.ts";
 import { seedState } from "./seed.ts";
 import { loadFactoryState } from "./state.ts";
@@ -4295,6 +4296,39 @@ test("classifyRevert names the reverting commit, and only inside the 30-day wind
     assert.match(late.why, /30-day/);
     assert.match(late.why, /landed 31 days after the merge/, late.why);
   }
+
+  // A rollback dated BEFORE the merge is impossible, and the window must say so on BOTH paths.
+  // `classifyRevert` filters it in its own loop (`at < mergedMs`), so the shared predicate was
+  // never asked; the operator path, which reaches `revertWindow` directly with `--at`, was. An
+  // upper-bound-only comparison accepted a negative-day rollback, incremented `reverts`, and
+  // `health()` turns that into a permanent `stop` — a repository retired on an impossible date.
+  const preMerge = revertWindow(mergedAt, "2026-08-17T09:00:00Z");
+  assert.equal(preMerge.known, true);
+  if (preMerge.known) {
+    assert.equal(preMerge.within, false, "a rollback dated before the merge is not inside the window");
+    assert.ok(preMerge.days < 0, `days must show the impossibility, got ${preMerge.days}`);
+  }
+  // And the refusal must describe the mistake it refused. The late-rollback paragraph tells the
+  // operator their date is "past the window that closed" and advises re-dating it EARLIER — both
+  // false, and the second actively wrong, for a date before the merge.
+  const preMergeSeed = seedState();
+  const preMergePacket = preMergeSeed.packets.find((k) => k.id === "pkt_ravidsrk_orca-fleet_42")!;
+  const preMergeAt = new Date(Date.parse(preMergePacket.prMeta!.mergedAt!) - 10 * 86_400_000).toISOString();
+  const preMergeState = applyRevert(preMergeSeed, preMergePacket.id, {
+    source: "operator",
+    why: "maintainer said so",
+    at: preMergeAt,
+  });
+  assert.equal(preMergeState.recorded, false, "a pre-merge rollback must not be recorded");
+  assert.match(preMergeState.error!, /BEFORE the merge/, preMergeState.error);
+  assert.doesNotMatch(preMergeState.error!, /past the 30-day window/, preMergeState.error);
+  assert.doesNotMatch(preMergeState.error!, /-\d+ days after the merge/, preMergeState.error);
+  // The repo stays selectable: an impossible date must not retire it.
+  assert.equal(repoHealth(preMergeState.state.scorecard, preMergePacket.repoId), "good");
+
+  // The bound is closed at the merge instant itself, not one millisecond after it.
+  const atMerge = revertWindow(mergedAt, mergedAt);
+  if (atMerge.known) assert.equal(atMerge.within, true, "a rollback at the merge instant is inside the window");
 
   // The merge commit cannot revert itself, and nothing before the merge can revert it.
   const self = classifyRevert({

--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -3,8 +3,8 @@ import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
-import { pathToFileURL } from "node:url";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { after, test } from "node:test";
 import { ALLOWLIST, CAPS, repoById } from "./allowlist.ts";
 import {
@@ -40,6 +40,7 @@ import { packetChecks, packetDivergences } from "./ledger-check.ts";
 import {
   commandTools,
   isTestPath,
+  resolveToolchain,
   runFailureDetail,
   toolchainLabel,
   verifyWitnessLogs,
@@ -1988,6 +1989,91 @@ test("a refusal names the toolchain when it knows one and stays silent when it d
   assert.match(unknown, /^ {2}command: python3 -m pytest$/m, unknown);
 });
 
+/**
+ * The witnessed repository is third-party code, run in a sandbox precisely because it is not
+ * trusted — and until issue #78 its stdout/stderr reached `console.error` with only a trailing
+ * -whitespace trim and a tail slice between it and the operator's terminal.
+ *
+ * That is not a rendering nit. This surface's ENTIRE job is to tell a human what actually happened,
+ * and control sequences let the output rewrite the story it is part of: `\r` plus a cursor move
+ * repaints a red witness as green, `\x1b[2J` scrolls the real failure away, and OSC 52 asks the
+ * terminal itself to take an action (a clipboard write) that has nothing to do with printing text.
+ * #41 added this block because a silent refusal was indistinguishable from a broken interpreter;
+ * printing it raw reopens the same question one level up — can the operator trust what they just
+ * read?
+ *
+ * `\n` and `\t` survive, because they are how a test log is shaped and stripping them would destroy
+ * the diagnostic this block exists to carry.
+ */
+test("a witnessed repository's output cannot write control sequences to the operator's console", () => {
+  const ESC = "\x1b";
+  const hostile = [
+    "FAIL src/thing.test.js",
+    `${ESC}[2J${ESC}[H`, // clear screen, home the cursor: scroll the real failure away
+    `${ESC}]52;c;aGVsbG8=\x07`, // OSC 52: ask the terminal to write the clipboard
+    "3 failing\rnegative control passed, 0 failing", // CR repaint: forge a green verdict over a red one
+    `${ESC}[32mall green${ESC}[0m`,
+    "\x07\x08\x1b[1;1H", // BEL, BS, cursor home
+    "\x9b31m", // a bare C1 CSI — the 8-bit form, which a naive `\x1b`-only strip misses
+  ].join("\n");
+
+  const detail = runFailureDetail("npm test", hostile, "npm 10.9.2");
+
+  for (const [name, needle] of [
+    ["ESC", ESC],
+    ["BEL", "\x07"],
+    ["BS", "\x08"],
+    ["CR", "\r"],
+    ["C1 CSI", "\x9b"],
+  ] as const) {
+    assert.equal(detail.includes(needle), false, `${name} reached the console: ${JSON.stringify(detail)}`);
+  }
+  assert.equal(/[\x00-\x08\x0b-\x1f\x7f-\x9f]/.test(detail), false, JSON.stringify(detail));
+  // The whole OSC payload goes, not just its introducer — a stripped `\x1b` leaving `]52;c;…`
+  // behind would be a terminal action reassembled by the next thing to touch this text.
+  assert.equal(detail.includes("]52;c;"), false, JSON.stringify(detail));
+  // `\x9b` IS `\x1b[`, so its parameters must go with it. A strip that removed only the
+  // introducer would leave `31m` behind as text — harmless, but it would mean the 8-bit form was
+  // never actually understood, and the next sequence it meets may not be so forgiving.
+  assert.equal(detail.includes("31m"), false, JSON.stringify(detail));
+
+  // Sanitising must not become its own concealment channel: the readable text survives, and the
+  // operator is told that something was removed rather than handed a quietly tidied transcript.
+  assert.match(detail, /FAIL src\/thing\.test\.js/, detail);
+  assert.match(detail, /3 failing/, detail);
+  assert.match(detail, /control sequence/i, detail);
+  // Newlines and tabs are the shape of a log, and they stay.
+  assert.match(detail, /^ {2}\| FAIL src\/thing\.test\.js$/m, detail);
+  assert.equal(runFailureDetail("npm test", "a\tb").includes("\t"), true);
+});
+
+/**
+ * The second sink, and the reason issue #78 says "check for OTHER sinks besides this one".
+ *
+ * `resolveToolchain` runs `command -v <tool> && <tool> --version` through the same runner as the
+ * test phases and, inside `witnessEvidence`, with `cwd` set to the CLONE — so the probe's output is
+ * as repository-controlled as the test output is. A repo that ships the tool the `testCommand`
+ * names (`./scripts/test.sh` is a legal tool token) chooses every byte of both lines this reads.
+ * `witness-check` prints `tool.path` straight to the operator's terminal.
+ */
+test("the toolchain probe's output cannot write control sequences either", async () => {
+  const ESC = "\x1b";
+  const { runner } = fakeRunner({
+    "probe command -v python3": {
+      exit: 0,
+      output: `/opt/homebrew/bin/python3${ESC}[2K\r/usr/bin/false\nPython${ESC}]0;pwned\x07 3.14.7\n`,
+    },
+  });
+  const resolved = await resolveToolchain("python3 -m pytest", runner);
+  const probed = resolved[0]!;
+  assert.equal(/[\x00-\x08\x0b-\x1f\x7f-\x9f]/.test(probed.path ?? ""), false, probed.path);
+  assert.equal(/[\x00-\x08\x0b-\x1f\x7f-\x9f]/.test(probed.raw ?? ""), false, probed.raw);
+  assert.equal((probed.path ?? "").includes("]0;"), false, probed.path);
+  assert.equal((probed.raw ?? "").includes("]0;"), false, probed.raw);
+  // Still resolved: the point is to clean the report, not to lose it.
+  assert.equal(probed.version, "3.14.7");
+});
+
 test("the witness records the toolchain that produced the green, resolved inside the clone", async () => {
   const { runner, calls, cwds } = fakeRunner({
     "probe command -v python3": { exit: 0, output: "/opt/homebrew/bin/python3\nPython 3.14.7\n" },
@@ -2984,7 +3070,19 @@ function writeCompareStub(dir: string, issueNumber: number, filesChanged = 1): s
   return stub;
 }
 
-function runCli(dir: string, args: string[], stub?: string, env: Record<string, string> = {}) {
+function runCli(
+  dir: string,
+  args: string[],
+  stub?: string,
+  env: Record<string, string> = {},
+  // Where the fixture's ledger lives, when that is deliberately NOT the cwd the child is started
+  // in. Issue #80: witness log paths used to be found only because `cwd` happened to be the
+  // fixture, so a test that proves the anchor has to be able to separate the two.
+  stateDir: string = dir,
+  // Only the guard test sets this: it needs a spawned CLI that FORGOT `--logs-root`, which is the
+  // one thing every other caller here is careful never to be.
+  omitLogsRoot = false,
+) {
   const nodeArgs = ["--experimental-strip-types"];
   if (stub) nodeArgs.push("--import", pathToFileURL(stub).href);
   // `--state` is what isolates this, not `cwd`: the ledger path is anchored to the repo root, so a
@@ -2992,8 +3090,13 @@ function runCli(dir: string, args: string[], stub?: string, env: Record<string, 
   // which temp directory it was started in. Every fixture here writes its ledger to
   // `<dir>/.foundry-state.json`, so point the child at that one unless a caller is deliberately
   // exercising some other path. `cwd` still matters — the witness log paths are relative to it.
-  const stateArgs = args.includes("--state") ? [] : ["--state", join(dir, ".foundry-state.json")];
-  nodeArgs.push(join(import.meta.dirname, "cli.ts"), ...args, ...stateArgs);
+  const stateArgs = args.includes("--state") ? [] : ["--state", join(stateDir, ".foundry-state.json")];
+  // …and the same for the witness log root (issue #80). These fixtures used to find their logs
+  // because `cwd` happened to be the fixture tree, which is precisely the resolution rule the issue
+  // is about: the tests were isolated by the defect. Anchored explicitly, like the ledger, so the
+  // isolation survives the fix and a test that wants a foreign cwd can have one.
+  const logArgs = args.includes("--logs-root") || omitLogsRoot ? [] : ["--logs-root", stateDir];
+  nodeArgs.push(join(import.meta.dirname, "cli.ts"), ...args, ...stateArgs, ...logArgs);
   const run = spawnSync(process.execPath, nodeArgs, {
     cwd: dir,
     encoding: "utf8",
@@ -3097,6 +3200,60 @@ test("attach-witness refuses when a run log on disk is not what was witnessed", 
   assert.equal(missing.status, 1, missing.seen);
   assert.match(missing.seen, /missing or unreadable/);
   assert.equal(ledgerAt(gone.dir).packets[0].evidence, undefined);
+});
+
+/**
+ * Issue #80 — the eighth time in this run a fix landed on one call site and not its sibling.
+ *
+ * #43 anchored `STATE_FILE` to the repository root and gave it a `--state` override, because "the
+ * ledger belongs to the repository, not to whatever directory the operator happened to be in".
+ * Witness log paths are the same kind of path — `witnessLogPathViolation` refuses anything that is
+ * not exactly `docs/evidence/logs/<packetId>/{test,revert}.log`, and its own refusal message says
+ * "run logs are repo-root-relative" — but `readIfPresent` resolved them with a bare `resolve()`,
+ * which is cwd-relative. So the schema said one thing and the reader did another, and an operator
+ * who ran `attach-witness` from anywhere but the repository root had a valid witness rejected as a
+ * missing log.
+ *
+ * The cwd here is deliberately NOT the fixture. Before this, `cwd` was the only thing that made
+ * these tests find their logs — the suite was pinning the defect, and the fix could not be red.
+ */
+test("attach-witness resolves witness logs against the log root, not the operator's cwd", () => {
+  const { dir, id, manifestPath, stub } = ingestFixture();
+  // Run from a directory that is neither the fixture nor the repository: the only thing that can
+  // make the logs findable is the anchor.
+  const elsewhere = mkdtempSync(join(tmpdir(), "foundry-elsewhere-"));
+  const run = runCli(elsewhere, ["attach-witness", id, "--manifest", manifestPath, "--logs-root", dir], stub, {}, dir);
+  assert.equal(run.status, 0, `a valid witness must ingest from any cwd:\n${run.seen}`);
+  assert.ok(ledgerAt(dir).packets[0].evidence, "the witness must have reached the ledger");
+
+  // The negative case, from the same foreign cwd: a genuinely missing log still refuses. Without
+  // this, "anchor everything to a directory that happens to contain the logs" would also pass.
+  const gone = ingestFixture();
+  rmSync(join(gone.dir, "docs", "evidence", "logs", gone.id, "test.log"));
+  const missing = runCli(
+    elsewhere,
+    ["attach-witness", gone.id, "--manifest", gone.manifestPath, "--logs-root", gone.dir],
+    gone.stub,
+    {},
+    gone.dir,
+  );
+  assert.equal(missing.status, 1, missing.seen);
+  assert.match(missing.seen, /missing or unreadable/);
+  assert.equal(ledgerAt(gone.dir).packets[0].evidence, undefined);
+});
+
+test("the witness log root defaults to the repository root and the state file's own anchor", async () => {
+  // The default is the half an override can hide. `--logs-root` above proves the plumbing; this
+  // proves that an operator who passes nothing gets the checkout rather than their shell's cwd —
+  // which is the whole defect. Asserted through the CLI's own resolver so it cannot be satisfied by
+  // a test-local reimplementation of the rule.
+  const { witnessLogRootFor } = await import("./cli.ts");
+  const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+  assert.equal(witnessLogRootFor([]), repoRoot);
+  assert.equal(witnessLogRootFor(["attach-witness", "pkt_x", "--manifest", "w.json"]), repoRoot);
+  // Not the cwd: this test's own process is started in the repo root by the runner, so the two
+  // would be indistinguishable if the assertion were `!== process.cwd()`. Name the value instead.
+  assert.equal(witnessLogRootFor(["--logs-root", "/tmp/elsewhere"]), resolve("/tmp/elsewhere"));
 });
 
 test("attach-witness refuses a manifest that names logs outside its own packet", () => {
@@ -3354,8 +3511,12 @@ function evidenceFixture(filesChanged = 2, message = "fix the answer\n\nFixes #7
     HOME: home,
     PATH: `${git.binDir}:${process.env.PATH ?? ""}`,
   };
-  const runEvidence = () =>
-    runCli(dir, ["evidence", id, "--base", origin.base, "--head", origin.head], stub, childEnv);
+  // `from` exists so the WRITE side of issue #80 can be observed. With cwd and the log root the
+  // same directory — which is what every caller here wants — a `persistWitnessLogs` that resolved
+  // against `"."` and one that resolved against the anchor put the files in the identical place,
+  // so no assertion could tell them apart. Separating the two is the only thing that can.
+  const runEvidence = (from: string = dir, omitLogsRoot = false) =>
+    runCli(from, ["evidence", id, "--base", origin.base, "--head", origin.head], stub, childEnv, dir, omitLogsRoot);
   /** The pre-flight, run from the same working directory and the same environment as the witness. */
   const runWitnessCheck = () => runCli(dir, ["witness-check", "ravidsrk/orca-fleet"], stub, childEnv);
   return { dir, id, origin, logPaths, runEvidence, runWitnessCheck, gitCalls: git.calls };
@@ -3369,6 +3530,70 @@ function exists(path: string): boolean {
     return false;
   }
 }
+
+test("a spawned CLI that forgot --logs-root refuses rather than writing into the real checkout", () => {
+  // The cost of anchoring, and the half of #43 that has to come with it.
+  //
+  // `persist` carries this comment for the ledger: "Anchoring `STATE_FILE` took away the isolation
+  // that spawned-CLI tests were getting for free from a temp cwd: with the path fixed to the repo
+  // root, a test that forgets `--state` reads and writes the developer's real ledger, and the damage
+  // lands in whichever *other* test file reads it next." Anchoring `LOGS_ROOT` does the identical
+  // thing to the run logs, and it is not hypothetical — an intermediate state of this very change
+  // left two real run logs sitting in `docs/evidence/logs/` in the working checkout.
+  //
+  // Same guard, same shape, same reason: refuse at the WRITE, only for the un-overridden repo-root
+  // default, and only under `node --test` (`NODE_TEST_CONTEXT`), so it is inert for an operator.
+  const { dir, id, runEvidence } = evidenceFixture();
+  const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+  const leaked = join(repoRoot, "docs", "evidence", "logs", id);
+  // Scrubbed FIRST, so the assertion below is about this run and not about the tree's history. It
+  // also keeps the mutant that disables the guard from poisoning the next baseline: without this,
+  // proving the guard matters would leave behind the very artifact the guard exists to prevent.
+  rmSync(leaked, { recursive: true, force: true });
+
+  const run = runEvidence(dir, true);
+  assert.equal(run.status, 1, `a forgotten --logs-root must refuse:\n${run.seen}`);
+  assert.match(run.seen, /refusing to write .* run logs?/i, run.seen);
+  assert.match(run.seen, /--logs-root/, run.seen);
+  // The claim is the filesystem, not the message: nothing may reach the real checkout.
+  assert.equal(
+    exists(join(leaked, "test.log")),
+    false,
+    "a test run must never write run logs into the developer's own checkout",
+  );
+  rmSync(leaked, { recursive: true, force: true });
+});
+
+test("the evidence verb writes its run logs under the log root, not beside the operator's shell", () => {
+  // The WRITE half of issue #80, and the half the first pass of this fix left untested — the
+  // mutation audit found it by putting `persistWitnessLogs`'s default back to `"."` and watching
+  // the whole suite stay green. Which is the defect this repository keeps shipping, arriving one
+  // more time inside the change that was meant to close it: the read anchor had a test, its sibling
+  // did not, and the two were indistinguishable as long as cwd happened to be the log root.
+  //
+  // What it would cost: the ledger records `docs/evidence/logs/<id>/test.log` and the evidence page
+  // offers a maintainer `shasum -a 256` over that path in the Foundry checkout — while the bytes
+  // sit in whatever directory the operator was standing in. The recompute offer, which is the whole
+  // proof, resolves to nothing.
+  const { dir, id, logPaths, runEvidence } = evidenceFixture();
+  const elsewhere = evidenceScratchDir("foundry-evidence-cwd-");
+
+  const run = runEvidence(elsewhere);
+  assert.equal(run.status, 0, run.seen);
+  for (const path of logPaths) {
+    assert.ok(exists(path), `${path} was never written from a foreign cwd: ${run.seen}`);
+  }
+  // …and nothing was written next to the shell instead.
+  assert.equal(
+    exists(join(elsewhere, "docs", "evidence", "logs", id, "test.log")),
+    false,
+    "run logs must not land in the operator's working directory",
+  );
+  // The ledger's own claim about where they are still holds, which is what a maintainer acts on.
+  const witness = ledgerAt(dir).packets[0].evidence?.witness;
+  assert.equal(witness?.testLogPath, `docs/evidence/logs/${id}/test.log`);
+  assert.ok(exists(join(dir, witness!.testLogPath)), "the ledger's path must resolve under the log root");
+});
 
 test("the evidence verb writes the run logs its own ledger entry points at", () => {
   const { dir, id, origin, logPaths, runEvidence } = evidenceFixture();
@@ -4097,6 +4322,83 @@ test("applyRevert refuses a packet that was never merged, and one it has never h
 
   const unknown = applyRevert(state, "pkt_nope", { source: "operator", why: "x" });
   assert.match(unknown.error ?? "", /unknown packet/);
+});
+
+/**
+ * ONE definition of "a revert", enforced on both of its paths (issue #81).
+ *
+ * docs/08-operations.md says a revert counts "within 30 days of merge". `classifyRevert` makes that
+ * structural for the mechanical path — a commit past the deadline is set aside with a reason and
+ * `reverted: false` comes back. The operator's `revert` verb went straight to `applyRevert` with no
+ * deadline anywhere, so the SAME rollback, of the SAME merge, on the SAME day, was a no-op through
+ * one door and a permanent repository stop through the other: `reverts` is cumulative and
+ * `health()` turns `reverts > 0` into an unconditional `stop`, which only a hand edit of the
+ * scorecard row in `factory/seed.ts` can undo.
+ *
+ * Refuse rather than record-without-halting, because the counter and the halt are the same fact:
+ * `health()` reads `reverts`, so "record it but do not halt" would need a second, quieter revert
+ * counter that no KPI is defined over — a number kept for nobody. The window is what the classifier
+ * already does; the operator's verb now does it too, and says which rule refused.
+ */
+test("applyRevert enforces the 30-day window on the operator's path, not only the classifier's", () => {
+  const seed = seedState();
+  const id = "pkt_ravidsrk_orca-fleet_71";
+  const merged = seed.packets.find((p) => p.id === id)!;
+  const mergedMs = Date.parse(merged.prMeta!.mergedAt!);
+  const at = (days: number) => new Date(mergedMs + days * 86_400_000).toISOString();
+
+  const withMergedAt = (mergedAt: string | undefined): FactoryState => ({
+    ...seed,
+    packets: seed.packets.map((p) =>
+      p.id === id ? { ...p, prMeta: { ...p.prMeta!, mergedAt } as typeof p.prMeta } : p,
+    ),
+  });
+
+  // Out of window: refused, the counter does not move, and the repo does not become unselectable.
+  const late = applyRevert(seed, id, { source: "operator", why: "maintainer said so", at: at(31) });
+  assert.equal(late.recorded, false, "an out-of-window rollback must not be recorded");
+  assert.match(late.error ?? "", /30-day window/, late.error);
+  assert.match(late.error ?? "", /docs\/08-operations\.md/, late.error);
+  assert.equal(scorecardRow(late.state.scorecard, merged.repoId)!.reverts, 0);
+  assert.equal(health(scorecardRow(late.state.scorecard, merged.repoId)!), "good");
+
+  // The classifier reaches the same verdict on the same facts — that is the point of the change.
+  const classified = classifyRevert({
+    mergeCommitSha: merged.prMeta!.mergeCommitSha!,
+    mergedAt: merged.prMeta!.mergedAt!,
+    commits: [
+      {
+        sha: "ffff1110000",
+        message: `Revert it\n\nThis reverts commit ${merged.prMeta!.mergeCommitSha}.`,
+        committedAt: at(31),
+      },
+    ],
+  });
+  assert.equal(classified.reverted, false);
+  assert.match(classified.why, /30-day window/);
+
+  // In window, including the last instant of it: still recorded, still a stop.
+  for (const day of [0, 29, 30]) {
+    const inWindow = applyRevert(seed, id, { source: "operator", why: "rolled back", at: at(day) });
+    assert.equal(inWindow.recorded, true, `day ${day} is inside the window`);
+    assert.equal(scorecardRow(inWindow.state.scorecard, merged.repoId)!.reverts, 1, `day ${day}`);
+    assert.equal(health(scorecardRow(inWindow.state.scorecard, merged.repoId)!), "stop", `day ${day}`);
+  }
+
+  // A ledger that cannot say when the merge happened must not be a way to dodge the halt. The
+  // window is unevaluable, so it does not apply, and the revert is recorded with that said out
+  // loud — the permissive direction here would let a missing field unlock the factory.
+  for (const missing of [undefined, "not-a-date"]) {
+    const blind = applyRevert(withMergedAt(missing), id, {
+      source: "operator",
+      why: "rolled back",
+      at: at(400),
+    });
+    assert.equal(blind.recorded, true, `mergedAt=${missing} must still record`);
+    assert.equal(scorecardRow(blind.state.scorecard, merged.repoId)!.reverts, 1);
+    const note = revertNote(blind.state.packets.find((p) => p.id === id)!);
+    assert.match(note?.body ?? "", /window could not be checked/i, note?.body);
+  }
 });
 
 test("a recorded revert points the operator at the seed, never at allowlist.yaml", () => {

--- a/factory/engine.ts
+++ b/factory/engine.ts
@@ -11,7 +11,9 @@ import {
   health,
   isTerminalReviewSubject,
   REVERT_NOTE_PREFIX,
+  REVERT_WINDOW_DAYS,
   revertNote,
+  revertWindow,
   scorecardRow,
 } from "./scorecard.ts";
 import { foundryAttestedWave0Merges } from "./status.ts";
@@ -78,6 +80,23 @@ export function applyTick(
   if (hasInflight(state.packets)) {
     const next = appendEvent(state, ev("tick", "Tick aborted — a packet is already in flight. One at a time."));
     return { state: next, packet: null, reason: "in-flight" };
+  }
+
+  // A halted tick has its own verdict, and it is not `idle` (issue #79).
+  //
+  // `pickCandidate` already consulted `maySelectRepo` per repo, so a halt DID keep every candidate
+  // out — but by refusing them one at a time it arrived at "no candidate", which this function
+  // reports as `Tick idle — no named candidate. Factory will not invent work.` and the CLI exits 0
+  // over. So a bricked factory read as a quiet one: the operator is told the roster had nothing to
+  // offer, when in fact the roster was never eligible. Same gate, same `factoryHalt` the per-repo
+  // check reads, asked once up front where the answer can be stated instead of inferred.
+  const halted = factoryHalt(state);
+  if (halted) {
+    const next = appendEvent(
+      state,
+      ev("tick", `Tick refused — factory halted ${halted.at}: ${halted.reason}`),
+    );
+    return { state: next, packet: null, reason: `Factory halted ${halted.at}: ${halted.reason}` };
   }
 
   let held = state;
@@ -1232,7 +1251,35 @@ export function applyRevert(
   const already = revertNote(packet);
   if (already) return { state, recorded: false };
   const at = input.at ?? now();
-  const detail = input.sha ? `${input.sha.slice(0, 12)} — ${input.why}` : input.why;
+  // docs/08-operations.md's window, on BOTH paths into this counter (issue #81).
+  //
+  // It lives here rather than in the `revert` verb because this function is the sole writer of
+  // `reverts`, and `health()` turns `reverts > 0` into an unconditional stop that only a hand edit
+  // of `factory/seed.ts` lifts. A check in the CLI would guard today's two callers and none of
+  // tomorrow's; a check at the counter guards the counter. For the `commit` path this is belt and
+  // braces — `classifyRevert` already filtered on the same predicate before `reconcile` got here —
+  // and the redundancy is the cheapest possible proof that the two agree.
+  //
+  // Refused, not recorded-quietly: `reverts` IS the halt, so there is no way to record without
+  // halting that does not invent a second counter nothing is defined over. An unknown window is
+  // the one exception, and it errs toward the halt — a ledger missing `mergedAt` must not become
+  // the way to keep a reverted repo selectable.
+  const window = revertWindow(packet.prMeta?.mergedAt, at);
+  if (window.known && !window.within) {
+    return {
+      state,
+      error:
+        `refusing to record a revert on ${id}: the rollback is dated ${at}, ${window.days} days after the ` +
+        `merge at ${packet.prMeta!.mergedAt} — past the ${REVERT_WINDOW_DAYS}-day window that closed ${window.deadline} ` +
+        `(docs/08-operations.md, "within 30 days of merge"). classifyRevert discards a commit this late for the same ` +
+        `reason, and reverts is a permanent scorecard stop. Record it as a follow-up note instead if it should be kept.`,
+      recorded: false,
+    };
+  }
+  const unknownWindow = window.known
+    ? ""
+    : ` [window could not be checked — no parseable mergedAt on this packet; recorded anyway rather than letting a missing date skip the halt]`;
+  const detail = (input.sha ? `${input.sha.slice(0, 12)} — ${input.why}` : input.why) + unknownWindow;
   const note = followUpEntry(at, "note", `${REVERT_NOTE_PREFIX} (${input.source}) ${detail}`, packet.prUrl);
   const next = bump(packet, { followUps: [...(packet.followUps ?? []), note] });
   const scorecard = applyPacketToScorecard(state.scorecard, packet, "reverted");

--- a/factory/engine.ts
+++ b/factory/engine.ts
@@ -1250,6 +1250,11 @@ export function applyRevert(
   }
   const already = revertNote(packet);
   if (already) return { state, recorded: false };
+  // `at` is WHEN THE ROLLBACK HAPPENED. Both callers now supply it from the event — `reconcile`
+  // from the reverting commit's `committedAt`, the `revert` verb from `--at` — because a shared
+  // predicate handed two different subjects is not a shared predicate. Defaulting to `now()` is the
+  // operator who did not say otherwise, and nothing else; it is not a licence to date a maintainer's
+  // rollback by when somebody got round to recording it (issue #81, round 2).
   const at = input.at ?? now();
   // docs/08-operations.md's window, on BOTH paths into this counter (issue #81).
   //
@@ -1272,7 +1277,10 @@ export function applyRevert(
         `refusing to record a revert on ${id}: the rollback is dated ${at}, ${window.days} days after the ` +
         `merge at ${packet.prMeta!.mergedAt} — past the ${REVERT_WINDOW_DAYS}-day window that closed ${window.deadline} ` +
         `(docs/08-operations.md, "within 30 days of merge"). classifyRevert discards a commit this late for the same ` +
-        `reason, and reverts is a permanent scorecard stop. Record it as a follow-up note instead if it should be kept.`,
+        `reason, and reverts is a permanent scorecard stop. If the maintainer rolled it back earlier than this and you ` +
+        `are only writing it down now, re-run with \`--at <iso>\` naming the day THEY did it — the window is measured ` +
+        `from the rollback, not from when you typed. If it really did land this late it is rework, not a revert ` +
+        `(docs/08-operations.md), and the scorecard is right to stay as it is.`,
       recorded: false,
     };
   }

--- a/factory/engine.ts
+++ b/factory/engine.ts
@@ -1270,6 +1270,22 @@ export function applyRevert(
   // the one exception, and it errs toward the halt — a ledger missing `mergedAt` must not become
   // the way to keep a reverted repo selectable.
   const window = revertWindow(packet.prMeta?.mergedAt, at);
+  // A date BEFORE the merge fails the same predicate but is a different mistake, and the paragraph
+  // below is written entirely for the late one — it would tell an operator their rollback is "past
+  // the window that closed" on a day before the window opened, and advise re-dating it EARLIER.
+  // A refusal that misdescribes the thing it refused is the defect this repo keeps filing.
+  if (window.known && !window.within && window.days < 0) {
+    return {
+      state,
+      error:
+        `refusing to record a revert on ${id}: the rollback is dated ${at}, which is ${-window.days} days ` +
+        `BEFORE the merge at ${packet.prMeta!.mergedAt} — nothing can revert a commit that did not exist yet. ` +
+        `classifyRevert skips pre-merge commits for the same reason, and reverts is a permanent scorecard stop, ` +
+        `so this is refused rather than recorded. Check the date you passed to \`--at\`: it wants the day the ` +
+        `maintainer rolled the patch back, in ISO form.`,
+      recorded: false,
+    };
+  }
   if (window.known && !window.within) {
     return {
       state,

--- a/factory/fixture-counts.ts
+++ b/factory/fixture-counts.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+
+/**
+ * One home for the fixture rule the issue #77 count assertions depend on.
+ *
+ * A number that is a substring of another number in the same render cannot be asserted by matching
+ * for it, and a test that cannot fail is not evidence. Round 1 of #77 shipped a document of 4,883
+ * characters withholding 883 of them, and `"883"` is a suffix of `"4883"`: every assertion about the
+ * withheld count matched inside the TOTAL, all four count mutants survived a green suite, and the
+ * number an operator's approval rests on was pinned nowhere.
+ *
+ * WHY THIS IS A MODULE AND NOT A HELPER IN EACH SUITE. It was two — defined in `packet.test.ts` and
+ * hand-written again inside `cli.test.ts`. Two copies of one rule is the defect this repository
+ * keeps shipping: the rule drifts on one side, the other side keeps passing, and nothing says so
+ * because each copy looks correct read on its own.
+ *
+ * Deliberately NOT a `.test.ts`. `run-tests.ts` collects every `*.test.ts` in this directory, and
+ * importing one test file from another registers its tests a second time, so shared test support
+ * needs a file the runner does not collect. Kept trivial for the same reason it was inline: this
+ * has to read as a precondition, not as a second mechanism.
+ */
+export function assertDisjointCounts(total: number, withheld: number): void {
+  assert.equal(
+    String(total).includes(String(withheld)),
+    false,
+    `fixture is unusable: ${withheld} is a substring of ${total}, so matching for the withheld count would match inside the total (this is exactly how round 1 of #77 shipped three unpinned counts)`,
+  );
+}

--- a/factory/packet.test.ts
+++ b/factory/packet.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import { assertDisjointCounts } from "./fixture-counts.ts";
 import { evidenceIsStale, needsRewitness, packetDivergences } from "./ledger-check.ts";
 import { DISCLOSURE } from "./neighbor.ts";
 import { buildPacket, POLICY_DOC_EXCERPT_LIMIT, renderEvidencePage, renderFreezeEvidence } from "./packet.ts";
@@ -178,25 +179,13 @@ test("the freeze prints the words the scanner read, not a boolean", () => {
  * characters withholding 883 of them — and `"883"` is a suffix of `"4883"`, so every one of the
  * three assertions matched inside the TOTAL and pinned nothing at all. All four count mutants
  * survived a green suite. The offset below is chosen so the withheld count carries into the
- * thousands digit (1234 withheld of 5234 total) and `assertDisjointCounts` refuses the fixture if a
- * later edit reintroduces the overlap.
+ * thousands digit (1234 withheld of 5234 total) and `assertDisjointCounts` — one rule in
+ * `fixture-counts.ts`, shared with `cli.test.ts`, which used to hold a second hand-written copy of
+ * it — refuses the fixture if a later edit reintroduces the overlap.
  */
 const withheldFixture = (banAt: number, ban: string) => {
   const filler = "Please read the guidelines below before opening a pull request.\n".repeat(200);
   return `${filler.slice(0, banAt)}\n${ban}\n`;
-};
-
-/**
- * The fixture guard. A number that is a substring of another number in the same render cannot be
- * asserted by matching for it, and a test that cannot fail is not evidence. Exported shape kept
- * trivial on purpose: this must be readable as a precondition, not as a second mechanism.
- */
-const assertDisjointCounts = (total: number, withheld: number) => {
-  assert.equal(
-    String(total).includes(String(withheld)),
-    false,
-    `fixture is unusable: ${withheld} is a substring of ${total}, so matching for the withheld count would match inside the total (this is exactly how round 1 of #77 shipped three unpinned counts)`,
-  );
 };
 
 test("the freeze never claims a clean scan over characters it did not show", () => {
@@ -281,6 +270,52 @@ test("the freeze prints the ban statement the scanner did match", () => {
   const out = renderFreezeEvidence(packet);
   assert.match(out, /are not welcome/i);
   assert.equal(/no ban statement matched/i.test(out), false);
+});
+
+/**
+ * THE PRECEDENCE BETWEEN THE TWO CLOSING BRANCHES, which nothing chose between.
+ *
+ * `renderFreezeEvidence` closes with matched phrases if there are any, and otherwise with the
+ * withheld-characters warning. A document can be BOTH — a ban inside the excerpt and 1,000
+ * characters past it — and every fixture so far was one or the other, so
+ * `matchedPhrases.length > 0` → `matchedPhrases.length > 0 && withheld === 0` survived: the matched
+ * ban silently disappears from the block an operator reads immediately above the attest, replaced by
+ * a warning about text they were not shown. The strictly worse of the two orderings, because the
+ * phrases are the reason the verdict is DENY.
+ *
+ * So the ordering is asserted, and so is the fact that choosing it costs the withholding nothing:
+ * the header and the end-of-excerpt marker still say how much was held back.
+ */
+test("a truncated document that DID match a ban still shows the phrases", () => {
+  const doc = `${BAN_AGENTS_MD}\n${"Please read the guidelines below before opening a pull request.\n".repeat(200)}`;
+  const packet = freezePacket({ agentsMd: doc });
+  const total = doc.length;
+  const withheld = total - POLICY_DOC_EXCERPT_LIMIT;
+
+  // Preconditions: both conditions genuinely hold at once, which is the composition nothing covered.
+  assert.equal(packet.policy.code, "DENY_FORBIDDEN", "the scanner must MATCH for this test to bite");
+  assert.ok(packet.policy.matchedPhrases.length > 0);
+  assert.equal(packet.policyDocs![0].truncated, true, "the document must also exceed the excerpt limit");
+  assert.ok(withheld > 0);
+  assertDisjointCounts(total, withheld);
+
+  const out = renderFreezeEvidence(packet);
+  const lines = out.split("\n");
+  assert.ok(
+    lines.includes("  Scanner matched — confirm these are the maintainer's words and mean what the verdict says:"),
+    `the matched-phrase block is the reason the verdict is DENY and it is gone:\n${out.slice(-700)}`,
+  );
+  for (const phrase of packet.policy.matchedPhrases) {
+    assert.ok(lines.includes(`    · ${phrase}`), `the matched phrase is not quoted:\n${out.slice(-700)}`);
+  }
+
+  // …and the withholding is still disclosed where the text stops, so taking the phrase branch does
+  // not cost the operator the other fact.
+  assert.ok(
+    lines.includes(`  AGENTS.md — ${total} chars (first ${POLICY_DOC_EXCERPT_LIMIT} shown, ${withheld} NOT shown)`),
+    lines.slice(0, 5).join("\n"),
+  );
+  assert.match(out, new RegExp(`⟪ ${withheld} more characters of AGENTS\\.md are NOT shown above`), out.slice(0, 900));
 });
 
 test("a freeze with nothing fetched says so instead of reporting a clean scan", () => {

--- a/factory/packet.test.ts
+++ b/factory/packet.test.ts
@@ -149,6 +149,93 @@ test("the freeze prints the words the scanner read, not a boolean", () => {
   assert.match(out, /AGENTS\.md.*not fetched/i);
 });
 
+/**
+ * Issue #77, and the reason it is a P1 rather than a rendering nit.
+ *
+ * #37 legs 2–3 exist because "the human freeze is blind — fetched docs are discarded". #70 fixed
+ * that by printing the parsed text, and then capped the print at 4,000 characters — so for the one
+ * case the whole mechanism is for, the human was still blind. The scanner reads the WHOLE document;
+ * the freeze showed a prefix. And #37's scanner leg is parked, so "the scanner misses a realistic
+ * ban" is a live condition on this tree, not a hypothesis.
+ *
+ * The specific sentence that made it dangerous is the closing one. After 4,000 characters of quoted
+ * text the surface said `no ban statement matched in 4,882 chars from CONTRIBUTING` — a claim of
+ * coverage over 882 characters the operator had not been shown, phrased as reassurance, sitting
+ * directly above the attest. The `(first 4000 shown)` marker was real but was ~55 screens further
+ * up, which is not a disclosure at the moment of the decision.
+ *
+ * INVARIANT: an operator must never be able to approve while text the scanner read is hidden from
+ * them without their knowing it. So the withheld amount is stated where the text stops AND in the
+ * scan claim itself, and the scan claim may never assert coverage over characters it did not show.
+ */
+const withheldFixture = (banAt: number, ban: string) => {
+  const filler = "Please read the guidelines below before opening a pull request.\n".repeat(200);
+  return `${filler.slice(0, banAt)}\n${ban}\n`;
+};
+
+test("the freeze never claims a clean scan over characters it did not show", () => {
+  // A ban the scanner MISSES, past the excerpt limit: the exact composition issue #77 describes.
+  const missedBan = "Kindly refrain from opening pull requests that were authored by an AI assistant.";
+  const doc = withheldFixture(POLICY_DOC_EXCERPT_LIMIT + 801, missedBan);
+  const packet = freezePacket({ contributing: doc });
+
+  // Preconditions — if either of these stops holding, the test below is measuring something else.
+  assert.equal(packet.policy.code, "ALLOW", "the scanner must MISS this ban for the test to bite");
+  assert.ok(doc.length > POLICY_DOC_EXCERPT_LIMIT, "the document must exceed the excerpt limit");
+  assert.equal(packet.policyDocs![0].truncated, true);
+
+  const out = renderFreezeEvidence(packet);
+  const withheld = doc.length - POLICY_DOC_EXCERPT_LIMIT;
+
+  // 1. The withheld amount is stated, in characters, so "how much" is answerable.
+  assert.match(out, new RegExp(`${withheld} character`), out);
+
+  // 2. It is stated WHERE THE TEXT STOPS, not only in a header 4,000 characters earlier. The line
+  //    after the last quoted line must be the notice — that is the position an operator scrolling
+  //    to the end of the quote actually lands on.
+  //    Located from the DOCUMENT's own header, not from the last `| ` line in the render: the
+  //    committed policy record and `policyNotes` are quoted the same way further down, so a
+  //    whole-output search would land on those and pass over a marker that was never emitted.
+  const lines = out.split("\n");
+  const header = lines.findIndex((l) => l.startsWith(`  ${packet.policyDocs![0].name} — `));
+  assert.ok(header >= 0, out);
+  let end = header + 1;
+  while (lines[end]?.startsWith("  | ")) end += 1;
+  assert.match(
+    lines[end] ?? "",
+    /not shown|withheld/i,
+    `the line where the document's text stops must say so:\n${lines.slice(end - 1, end + 2).join("\n")}`,
+  );
+
+  // 3. The closing scan claim — the sentence directly above the attest — may not stand as a clean
+  //    bill of health over the full character count. The shipped line was exactly
+  //    `Scanner: no ban statement matched in 4883 chars from CONTRIBUTING.`: a complete sentence,
+  //    terminated, unqualified. The count may still be reported (it is a true fact about the
+  //    scanner) but it may not be the last word, so the FULL STOP is what must be gone.
+  assert.equal(
+    out.includes(`no ban statement matched in ${doc.length} chars from CONTRIBUTING.`),
+    false,
+    `the scan claim must not close over unshown text:\n${out.slice(-900)}`,
+  );
+  // …and the qualification is in the closing block, where the decision is made, not only upstream.
+  const closing = out.slice(out.lastIndexOf("  Scanner:"));
+  assert.match(closing, new RegExp(`${withheld}`), closing);
+  assert.match(closing, /not shown|you have not/i, closing);
+
+  // 4. And the ban itself is genuinely absent from the render — this is the harm, restated as a
+  //    fact rather than assumed. The operator's protection is that they are TOLD it is absent.
+  assert.equal(out.includes(missedBan), false, "precondition: the ban really is past the limit");
+});
+
+test("a fully shown document carries no withheld notice at all", () => {
+  // The negative half. A guard that fires on every document teaches the operator to skip it, and
+  // "N characters not shown" over a document that was shown whole is a false statement in its own
+  // right. Most CONTRIBUTINGs fit, and those freezes must read exactly as they did.
+  const out = renderFreezeEvidence(freezePacket({ contributing: CLEAN_CONTRIBUTING }));
+  assert.equal(/not shown|withheld/i.test(out), false, out);
+  assert.match(out, new RegExp(`no ban statement matched in ${CLEAN_CONTRIBUTING.length} chars`, "i"));
+});
+
 test("the freeze prints the ban statement the scanner did match", () => {
   const packet = freezePacket({ agentsMd: BAN_AGENTS_MD });
   assert.equal(packet.policy.code, "DENY_FORBIDDEN");

--- a/factory/packet.test.ts
+++ b/factory/packet.test.ts
@@ -159,68 +159,107 @@ test("the freeze prints the words the scanner read, not a boolean", () => {
  * ban" is a live condition on this tree, not a hypothesis.
  *
  * The specific sentence that made it dangerous is the closing one. After 4,000 characters of quoted
- * text the surface said `no ban statement matched in 4,882 chars from CONTRIBUTING` — a claim of
- * coverage over 882 characters the operator had not been shown, phrased as reassurance, sitting
- * directly above the attest. The `(first 4000 shown)` marker was real but was ~55 screens further
- * up, which is not a disclosure at the moment of the decision.
+ * text the surface said `no ban statement matched in 5234 chars from CONTRIBUTING` — a claim of
+ * coverage over 1,234 characters the operator had not been shown, phrased as reassurance, sitting
+ * directly above the attest. The `(first 4000 shown)` marker was real but was 63 quoted lines
+ * further up — one to three screens — which is not a disclosure at the moment of the decision.
  *
  * INVARIANT: an operator must never be able to approve while text the scanner read is hidden from
  * them without their knowing it. So the withheld amount is stated where the text stops AND in the
  * scan claim itself, and the scan claim may never assert coverage over characters it did not show.
+ *
+ * THE COUNT IS THE ACCEPTANCE, AND IT IS PINNED THREE TIMES. `N characters not shown — the scanner
+ * read them, you have not` protects nobody if N can be wrong: `0 characters not shown` printed above
+ * a hidden ban is affirmative false reassurance, which is worse than the silence #77 replaced. The
+ * three renderings (header, end-of-excerpt marker, closing claim) are therefore asserted separately,
+ * each against the literal number, with a mutant per rendering in `scripts/mutation-audit.ts`.
+ *
+ * THE FIXTURE'S OWN SHAPE IS PART OF THE TEST. Round 1 of this fix used a document of 4883
+ * characters withholding 883 of them — and `"883"` is a suffix of `"4883"`, so every one of the
+ * three assertions matched inside the TOTAL and pinned nothing at all. All four count mutants
+ * survived a green suite. The offset below is chosen so the withheld count carries into the
+ * thousands digit (1234 withheld of 5234 total) and `assertDisjointCounts` refuses the fixture if a
+ * later edit reintroduces the overlap.
  */
 const withheldFixture = (banAt: number, ban: string) => {
   const filler = "Please read the guidelines below before opening a pull request.\n".repeat(200);
   return `${filler.slice(0, banAt)}\n${ban}\n`;
 };
 
+/**
+ * The fixture guard. A number that is a substring of another number in the same render cannot be
+ * asserted by matching for it, and a test that cannot fail is not evidence. Exported shape kept
+ * trivial on purpose: this must be readable as a precondition, not as a second mechanism.
+ */
+const assertDisjointCounts = (total: number, withheld: number) => {
+  assert.equal(
+    String(total).includes(String(withheld)),
+    false,
+    `fixture is unusable: ${withheld} is a substring of ${total}, so matching for the withheld count would match inside the total (this is exactly how round 1 of #77 shipped three unpinned counts)`,
+  );
+};
+
 test("the freeze never claims a clean scan over characters it did not show", () => {
   // A ban the scanner MISSES, past the excerpt limit: the exact composition issue #77 describes.
   const missedBan = "Kindly refrain from opening pull requests that were authored by an AI assistant.";
-  const doc = withheldFixture(POLICY_DOC_EXCERPT_LIMIT + 801, missedBan);
+  const doc = withheldFixture(POLICY_DOC_EXCERPT_LIMIT + 1152, missedBan);
   const packet = freezePacket({ contributing: doc });
+  const total = doc.length;
+  const withheld = total - POLICY_DOC_EXCERPT_LIMIT;
 
-  // Preconditions — if either of these stops holding, the test below is measuring something else.
+  // Preconditions — if any of these stops holding, the test below is measuring something else.
   assert.equal(packet.policy.code, "ALLOW", "the scanner must MISS this ban for the test to bite");
   assert.ok(doc.length > POLICY_DOC_EXCERPT_LIMIT, "the document must exceed the excerpt limit");
   assert.equal(packet.policyDocs![0].truncated, true);
+  assert.deepEqual([total, withheld], [5234, 1234], "the numbers the module comment cites");
+  assertDisjointCounts(total, withheld);
 
   const out = renderFreezeEvidence(packet);
-  const withheld = doc.length - POLICY_DOC_EXCERPT_LIMIT;
+  const lines = out.split("\n");
 
-  // 1. The withheld amount is stated, in characters, so "how much" is answerable.
-  assert.match(out, new RegExp(`${withheld} character`), out);
+  // 1. THE HEADER. Named source, true size, and how much of it is missing — the whole line, anchored,
+  //    so neither the count nor the clause around it can quietly go.
+  const headerLine = `  CONTRIBUTING — ${total} chars (first ${POLICY_DOC_EXCERPT_LIMIT} shown, ${withheld} NOT shown)`;
+  assert.ok(lines.includes(headerLine), `expected exactly:\n${headerLine}\ngot:\n${lines.slice(0, 4).join("\n")}`);
 
-  // 2. It is stated WHERE THE TEXT STOPS, not only in a header 4,000 characters earlier. The line
-  //    after the last quoted line must be the notice — that is the position an operator scrolling
-  //    to the end of the quote actually lands on.
+  // 2. THE MARKER, stated WHERE THE TEXT STOPS rather than only in a header 63 quoted lines earlier.
+  //    The line after the last quoted line must be the notice — that is the position an operator
+  //    scrolling to the end of the quote actually lands on.
   //    Located from the DOCUMENT's own header, not from the last `| ` line in the render: the
   //    committed policy record and `policyNotes` are quoted the same way further down, so a
   //    whole-output search would land on those and pass over a marker that was never emitted.
-  const lines = out.split("\n");
-  const header = lines.findIndex((l) => l.startsWith(`  ${packet.policyDocs![0].name} — `));
-  assert.ok(header >= 0, out);
+  const header = lines.indexOf(headerLine);
   let end = header + 1;
   while (lines[end]?.startsWith("  | ")) end += 1;
+  assert.equal(end - header - 1, 63, "the excerpt is 63 quoted lines — one to three screens, not dozens");
+  const marker = lines[end] ?? "";
   assert.match(
-    lines[end] ?? "",
-    /not shown|withheld/i,
-    `the line where the document's text stops must say so:\n${lines.slice(end - 1, end + 2).join("\n")}`,
+    marker,
+    new RegExp(`⟪ ${withheld} more characters of CONTRIBUTING are NOT shown above`),
+    `the line where the document's text stops must say so, with the count:\n${lines.slice(end - 1, end + 2).join("\n")}`,
   );
+  // …and it must be the WITHHELD count there, not the total borrowed from the header.
+  assert.equal(marker.includes(String(total)), false, marker);
 
-  // 3. The closing scan claim — the sentence directly above the attest — may not stand as a clean
-  //    bill of health over the full character count. The shipped line was exactly
-  //    `Scanner: no ban statement matched in 4883 chars from CONTRIBUTING.`: a complete sentence,
+  // 3. THE CLOSING CLAIM — the sentence directly above the attest — may not stand as a clean bill of
+  //    health over the full character count. The shipped line was exactly
+  //    `Scanner: no ban statement matched in 5234 chars from CONTRIBUTING.`: a complete sentence,
   //    terminated, unqualified. The count may still be reported (it is a true fact about the
   //    scanner) but it may not be the last word, so the FULL STOP is what must be gone.
   assert.equal(
-    out.includes(`no ban statement matched in ${doc.length} chars from CONTRIBUTING.`),
+    out.includes(`no ban statement matched in ${total} chars from CONTRIBUTING.`),
     false,
     `the scan claim must not close over unshown text:\n${out.slice(-900)}`,
   );
-  // …and the qualification is in the closing block, where the decision is made, not only upstream.
+  // …and the qualification is in the closing block, where the decision is made, not only upstream,
+  //    and it names BOTH numbers in their own roles: withheld of total, in that order.
   const closing = out.slice(out.lastIndexOf("  Scanner:"));
-  assert.match(closing, new RegExp(`${withheld}`), closing);
-  assert.match(closing, /not shown|you have not/i, closing);
+  assert.match(
+    closing,
+    new RegExp(`BUT ${withheld} of those ${total} characters are not shown above`),
+    closing,
+  );
+  assert.match(closing, /The scanner read them; you have not/, closing);
 
   // 4. And the ban itself is genuinely absent from the render — this is the harm, restated as a
   //    fact rather than assumed. The operator's protection is that they are TOLD it is absent.

--- a/factory/packet.ts
+++ b/factory/packet.ts
@@ -139,10 +139,13 @@ function withheldChars(docs: PolicyDocSource[]): number {
  *
  * PARTIAL absence is the same defect one step in, and it is issue #77. The scanner reads the whole
  * fetched document; the packet keeps `POLICY_DOC_EXCERPT_LIMIT` characters of it. So this surface
- * could print 4,000 characters and then close with "no ban statement matched in 4,882 chars from
- * CONTRIBUTING" — a claim of coverage over 882 characters the reader had not been given, phrased as
- * reassurance, immediately above the attest. Combined with the scanner's known-and-parked miss mode
- * (#37) that is an operator approving a contribution to a repository that said in words not to.
+ * could print 4,000 characters and then close with "no ban statement matched in 5234 chars from
+ * CONTRIBUTING" — a claim of coverage over the 1,234 characters the reader had not been given,
+ * phrased as reassurance, immediately above the attest. Those two numbers are the fixture in
+ * `packet.test.ts` ("the freeze never claims a clean scan over characters it did not show"), so the
+ * example is re-derivable rather than illustrative. Combined with the scanner's known-and-parked
+ * miss mode (#37) that is an operator approving a contribution to a repository that said in words
+ * not to.
  *
  * The fix is loudness, not more text, and the reason is that the excerpt limit is a LEDGER bound:
  * `policyDocs` is stored state, the full document is never kept, and re-fetching at freeze time
@@ -167,8 +170,9 @@ export function renderFreezeEvidence(packet: TaskPacket): string {
     );
     for (const line of doc.excerpt.split("\n")) lines.push(`  | ${line}`);
     // Where the text stops, because that is where a scrolling reader's eye lands. The header above
-    // carries the same number, but after 4,000 characters of quoted prose it is dozens of screens
-    // back — a disclosure the operator has to remember is not one they have at the decision.
+    // carries the same number, but 4,000 characters of quoted prose renders as 63 quoted lines —
+    // one to three screens back, depending on the terminal — and a disclosure the operator has to
+    // remember having read is not one they have at the decision.
     if (missing > 0) {
       lines.push(
         `  ⟪ ${missing} more characters of ${doc.name} are NOT shown above. The scanner read them; you have not. ⟫`,

--- a/factory/packet.ts
+++ b/factory/packet.ts
@@ -112,6 +112,14 @@ export function buildPacket(input: {
 }
 
 /**
+ * How many characters the scanner read that the freeze will NOT show (issue #77). Derived from the
+ * two fields `policyDocSource` already carries, so there is one number and no new stored state.
+ */
+function withheldChars(docs: PolicyDocSource[]): number {
+  return docs.reduce((n, d) => n + Math.max(0, d.chars - d.excerpt.length), 0);
+}
+
+/**
  * What the operator reads at the freeze, before the attest is taken.
  *
  * The freeze is the documented second layer over a scanner whose miss mode is known and named
@@ -128,6 +136,21 @@ export function buildPacket(input: {
  * `CONTRIBUTING` — a repository with the file present and empty, a truncated response — produces a
  * `policyDocs` entry, so a document-counted branch would take the scanned path and print the exact
  * sentence the branch exists to prevent: "no ban statement matched in 0 chars from CONTRIBUTING".
+ *
+ * PARTIAL absence is the same defect one step in, and it is issue #77. The scanner reads the whole
+ * fetched document; the packet keeps `POLICY_DOC_EXCERPT_LIMIT` characters of it. So this surface
+ * could print 4,000 characters and then close with "no ban statement matched in 4,882 chars from
+ * CONTRIBUTING" — a claim of coverage over 882 characters the reader had not been given, phrased as
+ * reassurance, immediately above the attest. Combined with the scanner's known-and-parked miss mode
+ * (#37) that is an operator approving a contribution to a repository that said in words not to.
+ *
+ * The fix is loudness, not more text, and the reason is that the excerpt limit is a LEDGER bound:
+ * `policyDocs` is stored state, the full document is never kept, and re-fetching at freeze time
+ * would show text the gate never parsed — which is the opposite of what this function promises. So
+ * what is shown cannot grow; what can change is that the omission is impossible to miss and the
+ * scan claim can no longer overstate itself. `withheldChars` is computed ONCE, from `chars` and
+ * `excerpt.length` the record already carries — no new stored field, and the three places that
+ * mention the omission render one value rather than each deriving it.
  */
 export function renderFreezeEvidence(packet: TaskPacket): string {
   const docs = packet.policyDocs ?? [];
@@ -138,10 +161,19 @@ export function renderFreezeEvidence(packet: TaskPacket): string {
   ];
 
   for (const doc of docs) {
+    const missing = Math.max(0, doc.chars - doc.excerpt.length);
     lines.push(
-      `  ${doc.name} — ${doc.chars} chars${doc.truncated ? ` (first ${doc.excerpt.length} shown)` : ""}`,
+      `  ${doc.name} — ${doc.chars} chars${missing > 0 ? ` (first ${doc.excerpt.length} shown, ${missing} NOT shown)` : ""}`,
     );
     for (const line of doc.excerpt.split("\n")) lines.push(`  | ${line}`);
+    // Where the text stops, because that is where a scrolling reader's eye lands. The header above
+    // carries the same number, but after 4,000 characters of quoted prose it is dozens of screens
+    // back — a disclosure the operator has to remember is not one they have at the decision.
+    if (missing > 0) {
+      lines.push(
+        `  ⟪ ${missing} more characters of ${doc.name} are NOT shown above. The scanner read them; you have not. ⟫`,
+      );
+    }
     lines.push("");
   }
   for (const name of ["AGENTS.md", "CONTRIBUTING"]) {
@@ -165,6 +197,7 @@ export function renderFreezeEvidence(packet: TaskPacket): string {
 
   lines.push("");
   const total = docs.reduce((n, d) => n + d.chars, 0);
+  const withheld = withheldChars(docs);
   if (total === 0) {
     lines.push(
       docs.length === 0
@@ -175,6 +208,17 @@ export function renderFreezeEvidence(packet: TaskPacket): string {
   } else if (packet.policy.matchedPhrases.length > 0) {
     lines.push("  Scanner matched — confirm these are the maintainer's words and mean what the verdict says:");
     for (const phrase of packet.policy.matchedPhrases) lines.push(`    · ${phrase}`);
+  } else if (withheld > 0) {
+    // The sentence issue #77 is about. `no ban statement matched in ${total} chars` is true of the
+    // SCANNER and false of the reader, and printed unqualified directly above the attest it read as
+    // a clean bill of health over text nobody had seen. Split, so the two subjects stay separate:
+    // what the scanner covered, and what the operator was actually shown.
+    lines.push(
+      `  Scanner: no ban statement matched in ${total} chars from ${docs.map((d) => d.name).join(" + ")} —`,
+      `  BUT ${withheld} of those ${total} characters are not shown above. The scanner read them; you have not,`,
+      "  and the scanner's miss mode is exactly what your reading is here to cover. Treat this as unread policy",
+      "  text: open the document upstream and check the rest, or do not attest.",
+    );
   } else {
     lines.push(`  Scanner: no ban statement matched in ${total} chars from ${docs.map((d) => d.name).join(" + ")}.`);
   }

--- a/factory/policy-records.ts
+++ b/factory/policy-records.ts
@@ -9,8 +9,24 @@ const STANCES = new Set(["forbidden", "conditional", "welcome", "silent"]);
  * A derived measurement: a ratio (`141 of 272`, `141/272`) or a percentage (`61%`). Deliberately
  * narrow — an ISO date, a file path and a version number must all pass, because absence notes carry
  * them ("no CONTRIBUTING.md ... as of 2026-08-28").
+ *
+ * The two alternatives are written separately, and the `i` flag is why (issue #82). The first
+ * pattern was `(?:\/|of)` under one case-sensitive expression, which failed in both directions at
+ * once: `141 Of 272` walked through the guard because `of` matched lowercase only, and `docs/2026/08`
+ * tripped it because a slash between two numbers was accepted anywhere at all — including inside a
+ * path, which the comment above says must pass. Only the word needs the case fold, so only the word
+ * gets it; the slash form is instead anchored to *not* be a path segment. That anchoring is the
+ * whole difference between a ratio and a path: a ratio has whitespace or a sentence around it, a
+ * path segment has another `/` on one side. Adjacent slashes are therefore the exclusion, which
+ * also drops `2026/08/28` — a date written the other way — without needing to know it is a date.
  */
-const DERIVED_FIGURE = /\b\d[\d,]*\s*(?:\/|of)\s*\d[\d,]*\b|\b\d+(?:\.\d+)?\s*%/;
+const RATIO_IN_WORDS = /\b\d[\d,]*\s*of\s*\d[\d,]*\b/i;
+const RATIO_AS_SLASH = /(?<![/\w])\b\d[\d,]*\s*\/\s*\d[\d,]*\b(?![/\w])/;
+const PERCENTAGE = /\b\d+(?:\.\d+)?\s*%/;
+
+export function hasDerivedFigure(quote: string): boolean {
+  return RATIO_IN_WORDS.test(quote) || RATIO_AS_SLASH.test(quote) || PERCENTAGE.test(quote);
+}
 
 export function policyRecordsPath(from = import.meta.url): string {
   return join(dirname(fileURLToPath(from)), "..", "policy-records.json");
@@ -40,7 +56,7 @@ export function parsePolicyRecords(text: string): Map<string, PolicyRecord> {
     // its method. Scoped to `silent` on purpose: a `welcome` / `conditional` / `forbidden` quote is
     // genuinely the maintainer's prose and may legitimately count something (issue #44 item 2,
     // docs/SPEC.md §3, docs/10-schemas.md).
-    if (stance === "silent" && DERIVED_FIGURE.test(quote)) {
+    if (stance === "silent" && hasDerivedFigure(quote)) {
       throw new Error(
         `policy-records.json: ${repoId} is silent but its quote carries a derived figure — ` +
           `that quote renders as the maintainer's own words; measurements belong in allowlist.yaml policyNotes`,

--- a/factory/policy-records.ts
+++ b/factory/policy-records.ts
@@ -19,6 +19,14 @@ const STANCES = new Set(["forbidden", "conditional", "welcome", "silent"]);
  * whole difference between a ratio and a path: a ratio has whitespace or a sentence around it, a
  * path segment has another `/` on one side. Adjacent slashes are therefore the exclusion, which
  * also drops `2026/08/28` — a date written the other way — without needing to know it is a date.
+ *
+ * KNOWN LIMIT, pinned in `policy.test.ts`: a bare two-component `2026/08`, with no third segment and
+ * no path around it, is refused. It is indistinguishable in form from `141/272`, and the paragraph
+ * above is a deliberate commitment not to start recognising dates. The promise is that an ISO date
+ * (`2026-08-28`) passes, and it does. The fail direction is also the safe one — this guard THROWS,
+ * so a false positive stops `validate` in front of a human who rewords the note, while a false
+ * negative puts an unreproducible measurement into a maintainer's mouth on the evidence page and
+ * nothing ever says so.
  */
 const RATIO_IN_WORDS = /\b\d[\d,]*\s*of\s*\d[\d,]*\b/i;
 const RATIO_AS_SLASH = /(?<![/\w])\b\d[\d,]*\s*\/\s*\d[\d,]*\b(?![/\w])/;

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -314,11 +314,21 @@ test("the derived-figure guard reads case-insensitively and does not mistake a p
   assert.equal(hasDerivedFigure("no CONTRIBUTING.md as of 2026/08"), true, "known limit, not a promise");
   assert.equal(hasDerivedFigure("no CONTRIBUTING.md as of 2026/08/28"), false, "three segments read as a path");
 
-  // …and the loosening must not cost the catch it was loosened around: a bare ratio still dies.
-  assert.throws(
-    () => parsePolicyRecords(record({ quote: "Behaviorally open: 250/408 non-owner PRs merged." })),
-    /is silent but its quote carries a derived figure/,
-  );
+  // …and the loosening must not cost the catch it was loosened around: a bare ratio still dies,
+  // whether or not the writer put spaces around the slash. Every fixture wrote it tight, so the
+  // `\s*` on either side of the `/` was pinned by nothing and deleting it stayed green — and
+  // `141 / 272` is how a human types a ratio into prose at least as often as `141/272`.
+  for (const figure of [
+    "Behaviorally open: 250/408 non-owner PRs merged.",
+    "Behaviorally open: 141 / 272 external PRs merged.",
+    "Behaviorally open: 141/ 272 external PRs merged.",
+  ]) {
+    assert.throws(
+      () => parsePolicyRecords(record({ quote: figure })),
+      /is silent but its quote carries a derived figure/,
+      figure,
+    );
+  }
 });
 
 test("the committed policy records parse under the quote guard", () => {

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { test } from "node:test";
-import { parsePolicyRecords, policyRecordsPath } from "./policy-records.ts";
+import { hasDerivedFigure, parsePolicyRecords, policyRecordsPath } from "./policy-records.ts";
 import { evaluatePolicy } from "./policy.ts";
 
 test("denylist always forbids matplotlib", () => {
@@ -256,6 +256,52 @@ test("a silent quote may hold an absence note but never a derived figure", () =>
   );
 });
 
+/**
+ * The guard failed in BOTH directions at once, which is why one test covers both (issue #82).
+ *
+ * Permissive: the pattern had no `i` flag, so `of` matched lowercase only and `141 Of 272` walked
+ * straight through the guard #44 added — the same unreproducible measurement in a maintainer's
+ * mouth, one shift key away.
+ *
+ * Strict: the `number/number` alternative was unanchored, so it also matched the `2026/08` inside a
+ * path. That contradicts the constant's own comment, which requires that "an ISO date, a file path
+ * and a version number must all pass, because absence notes carry them" — and a rejected absence
+ * note is not a cosmetic failure: `policyRecordFor` throws out of a lazy cache, so one such quote
+ * takes down `validate` and every packet build that touches the record.
+ */
+test("the derived-figure guard reads case-insensitively and does not mistake a path for a ratio", () => {
+  // Permissive direction. Every casing of the ratio word is the same claim.
+  for (const figure of [
+    "Behaviorally open: 141 Of 272 external PRs merged.",
+    "Behaviorally open: 141 OF 272 external PRs merged.",
+    "Behaviorally open: 141 oF 272 external PRs merged.",
+  ]) {
+    assert.throws(
+      () => parsePolicyRecords(record({ quote: figure })),
+      /is silent but its quote carries a derived figure/,
+      figure,
+    );
+  }
+
+  // Strict direction. A numeric path segment is a path, not a measurement.
+  for (const note of [
+    "no CONTRIBUTING.md at docs/2026/08 as of 2026-08-28",
+    "nothing under .github/2026/08/ and nothing in AGENTS.md as of 2026-08-28",
+    "checked https://example.invalid/docs/2026/08/policy as of 2026-08-28",
+  ]) {
+    assert.ok(
+      parsePolicyRecords(record({ quote: note })).get("ColeMurray/background-agents"),
+      note,
+    );
+  }
+
+  // …and the loosening must not cost the catch it was loosened around: a bare ratio still dies.
+  assert.throws(
+    () => parsePolicyRecords(record({ quote: "Behaviorally open: 250/408 non-owner PRs merged." })),
+    /is silent but its quote carries a derived figure/,
+  );
+});
+
 test("the committed policy records parse under the quote guard", () => {
   // Reads the shipped file, so restoring a figure into any silent quote turns this suite red.
   // Deliberately not a pin on the quote *text*: a legitimate refresh — upstream finally writes a
@@ -264,8 +310,13 @@ test("the committed policy records parse under the quote guard", () => {
   assert.ok(records.size > 0);
   const silent = [...records.values()].filter((r) => r.stance === "silent");
   assert.ok(silent.length > 0, "the file must still hold a silent record or this asserts nothing");
+  // Through the guard's OWN predicate, not a second copy of it. The copy that used to sit here was
+  // written when the two agreed, and issue #82 made them disagree: it had no `i` flag but also no
+  // path exclusion, so it was simultaneously looser and STRICTER than the rule it was checking. A
+  // legitimate absence note carrying `docs/2026/08` would have passed `validate` and turned this
+  // file red — the second half of #82's defect, relocated into the test suite.
   for (const r of silent) {
-    assert.doesNotMatch(r.quote, /\d\s*(?:\/|of)\s*\d|\d\s*%/, `${r.repoId} quote: ${r.quote}`);
+    assert.equal(hasDerivedFigure(r.quote), false, `${r.repoId} quote: ${r.quote}`);
   }
 });
 

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -284,16 +284,35 @@ test("the derived-figure guard reads case-insensitively and does not mistake a p
   }
 
   // Strict direction. A numeric path segment is a path, not a measurement.
+  //
+  // BOTH lookarounds are exercised. Every fixture here used to put the numeric pair AFTER a `/`,
+  // which only ever tested the LOOKBEHIND: deleting `(?![/\w])` on its own left the suite green.
+  // The last two put a numeric segment BEFORE a `/` with an ordinary word boundary in front of it,
+  // so the trailing exclusion is the only thing that can save them.
   for (const note of [
     "no CONTRIBUTING.md at docs/2026/08 as of 2026-08-28",
     "nothing under .github/2026/08/ and nothing in AGENTS.md as of 2026-08-28",
     "checked https://example.invalid/docs/2026/08/policy as of 2026-08-28",
+    "read 2026/08/28 of the archived policy page as of 2026-08-28",
+    "no AGENTS.md; the wiki path is 2026/08/28/contributing as of 2026-08-28",
   ]) {
     assert.ok(
       parsePolicyRecords(record({ quote: note })).get("ColeMurray/background-agents"),
       note,
     );
   }
+
+  // The guard's known limit, pinned rather than left to be rediscovered. A bare two-component
+  // `2026/08` — no third segment, no surrounding path — is indistinguishable IN FORM from the
+  // ratio `141/272`, and the constant's comment says in as many words that it will not learn to
+  // recognise dates ("without needing to know it is a date"). So it refuses, and that is the right
+  // direction: the guard THROWS, so a false positive stops `validate` in front of a human who can
+  // reword the note, while a false negative puts an unreproducible measurement in a maintainer's
+  // mouth on the evidence page and nothing ever says so. What the comment promises is that an ISO
+  // date passes, and it does.
+  assert.equal(hasDerivedFigure("no CONTRIBUTING.md as of 2026-08-28"), false);
+  assert.equal(hasDerivedFigure("no CONTRIBUTING.md as of 2026/08"), true, "known limit, not a promise");
+  assert.equal(hasDerivedFigure("no CONTRIBUTING.md as of 2026/08/28"), false, "three segments read as a path");
 
   // …and the loosening must not cost the catch it was loosened around: a bare ratio still dies.
   assert.throws(

--- a/factory/scorecard.ts
+++ b/factory/scorecard.ts
@@ -191,7 +191,11 @@ export function revertWindow(
   const deadlineMs = mergedMs + REVERT_WINDOW_DAYS * 86_400_000;
   return {
     known: true,
-    within: atMs <= deadlineMs,
+    // Both bounds, because both callers need both. `classifyRevert` filters pre-merge commits in
+    // its own loop and so never asked this predicate for the lower one; the operator path reaches
+    // here directly with `--at` and did. An impossible pre-merge rollback that passes increments
+    // `reverts`, and `health()` turns that into a permanent `stop`.
+    within: atMs >= mergedMs && atMs <= deadlineMs,
     deadline: new Date(deadlineMs).toISOString(),
     days: Math.floor((atMs - mergedMs) / 86_400_000),
   };

--- a/factory/scorecard.ts
+++ b/factory/scorecard.ts
@@ -164,6 +164,39 @@ export function revertNote(packet: TaskPacket) {
 /** docs/08-operations.md: a revert counts only "within 30 days of merge". */
 export const REVERT_WINDOW_DAYS = 30;
 
+/**
+ * Is a rollback observed at `at` inside the window opened by `mergedAt`? (issue #81.)
+ *
+ * ONE predicate, deliberately, read by BOTH halves of docs/08-operations.md's single definition:
+ * `classifyRevert` for the mechanical path, `applyRevert` for the operator's prose one. They used
+ * to be one enforcement and one nothing — the classifier discarded a commit past the deadline while
+ * the `revert` verb applied any rollback of any age, so the same maintainer statement about the
+ * same merge counted or did not depending on which door it came through. Two hand-written copies of
+ * a deadline is the shape this repository has shipped the same defect through repeatedly; a shared
+ * function is the only version of "they agree" that a mutation can prove.
+ *
+ * `unknown` is a third answer, not a lenient `true`. A packet whose ledger carries no parseable
+ * `mergedAt` cannot be placed against the deadline at all, and the two callers want opposite things
+ * from that: the classifier already refuses such a packet outright (it has no merge commit to match
+ * either), while the operator's verb must NOT treat a missing field as permission to skip the halt.
+ * Collapsing it into a boolean would pick one of those silently.
+ */
+export function revertWindow(
+  mergedAt: string | undefined,
+  at: string,
+): { known: true; within: boolean; deadline: string; days: number } | { known: false } {
+  const mergedMs = Date.parse(mergedAt ?? "");
+  const atMs = Date.parse(at);
+  if (!Number.isFinite(mergedMs) || !Number.isFinite(atMs)) return { known: false };
+  const deadlineMs = mergedMs + REVERT_WINDOW_DAYS * 86_400_000;
+  return {
+    known: true,
+    within: atMs <= deadlineMs,
+    deadline: new Date(deadlineMs).toISOString(),
+    days: Math.floor((atMs - mergedMs) / 86_400_000),
+  };
+}
+
 export interface RevertCandidate {
   sha: string;
   message: string;
@@ -196,7 +229,6 @@ export function classifyRevert(input: {
   if (merge.length < 7 || !Number.isFinite(mergedMs)) {
     return { reverted: false, why: "no merge commit recorded for this packet — nothing to revert" };
   }
-  const deadline = mergedMs + REVERT_WINDOW_DAYS * 86_400_000;
   let late: RevertCandidate | undefined;
   for (const commit of input.commits) {
     // A commit cannot revert itself, and the merge commit is in the branch's own history.
@@ -209,7 +241,10 @@ export function classifyRevert(input: {
     if (!names) continue;
     const at = Date.parse(commit.committedAt);
     if (!Number.isFinite(at) || at < mergedMs) continue;
-    if (at > deadline) {
+    // The shared deadline (issue #81) — the same call the operator's `revert` verb makes, so the
+    // two halves of one documented definition cannot drift into disagreeing about a date.
+    const window = revertWindow(input.mergedAt, commit.committedAt);
+    if (window.known && !window.within) {
       late = commit;
       continue;
     }
@@ -221,7 +256,8 @@ export function classifyRevert(input: {
     };
   }
   if (late) {
-    const days = Math.floor((Date.parse(late.committedAt) - mergedMs) / 86_400_000);
+    const window = revertWindow(input.mergedAt, late.committedAt);
+    const days = window.known ? window.days : 0;
     return {
       reverted: false,
       why: `${late.sha.slice(0, 12)} names our merge commit but landed ${days} days after the merge, past the ${REVERT_WINDOW_DAYS}-day window (docs/08-operations.md) — not counted as a revert`,

--- a/factory/terminal.test.ts
+++ b/factory/terminal.test.ts
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
-import { readFileSync, readdirSync } from "node:fs";
-import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { join, resolve } from "node:path";
-import { test } from "node:test";
+import { after, test } from "node:test";
 import {
   installTerminalBoundary,
   sanitizeTerminalText,
@@ -11,6 +13,7 @@ import {
 } from "./terminal.ts";
 
 const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const TERMINAL = resolve(REPO_ROOT, "factory/terminal.ts");
 
 /** A stream that records what the boundary actually handed to the real `write`. */
 function capture(): TerminalStream & { written: string[]; text: string } {
@@ -41,11 +44,41 @@ const ACTIONABLE = /[\x00-\x08\x0b-\x1f\x7f-\x9f]/;
  * mechanism the same commit was filed to close.
  */
 const HOSTILE = "\x1b]52;c;cm0gLXJmIH4=\x07\x1b[8mconcealed\r\x1b[2Jrepainted\x9b31mgreen\x9d0;title\x07";
+/** What HOSTILE looks like once the boundary has had it: the marker every drive below matches on. */
+const DEFANGED = "concealedrepaintedgreen";
+const DISCLOSED = /byte\(s\) of terminal control sequence removed/;
+
+/**
+ * Every temp tree this file makes, removed when it is done. `mkdtempSync` with no counterpart is how
+ * a developer's `$TMPDIR` acquires hundreds of them: the drives below build one per run, forever.
+ */
+const temps: string[] = [];
+function scratch(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  temps.push(dir);
+  return dir;
+}
+after(() => {
+  for (const dir of temps) rmSync(dir, { recursive: true, force: true });
+});
+
+function spawnNode(script: string, args: string[], opts: { preload?: string } = {}) {
+  const nodeArgs = ["--experimental-strip-types"];
+  if (opts.preload) nodeArgs.push("--import", pathToFileURL(opts.preload).href);
+  const run = spawnSync(process.execPath, [...nodeArgs, script, ...args], {
+    // Deliberately not the checkout: an entry point that only behaves from the repo root is not an
+    // entry point an operator can run.
+    cwd: tmpdir(),
+    encoding: "utf8",
+    env: { ...process.env, NODE_NO_WARNINGS: "1" },
+  });
+  return { code: run.status ?? 1, stdout: run.stdout, stderr: run.stderr };
+}
 
 test("the sanitiser removes whole sequences, keeps the shape of a log, and says how much it took", () => {
   const clean = sanitizeTerminalText(HOSTILE);
   assert.equal(ACTIONABLE.test(clean.text), false, JSON.stringify(clean.text));
-  assert.equal(clean.text, "concealedrepaintedgreen");
+  assert.equal(clean.text, DEFANGED);
   assert.ok(clean.removed > 0);
   assert.equal(clean.removed, HOSTILE.length - clean.text.length);
 
@@ -57,6 +90,43 @@ test("the sanitiser removes whole sequences, keeps the shape of a log, and says 
   // one line is the diagnostic thrown away.
   const log = "FAIL spec.ts\n\tat line 3\n";
   assert.deepEqual(sanitizeTerminalText(log), { text: log, removed: 0 });
+});
+
+/**
+ * THE C1/DEL SWEEP, WHICH NO SEQUENCE GRAMMAR COVERS.
+ *
+ * Every C1 byte the fixture above carries — `\x9b`, `\x9d` — is ALSO a sequence introducer, and
+ * `TERMINAL_SEQUENCE` removes those whether or not the C0/C1/DEL sweep exists at all. So narrowing
+ * `CONTROL_CHAR` to `[\x00-\x08\x0b-\x1f]` left the whole suite green: the bytes only the sweep can
+ * remove were in no fixture, and issue #78's acceptance says "strip C0/**C1** control characters".
+ *
+ * The unexercised ones are not decorative:
+ *   · `\x8d` RI (reverse index) moves the cursor up a line and SCROLLS at the top of the screen —
+ *     the "repaint a red witness as green" primitive, with no `\x1b` in it to notice.
+ *   · `\x85` NEL is a line break the terminal obeys and no line count expects.
+ *   · `\x7f` DEL, and `\x80` at the bottom of the C1 block, pin both ends of the range.
+ */
+test("the sweep removes the C1 and DEL bytes that are not sequence introducers", () => {
+  for (const [byte, name] of [
+    ["\x7f", "DEL"],
+    ["\x80", "PAD (C1 low end)"],
+    ["\x85", "NEL"],
+    ["\x8d", "RI — reverse index, which scrolls"],
+  ] as const) {
+    const hex = byte.charCodeAt(0).toString(16);
+    assert.deepEqual(
+      sanitizeTerminalText(`red${byte}green`),
+      { text: "redgreen", removed: 1 },
+      `\\x${hex} (${name}) survived: TERMINAL_SEQUENCE does not know this byte, so the sweep is the only thing that can remove it`,
+    );
+  }
+
+  // …and it is disclosed like anything else, because a byte removed in silence is a byte the
+  // operator is not told about.
+  const stream = capture();
+  installTerminalBoundary([stream]);
+  stream.write("witness: red\x8dgreen\n");
+  assert.match(stream.text, DISCLOSED, stream.text);
 });
 
 /**
@@ -99,7 +169,7 @@ test("the boundary sanitises every write to a stream, whatever printed it", () =
 
   assert.equal(ACTIONABLE.test(stream.text), false, JSON.stringify(stream.text));
   assert.equal(stream.written.length, 3, "one write in, one write out — no reordering");
-  for (const line of stream.written) assert.match(line, /concealedrepaintedgreen/);
+  for (const line of stream.written) assert.match(line, new RegExp(DEFANGED));
 });
 
 test("the boundary discloses what it removed rather than tidying in silence", () => {
@@ -120,14 +190,189 @@ test("the boundary discloses what it removed rather than tidying in silence", ()
   assert.equal(clean.written.length, 1);
 });
 
-test("installing the boundary twice does not sanitise twice or double the disclosure", () => {
+/**
+ * What the `WRAPPED` WeakSet actually decides, which is not what this test used to claim.
+ *
+ * The old claim was "installing twice does not sanitise twice or double the disclosure", and it
+ * passed with the WeakSet DELETED: sanitising is idempotent, so a second pass over already-clean
+ * text removes nothing and appends no second notice. It was a spurious pin — an assertion about a
+ * property the guard is not the cause of.
+ *
+ * The guard's own effect is the wrapper count: one install, one layer, however many times an entry
+ * point and something it imported both ask. So that is what is asserted, and the idempotence is
+ * kept underneath it as the consequence rather than as the evidence.
+ */
+test("installing the boundary twice wraps the stream once", () => {
   const stream = capture();
   installTerminalBoundary([stream]);
+  const wrapped = stream.write;
   installTerminalBoundary([stream]);
+  assert.equal(
+    stream.write,
+    wrapped,
+    "a second install re-wrapped an already-wrapped stream: every write now pays for two full sanitising passes and the chain grows once per call",
+  );
+
   stream.write(`x${HOSTILE}\n`);
-  const notices = stream.text.match(/byte\(s\) of terminal control sequence removed/g) ?? [];
+  const notices = stream.text.match(new RegExp(DISCLOSED, "g")) ?? [];
   assert.equal(notices.length, 1, stream.text);
 });
+
+/**
+ * The promise `installTerminalBoundary`'s own comment makes — "only the CHUNK is replaced … so
+ * back-pressure, `drain`, and write callbacks behave exactly as before" — which nothing held it to.
+ * `inner(…, encoding, callback)` → `inner(…); return true` survived the suite.
+ *
+ * A boundary that drops the callback strands every `write(chunk, cb)` caller, and one that always
+ * returns `true` tells a piping writer there is no back-pressure while the pipe fills.
+ */
+test("only the chunk is replaced — encoding, callback and back-pressure pass through", () => {
+  const seen: { chunk: unknown; encoding: unknown; callback: unknown }[] = [];
+  const stream: TerminalStream = {
+    write(chunk: unknown, encoding?: unknown, callback?: unknown) {
+      seen.push({ chunk, encoding, callback });
+      return false; // the real signal: the buffer is full, stop writing
+    },
+  };
+  installTerminalBoundary([stream]);
+  const done = () => {};
+
+  assert.equal(stream.write(`x${HOSTILE}\n`, "utf8", done), false, "back-pressure was swallowed");
+  assert.equal(seen[0].encoding, "utf8");
+  assert.equal(seen[0].callback, done);
+  assert.equal(typeof seen[0].chunk, "string", "a string in stays a string out");
+
+  // A Buffer in stays a Buffer out: the chunk's TYPE survives, not only its text.
+  stream.write(Buffer.from(`y${HOSTILE}\n`, "utf8"), "utf8", done);
+  assert.equal(Buffer.isBuffer(seen[1].chunk), true);
+  assert.match(String(seen[1].chunk), new RegExp(DEFANGED));
+
+  // A non-Buffer typed array is raw bytes, not a terminal render. Passed through as the SAME
+  // object, so nothing re-encodes a caller's binary payload — documented at the wrapper since it
+  // was written, and untested until now.
+  const raw = new Uint8Array([0x1b, 0x5b, 0x33, 0x31, 0x6d]);
+  stream.write(raw, undefined, done);
+  assert.equal(seen[2].chunk, raw, "a typed array that is not a Buffer must reach the stream intact");
+});
+
+/**
+ * What a sequence split across two writes costs, stated rather than assumed.
+ *
+ * The boundary sees one chunk at a time and keeps no cross-write state, so a `\x1b[` in one write
+ * and `31m` in the next cannot be matched as one sequence. What it does instead is take the
+ * INTRODUCER with the first chunk — the final byte of every form is optional exactly so a truncated
+ * sequence still loses it — and the remainder then arrives as literal text a terminal prints rather
+ * than obeys. Correct, and until now nowhere written down.
+ */
+test("an escape split across two writes still loses its introducer", () => {
+  const stream = capture();
+  installTerminalBoundary([stream]);
+  stream.write("a\x1b[");
+  stream.write("31mb\n");
+  assert.equal(ACTIONABLE.test(stream.text), false, JSON.stringify(stream.text));
+  assert.match(stream.text, /31mb/, "the orphaned tail is shown as text, which is the honest rendering");
+});
+
+/**
+ * THE DEFAULT STREAM LIST — the half of the boundary nothing bound.
+ *
+ * Every test above hands `installTerminalBoundary` an explicit stream, which is what a test must do
+ * to observe it — and it means the argument that actually SHIPS was exercised by nothing. Deleting
+ * `process.stderr` from the default left 302/302 green, and stderr is the sink issue #78 names: a
+ * `setupCommand` running `npm ci` inside the untrusted clone authors `setup.output`, `witness.ts`
+ * interpolates 200 characters of it into a `fail()`, and `cli.ts` prints that with `console.error`.
+ *
+ * Driven as a process because that is the only place `process.stdout` and `process.stderr` are the
+ * real things: wrapping this suite's own streams in-process would rewrite the reporter underneath
+ * the run.
+ */
+test("the default stream list is both halves of the terminal — stdout AND stderr", () => {
+  const dir = scratch("foundry-streams-");
+  const script = join(dir, "default-streams.mjs");
+  writeFileSync(
+    script,
+    `import { installTerminalBoundary } from ${JSON.stringify(pathToFileURL(TERMINAL).href)};\n` +
+      `const hostile = ${JSON.stringify(HOSTILE)};\n` +
+      // No argument: the production call, exactly as every entry point makes it.
+      `installTerminalBoundary();\n` +
+      `process.stdout.write(hostile + "\\n");\n` +
+      // #78's named sink, reached the way a refusal reaches it.
+      `console.error("witness: setup command failed — " + hostile);\n`,
+  );
+
+  const run = spawnNode(script, []);
+  assert.equal(run.code, 0, `${run.stdout}${run.stderr}`);
+  for (const [name, text] of [
+    ["stdout", run.stdout],
+    ["stderr", run.stderr],
+  ] as const) {
+    // Order matters: the raw-bytes check names the real fault. A stream left out of the default
+    // list carries the probe as RAW escapes, in which case `concealedrepaintedgreen` is not
+    // contiguous either — and "carried none of the probe" would be a true statement about the
+    // wrong thing.
+    assert.equal(
+      ACTIONABLE.test(text),
+      false,
+      `${name} is not in the default stream list: raw control bytes reached it\n${JSON.stringify(text)}`,
+    );
+    assert.match(
+      text,
+      new RegExp(DEFANGED),
+      `${name} carried none of the probe — this drive proves nothing:\n${JSON.stringify(text)}`,
+    );
+    assert.match(text, DISCLOSED, `${name} was stripped without saying so:\n${JSON.stringify(text)}`);
+  }
+});
+
+/**
+ * A preload that makes any entry point print hostile bytes THROUGH ITS OWN `console`.
+ *
+ * The injection has to sit ABOVE the stream, not below it. `installTerminalBoundary` replaces
+ * `stream.write` and is therefore the outermost wrapper by construction, so anything that hooks the
+ * stream first ends up INSIDE the boundary and its bytes are emitted after sanitising — proving
+ * nothing. `console.log` / `console.error` are the layer above: a wrapper there is exactly a verb
+ * that printed third-party text, which is the class the boundary claims to cover.
+ *
+ * The stream probe fires from inside the entry point's FIRST print, and both halves of it matter:
+ *   · it is the entry point's own output that carries it, so an install that happens AFTER the
+ *     first `console.log` (or under an `if (process.stdout.isTTY)` that is false in a runner) is
+ *     caught by bytes already on the pipe;
+ *   · it writes to stdout AND stderr, so the default stream list is bound per entry point too.
+ * Not from a `process.on("exit")` handler, which would be the obvious place: piped stdio is
+ * asynchronous on macOS and an exit-time write is a truncated one.
+ *
+ * `fetch` is replaced because a guard that reaches the network is a guard that fails on a plane. A
+ * 500 is the shortest path from `verify-ledger.ts` to a printed line.
+ */
+function boundaryProbe(): string {
+  const dir = scratch("foundry-probe-");
+  const preload = join(dir, "probe.mjs");
+  writeFileSync(
+    preload,
+    `const HOSTILE = ${JSON.stringify(HOSTILE)};
+let probed = false;
+function probe() {
+  if (probed) return;
+  probed = true;
+  process.stdout.write(HOSTILE + " probe-stdout\\n");
+  process.stderr.write(HOSTILE + " probe-stderr\\n");
+}
+for (const name of ["log", "error"]) {
+  const inner = console[name].bind(console);
+  console[name] = (...args) => {
+    probe();
+    inner(HOSTILE, ...args);
+  };
+}
+globalThis.fetch = async () =>
+  new Response(JSON.stringify({ message: "boundary probe: this guard does not use the network" }), {
+    status: 500,
+    headers: { "content-type": "application/json" },
+  });
+`,
+  );
+  return preload;
+}
 
 /**
  * THE CLASS INVARIANT — the assertion round 1 did not have, and the reason it failed.
@@ -138,45 +383,117 @@ test("installing the boundary twice does not sanitise twice or double the disclo
  * the boundary is installed on the process's own streams, which means no sink can bypass it, and
  * the only remaining way out is a NEW ENTRY POINT that never installs it.
  *
- * Entry points are therefore DISCOVERED — from `package.json`'s scripts and from the workflow that
- * runs unattended — rather than listed here. Add `factory/whatever.ts` to either, and this test
- * fails until it either installs the boundary or is written into `EXEMPT` with a reason.
+ * BEHAVIOURAL, NOT A GREP. Round 2 stated this as `/installTerminalBoundary\(\)/.test(source)`, and
+ * a regex that matches inside a comment is not evidence that anything runs. Four realistic
+ * regressions survived it green: commenting the call out in `verify-ledger.ts`; commenting it out in
+ * `validate-allowlist.ts`; guarding it with `if (process.stdout.isTTY)`, which is FALSE in the
+ * Actions runner where the unattended six-hour clock actually runs, so the boundary would have been
+ * off exactly where nobody is watching; and moving the call to the LAST line of
+ * `validate-allowlist.ts`, after every `console.log` it makes. Only `cli.ts` had any behavioural
+ * backup, and nothing anywhere checked "installed before anything prints".
+ *
+ * So each entry point is SPAWNED and made to print, and the assertion is over its bytes. That binds
+ * the install, the ordering and the default stream list at once, and no comment can satisfy it.
+ *
+ * Entry points are DISCOVERED — from `package.json`'s scripts and from the workflow that runs
+ * unattended — rather than listed here. Add `factory/whatever.ts` to either, and this test fails
+ * until it has a drive below, or is written into `EXEMPT` with a reason.
  */
-test("every operator entry point installs the terminal boundary — a tenth sink cannot bypass it", () => {
+test("every operator entry point installs the terminal boundary — driven, not grepped", () => {
   const scripts = Object.values(
     JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8")).scripts as Record<string, string>,
   );
   const workflows = readdirSync(join(REPO_ROOT, ".github/workflows")).map((f) =>
     readFileSync(join(REPO_ROOT, ".github/workflows", f), "utf8"),
   );
+  /**
+   * `_`, `.` and `/` are in the class because they were not, and the omission was the second hole
+   * in this guard: `factory/rogue_verb.ts`, `factory/rogue.verb.ts` and `factory/tools/deep.ts` were
+   * all invisible to `[A-Za-z0-9-]+`, so three uninstalled entry points passed green while the
+   * comment above promised the opposite.
+   */
+  const ENTRY_POINT = /factory\/([A-Za-z0-9_.-]+(?:\/[A-Za-z0-9_.-]+)*\.ts)/g;
   const entryPoints = new Set<string>();
   for (const text of [...scripts, ...workflows]) {
-    for (const m of text.matchAll(/factory\/([A-Za-z0-9-]+\.ts)/g)) entryPoints.add(m[1]);
+    for (const m of text.matchAll(ENTRY_POINT)) entryPoints.add(m[1]);
   }
   assert.ok(entryPoints.size >= 4, `entry-point discovery found only ${[...entryPoints].join(", ")}`);
   for (const expected of ["cli.ts", "verify-ledger.ts", "validate-allowlist.ts", "run-tests.ts"]) {
     assert.ok(entryPoints.has(expected), `discovery missed ${expected}; the regex above has drifted`);
+  }
+  // The discovery itself, pinned against the shapes it used to miss.
+  for (const shape of ["factory/rogue_verb.ts", "factory/rogue.verb.ts", "factory/tools/deep.ts"]) {
+    assert.deepEqual(
+      [...shape.matchAll(ENTRY_POINT)].map((m) => m[1]),
+      [shape.slice("factory/".length)],
+      `${shape} is invisible to entry-point discovery, so it could ship without the boundary`,
+    );
   }
 
   /**
    * The one exemption, and it is not an operator surface. `run-tests.ts` pipes `node:test`'s own
    * reporter into stdout — our output, legitimately coloured — and wrapping that stream would strip
    * the colour a developer reads the suite by. It prints no third-party text: its inputs are this
-   * repository's own test files.
+   * repository's own test files. Asserted by source and not by a drive on purpose: the drive would
+   * be this suite running itself.
    */
   const EXEMPT = new Map([["run-tests.ts", "pipes node:test's own reporter; prints no third-party text"]]);
 
+  /**
+   * How to make each entry point print, offline. A drive is not optional: an entry point with no
+   * way to observe its output is an entry point whose boundary nobody can check.
+   *   · `cli.ts --help` is the shortest verb that prints.
+   *   · `validate-allowlist.ts` takes no arguments and prints four lines.
+   *   · `verify-ledger.ts` reads the committed seed and asks GitHub; the probe's 500 puts it on its
+   *     `console.error` + `exit(1)` path, which is the stderr half in its own right.
+   */
+  const DRIVES = new Map<string, { args: string[]; code: number }>([
+    ["cli.ts", { args: ["--help"], code: 0 }],
+    ["validate-allowlist.ts", { args: [], code: 0 }],
+    ["verify-ledger.ts", { args: [], code: 1 }],
+  ]);
+
+  const probe = boundaryProbe();
   for (const file of [...entryPoints].sort()) {
-    const source = readFileSync(resolve(REPO_ROOT, "factory", file), "utf8");
-    const installs = /installTerminalBoundary\(\)/.test(source);
     if (EXEMPT.has(file)) {
-      assert.equal(installs, false, `${file} is listed EXEMPT but installs the boundary — pick one`);
+      const source = readFileSync(resolve(REPO_ROOT, "factory", file), "utf8");
+      assert.equal(
+        /installTerminalBoundary\(/.test(source),
+        false,
+        `${file} is listed EXEMPT but installs the boundary — pick one`,
+      );
       continue;
     }
-    assert.equal(
-      installs,
-      true,
-      `factory/${file} is an entry point that never installs the terminal boundary: third-party bytes it prints reach the operator's terminal raw. Call installTerminalBoundary() before it prints anything, or add it to EXEMPT above with the reason it prints nothing third-party.`,
+    const drive = DRIVES.get(file);
+    assert.ok(
+      drive,
+      `factory/${file} is a discovered entry point with no drive in this test. Add one — arguments that make it print, offline — or add it to EXEMPT above with the reason it prints nothing third-party. A drive is how this guard stopped being a grep.`,
+    );
+
+    const run = spawnNode(resolve(REPO_ROOT, "factory", file), drive.args, { preload: probe });
+    assert.equal(run.code, drive.code, `factory/${file} ${drive.args.join(" ")}:\n${run.stdout}${run.stderr}`);
+    for (const [name, text] of [
+      ["stdout", run.stdout],
+      ["stderr", run.stderr],
+    ] as const) {
+      // The raw-bytes assertion goes FIRST, because an entry point that never installs the boundary
+      // fails both: its probe arrives as raw escapes, so `concealedrepaintedgreen` is not contiguous
+      // in it either, and "wrote nothing" would be the wrong diagnosis of the right failure.
+      assert.equal(
+        ACTIONABLE.test(text),
+        false,
+        `factory/${file} let raw terminal control bytes reach ${name}. Either it never calls installTerminalBoundary(), or it calls it AFTER it starts printing, or it calls it on a stream list that leaves ${name} out.\n${JSON.stringify(text)}`,
+      );
+      assert.match(
+        text,
+        new RegExp(DEFANGED),
+        `factory/${file} wrote nothing to ${name}, so this drive asserts nothing about it. Pick arguments that print on both streams.\n${JSON.stringify(text)}`,
+      );
+    }
+    assert.match(
+      `${run.stdout}${run.stderr}`,
+      DISCLOSED,
+      `factory/${file} stripped the probe without disclosing it — a sanitiser that tidies in silence is itself a concealment channel`,
     );
   }
 });

--- a/factory/terminal.test.ts
+++ b/factory/terminal.test.ts
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, resolve } from "node:path";
+import { test } from "node:test";
+import {
+  installTerminalBoundary,
+  sanitizeTerminalText,
+  terminalBoundaryNotice,
+  type TerminalStream,
+} from "./terminal.ts";
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+
+/** A stream that records what the boundary actually handed to the real `write`. */
+function capture(): TerminalStream & { written: string[]; text: string } {
+  const written: string[] = [];
+  return {
+    written,
+    get text() {
+      return written.join("");
+    },
+    write(chunk: unknown) {
+      written.push(typeof chunk === "string" ? chunk : String(chunk));
+      return true;
+    },
+  };
+}
+
+/** Everything a terminal ACTS on rather than shows. `\n` and `\t` are not in it. */
+// eslint-disable-next-line no-control-regex
+const ACTIONABLE = /[\x00-\x08\x0b-\x1f\x7f-\x9f]/;
+
+/**
+ * A hostile repository's greatest hits, in one string.
+ *
+ * `\x1b[8m` is the one that matters most and it is the reason this boundary exists rather than a
+ * ninth per-sink call: SGR conceal, never reset, hides every line the terminal paints AFTER it. A
+ * `CONTRIBUTING.md` carrying it early suppresses each disclosure issue #77 added — the
+ * end-of-excerpt marker, the split scan claim, the verdict, the "not the arbiter" line — using the
+ * mechanism the same commit was filed to close.
+ */
+const HOSTILE = "\x1b]52;c;cm0gLXJmIH4=\x07\x1b[8mconcealed\r\x1b[2Jrepainted\x9b31mgreen\x9d0;title\x07";
+
+test("the sanitiser removes whole sequences, keeps the shape of a log, and says how much it took", () => {
+  const clean = sanitizeTerminalText(HOSTILE);
+  assert.equal(ACTIONABLE.test(clean.text), false, JSON.stringify(clean.text));
+  assert.equal(clean.text, "concealedrepaintedgreen");
+  assert.ok(clean.removed > 0);
+  assert.equal(clean.removed, HOSTILE.length - clean.text.length);
+
+  // Whole or not at all: `]52;c;<base64>` must not survive as text, one concatenation from working.
+  assert.equal(clean.text.includes("52;c;"), false);
+  assert.equal(clean.text.includes("31m"), false);
+
+  // `\n` and `\t` are the shape of a test log and of a policy document. A diagnostic flattened to
+  // one line is the diagnostic thrown away.
+  const log = "FAIL spec.ts\n\tat line 3\n";
+  assert.deepEqual(sanitizeTerminalText(log), { text: log, removed: 0 });
+});
+
+/**
+ * The sanitiser must not swallow the diagnostic it exists to preserve.
+ *
+ * Its own comment promised that "an unterminated OSC should cost the operator that one sequence,
+ * not every line of the run log after it" — and the body class `[^\x07\x1b\x9c]*` included `\n`, so
+ * it ran to the end of the input and did exactly the opposite. A repository whose output contained a
+ * bare `\x1b]0;t` lost EVERY line after it, including the real failure: issue #78's own harm
+ * ("conceal its own failure output") achieved THROUGH the sanitiser rather than around it.
+ */
+test("an unterminated OSC costs its own line, not the rest of the run log", () => {
+  const run = "\x1b]0;t\nFAIL src/auth.test.ts\n  expected 200, got 500\n  at verify (src/auth.ts:31)\n";
+  const clean = sanitizeTerminalText(run);
+  assert.match(clean.text, /FAIL src\/auth\.test\.ts/);
+  assert.match(clean.text, /expected 200, got 500/);
+  assert.match(clean.text, /at verify \(src\/auth\.ts:31\)/);
+  assert.equal(clean.text.split("\n").length, run.split("\n").length, clean.text);
+  // The sequence itself is gone, introducer and parameters together.
+  assert.equal(clean.text.includes("\x1b"), false);
+
+  // The bound is the LINE the introducer sits on: that line's remainder is forfeit, and it stops
+  // there. Stated as an assertion rather than left implicit, because the difference between "this
+  // line" and "everything after" is the whole diagnostic.
+  const inline = sanitizeTerminalText("\x1b]0;tFAIL one\nFAIL two\n");
+  assert.equal(inline.text, "\nFAIL two\n");
+
+  // A terminated OSC still loses its whole body, newline or no newline in the text around it.
+  assert.equal(sanitizeTerminalText("a\x1b]0;title\x07b").text, "ab");
+});
+
+test("the boundary sanitises every write to a stream, whatever printed it", () => {
+  const stream = capture();
+  installTerminalBoundary([stream]);
+
+  // Three different "sinks", none of which knows the boundary exists — which is the point.
+  stream.write(`freeze excerpt: ${HOSTILE}\n`);
+  stream.write(Buffer.from(`witness stdout: ${HOSTILE}\n`, "utf8"));
+  stream.write(`matched phrase: ${HOSTILE}\n`);
+
+  assert.equal(ACTIONABLE.test(stream.text), false, JSON.stringify(stream.text));
+  assert.equal(stream.written.length, 3, "one write in, one write out — no reordering");
+  for (const line of stream.written) assert.match(line, /concealedrepaintedgreen/);
+});
+
+test("the boundary discloses what it removed rather than tidying in silence", () => {
+  const stream = capture();
+  installTerminalBoundary([stream]);
+
+  stream.write(`policy text: ${HOSTILE}\n`);
+  const removed = sanitizeTerminalText(HOSTILE).removed;
+  assert.match(stream.text, new RegExp(`${removed} byte\\(s\\) of terminal control sequence removed`));
+  assert.equal(stream.text.includes(terminalBoundaryNotice(removed)), true, stream.text);
+
+  // A sink that sanitised upstream leaves nothing to remove, so the notice appears exactly once per
+  // write and never as noise on clean output.
+  const clean = capture();
+  installTerminalBoundary([clean]);
+  clean.write("tests are red at head d91fe2f (exit 1) — nothing to witness\n");
+  assert.equal(clean.text.includes("removed"), false, clean.text);
+  assert.equal(clean.written.length, 1);
+});
+
+test("installing the boundary twice does not sanitise twice or double the disclosure", () => {
+  const stream = capture();
+  installTerminalBoundary([stream]);
+  installTerminalBoundary([stream]);
+  stream.write(`x${HOSTILE}\n`);
+  const notices = stream.text.match(/byte\(s\) of terminal control sequence removed/g) ?? [];
+  assert.equal(notices.length, 1, stream.text);
+});
+
+/**
+ * THE CLASS INVARIANT — the assertion round 1 did not have, and the reason it failed.
+ *
+ * Round 1 fixed issue #78 at two sinks and its test named those two sinks. A test that names call
+ * sites can never see a third, and there were nine: seven raw `fail()` sites in `witness.ts`, the
+ * freeze excerpt, and `policy.matchedPhrases`. So the invariant is stated over the CLASS instead:
+ * the boundary is installed on the process's own streams, which means no sink can bypass it, and
+ * the only remaining way out is a NEW ENTRY POINT that never installs it.
+ *
+ * Entry points are therefore DISCOVERED — from `package.json`'s scripts and from the workflow that
+ * runs unattended — rather than listed here. Add `factory/whatever.ts` to either, and this test
+ * fails until it either installs the boundary or is written into `EXEMPT` with a reason.
+ */
+test("every operator entry point installs the terminal boundary — a tenth sink cannot bypass it", () => {
+  const scripts = Object.values(
+    JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8")).scripts as Record<string, string>,
+  );
+  const workflows = readdirSync(join(REPO_ROOT, ".github/workflows")).map((f) =>
+    readFileSync(join(REPO_ROOT, ".github/workflows", f), "utf8"),
+  );
+  const entryPoints = new Set<string>();
+  for (const text of [...scripts, ...workflows]) {
+    for (const m of text.matchAll(/factory\/([A-Za-z0-9-]+\.ts)/g)) entryPoints.add(m[1]);
+  }
+  assert.ok(entryPoints.size >= 4, `entry-point discovery found only ${[...entryPoints].join(", ")}`);
+  for (const expected of ["cli.ts", "verify-ledger.ts", "validate-allowlist.ts", "run-tests.ts"]) {
+    assert.ok(entryPoints.has(expected), `discovery missed ${expected}; the regex above has drifted`);
+  }
+
+  /**
+   * The one exemption, and it is not an operator surface. `run-tests.ts` pipes `node:test`'s own
+   * reporter into stdout — our output, legitimately coloured — and wrapping that stream would strip
+   * the colour a developer reads the suite by. It prints no third-party text: its inputs are this
+   * repository's own test files.
+   */
+  const EXEMPT = new Map([["run-tests.ts", "pipes node:test's own reporter; prints no third-party text"]]);
+
+  for (const file of [...entryPoints].sort()) {
+    const source = readFileSync(resolve(REPO_ROOT, "factory", file), "utf8");
+    const installs = /installTerminalBoundary\(\)/.test(source);
+    if (EXEMPT.has(file)) {
+      assert.equal(installs, false, `${file} is listed EXEMPT but installs the boundary — pick one`);
+      continue;
+    }
+    assert.equal(
+      installs,
+      true,
+      `factory/${file} is an entry point that never installs the terminal boundary: third-party bytes it prints reach the operator's terminal raw. Call installTerminalBoundary() before it prints anything, or add it to EXEMPT above with the reason it prints nothing third-party.`,
+    );
+  }
+});
+
+/**
+ * And the boundary is the ONLY definition of the strip, so there is one rule rather than a rule and
+ * a copy of it. The copy is how this repository has shipped the same defect repeatedly.
+ */
+test("the sanitiser has exactly one home", () => {
+  const owners = readdirSync(join(REPO_ROOT, "factory"))
+    .filter((f) => f.endsWith(".ts") && !f.endsWith(".test.ts"))
+    .filter((f) => /export function sanitizeTerminalText/.test(readFileSync(join(REPO_ROOT, "factory", f), "utf8")));
+  assert.deepEqual(owners, ["terminal.ts"]);
+});

--- a/factory/terminal.ts
+++ b/factory/terminal.ts
@@ -1,0 +1,151 @@
+/**
+ * The ONE boundary between third-party bytes and the operator's terminal.
+ *
+ * WHY THIS IS A MODULE AND NOT A CALL AT EACH SINK. Issue #78 was fixed at two sinks —
+ * `runFailureDetail` and `resolveToolchain` — and a review of that fix found at least seven more,
+ * all of them live:
+ *
+ *   · seven raw `fail()` sites in `witness.ts` interpolating `X.output.slice(0, 200)`, reachable
+ *     because `allowlist.yaml` runs `setupCommand: npm ci` with cwd inside the untrusted clone, so
+ *     that repository's lifecycle scripts author every byte of the refusal an operator then reads;
+ *   · the freeze excerpt in `packet.ts` — the target repository's own CONTRIBUTING/AGENTS.md, at
+ *     the same trust level as witnessed stdout and with LESS containment, since nothing sandboxes
+ *     a fetched document;
+ *   · `policy.matchedPhrases`, which are substrings of that same text.
+ *
+ * The freeze one is the argument for doing this as a class rather than as a ninth patch. A hostile
+ * `CONTRIBUTING.md` that places `\x1b[8m` (SGR conceal, never reset) early in its text hides every
+ * line the terminal paints after it — which is every disclosure issue #77 added: the end-of-excerpt
+ * marker, the split scan claim, the verdict, and the "high-recall suggester, not the arbiter" line.
+ * A repository that does not want to be read could therefore suppress the notice added to tell the
+ * operator it had not been read, using the mechanism the same commit was filed to close. Patching
+ * one more sink leaves the tenth.
+ *
+ * So the boundary is the process's own terminal streams, installed once by each entry point. It is
+ * not a sink that can be forgotten: a `console.log` added tomorrow, by anyone, in any verb, is
+ * already behind it. The only way past is a NEW entry point that never installs it, and
+ * `terminal.test.ts` asserts every entry point does — discovering them from `package.json` and the
+ * workflow rather than from a list, so a new one fails until it decides.
+ *
+ * RENDERING, NOT RECORD. Everything persisted keeps the original bytes: the witness run logs on
+ * disk, the sha256 computed over them, the ledger. What is sanitised is the copy a human reads.
+ * The audit trail is unchanged; a `git show` of a run log still shows exactly what the repository
+ * emitted.
+ */
+
+/**
+ * ANSI/OSC/DCS/APC and friends, as full sequences rather than as a lone `\x1b` (issue #78).
+ *
+ * Stripping only the introducer would leave `]52;c;<base64>` sitting in the text, one concatenation
+ * away from being a working OSC 52 again — so a sequence is removed whole or not at all.
+ *
+ * Both encodings of each introducer are handled, because a strip that knows only about `\x1b` is a
+ * strip a terminal in 8-bit mode walks straight through: `\x9b` IS `\x1b[` and `\x9d` IS `\x1b]`,
+ * so they take the same body grammar rather than merely losing their first byte and leaving the
+ * parameters behind as text.
+ *
+ * The string-terminated forms are bounded by `[^\x07\x1b\x9c\n]*`, and the `\n` in that set is
+ * load-bearing. Without it an unterminated OSC ran to the end of the input, so a run whose output
+ * contained a bare `\x1b]0;t` lost EVERY line after it — including the real failure. That is issue
+ * #78's own harm ("conceal its own failure output") achieved through the sanitiser rather than
+ * around it, and it is why the bound is stated per line: an unterminated sequence costs the
+ * operator that one sequence, not the rest of the run log. A real OSC payload (a title, an OSC 52
+ * base64 body) never contains a newline, so nothing legitimate is split by this.
+ *
+ * The final byte of each form is optional so a sequence truncated by a tail slice still loses its
+ * introducer and parameters.
+ */
+const TERMINAL_SEQUENCE = new RegExp(
+  [
+    // OSC / DCS / SOS / PM / APC: introducer, string body, string terminator.
+    "(?:\\x1b[\\]PX^_]|[\\x9d\\x90\\x98\\x9e\\x9f])[^\\x07\\x1b\\x9c\\n]*(?:\\x07|\\x1b\\\\|\\x9c)?",
+    // CSI: parameter bytes, intermediate bytes, final byte.
+    "(?:\\x1b\\[|\\x9b)[0-?]*[ -/]*[@-~]?",
+    // Any other two-character escape sequence, and a lone ESC.
+    "\\x1b[@-Z\\\\-_]?",
+  ].join("|"),
+  "g",
+);
+/** Everything else a terminal acts on rather than shows: C0, DEL, C1. `\n` and `\t` are not that. */
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHAR = /[\x00-\x08\x0b-\x1f\x7f-\x9f]/g;
+
+/**
+ * Make text safe to put in front of an operator.
+ *
+ * The subject is any THIRD-PARTY text: a witnessed repository's stdout (executed in a sandbox
+ * precisely because it is not trusted), a fetched CONTRIBUTING/AGENTS.md, a phrase quoted out of
+ * one, an issue title. With control sequences intact that text can repaint a red witness as green
+ * (`\r` plus a cursor move), scroll its own failure out of the scrollback, hide every line printed
+ * after it (`\x1b[8m`), or invoke a terminal action outright (OSC 52 writes the clipboard).
+ *
+ * `\n` and `\t` are kept: they are the shape of a test log and of a policy document, and a
+ * diagnostic flattened to one line is the diagnostic thrown away.
+ *
+ * `removed` is returned rather than discarded so a caller can say that something was taken out. A
+ * sanitiser that silently tidies hostile output is itself a concealment channel: the operator would
+ * see a coherent transcript with no sign that the coherence was ours.
+ */
+export function sanitizeTerminalText(text: string): { text: string; removed: number } {
+  const stripped = text.replace(TERMINAL_SEQUENCE, "").replace(CONTROL_CHAR, "");
+  return { text: stripped, removed: text.length - stripped.length };
+}
+
+/**
+ * What the boundary says when it had to remove something.
+ *
+ * The removal is disclosed for the same reason `runFailureDetail` discloses its own: a sanitiser
+ * that quietly tidies hostile output hands the operator a coherent transcript with no sign that the
+ * coherence was ours. A sink that sanitises upstream (`runFailureDetail`, `resolveToolchain`) hands
+ * the boundary text with nothing left to remove, so this line appears exactly once per write and
+ * names only bytes no sink had already accounted for.
+ */
+export function terminalBoundaryNotice(removed: number): string {
+  return `  [foundry: ${removed} byte(s) of terminal control sequence removed from the third-party text above — a repository does not get to move your cursor or hide the lines under it. The records on disk keep the original bytes.]`;
+}
+
+/** Streams already wrapped, so a second install is a no-op rather than a second sanitising pass. */
+const WRAPPED = new WeakSet<object>();
+
+/** The minimum a stream must offer to be wrapped — enough for a test to pass a fake one. */
+export interface TerminalStream {
+  write(chunk: unknown, encoding?: unknown, callback?: unknown): boolean;
+}
+
+/**
+ * Route every byte this process writes to the operator's terminal through `sanitizeTerminalText`.
+ *
+ * Called by each entry point (`cli.ts`, `verify-ledger.ts`, `validate-allowlist.ts`) as the first
+ * thing it does, and by nothing else. `run-tests.ts` is deliberately exempt and `terminal.test.ts`
+ * says why: it pipes `node:test`'s own reporter, which is our output and legitimately coloured.
+ *
+ * Installed at the stream and not at each `console.*` call on purpose. A sink-by-sink fix is a list
+ * that has to stay complete, and this repository has now shipped an incomplete one twice; a stream
+ * has no list. Only the CHUNK is replaced — the encoding and callback arguments are passed through
+ * untouched — so back-pressure, `drain`, and write callbacks behave exactly as before.
+ */
+export function installTerminalBoundary(
+  streams: TerminalStream[] = [process.stdout, process.stderr],
+): void {
+  for (const stream of streams) {
+    if (WRAPPED.has(stream)) continue;
+    WRAPPED.add(stream);
+    const inner = stream.write.bind(stream);
+    stream.write = (chunk: unknown, encoding?: unknown, callback?: unknown): boolean => {
+      const text =
+        typeof chunk === "string"
+          ? chunk
+          : Buffer.isBuffer(chunk)
+            ? chunk.toString("utf8")
+            : undefined;
+      // Not text at all (a typed array of raw bytes) — not a terminal render, so not ours to touch.
+      if (text === undefined) return inner(chunk, encoding, callback);
+      const scrubbed = sanitizeTerminalText(text);
+      const out =
+        scrubbed.removed === 0
+          ? scrubbed.text
+          : `${scrubbed.text}${scrubbed.text === "" || scrubbed.text.endsWith("\n") ? "" : "\n"}${terminalBoundaryNotice(scrubbed.removed)}\n`;
+      return inner(typeof chunk === "string" ? out : Buffer.from(out, "utf8"), encoding, callback);
+    };
+  }
+}

--- a/factory/terminal.ts
+++ b/factory/terminal.ts
@@ -23,9 +23,28 @@
  *
  * So the boundary is the process's own terminal streams, installed once by each entry point. It is
  * not a sink that can be forgotten: a `console.log` added tomorrow, by anyone, in any verb, is
- * already behind it. The only way past is a NEW entry point that never installs it, and
- * `terminal.test.ts` asserts every entry point does — discovering them from `package.json` and the
- * workflow rather than from a list, so a new one fails until it decides.
+ * already behind it. `terminal.test.ts` DRIVES every entry point it discovers from `package.json`
+ * and the workflow — spawning each one with a probe that prints hostile bytes through its own
+ * `console`, rather than grepping its source — so a new entry point fails until it either installs
+ * the boundary or is written into `EXEMPT` with a reason.
+ *
+ * WHAT IT DOES NOT COVER, said out loud rather than implied. This paragraph used to claim that "the
+ * only way past is a NEW entry point that never installs it". That is the claim about SINKS, and it
+ * holds; it is not a claim about every byte the process can emit, and two paths reach the terminal
+ * without going through `stream.write` as this module replaces it:
+ *
+ *   · Node's own fatal-exception printer. An uncaught `Error` is formatted and written by the
+ *     runtime, not by a `console.*` call. Latent rather than live on this tree: every `throw new
+ *     Error` in this repository is in `load-allowlist.ts`, `policy-records.ts` or
+ *     `validate-allowlist.ts` and interpolates OUR OWN committed files, while every GitHub read
+ *     parses its response inside a `try`/`catch` that returns `{ ok: false }` rather than throwing.
+ *     So the hole has nothing in it. It is named so the next `throw new Error(thirdPartyText)` is
+ *     recognised as putting something in it.
+ *   · A non-`Buffer` typed array, which the wrapper passes through untouched on purpose (see the
+ *     comment at the `text === undefined` branch below). Nothing in this repository writes one.
+ *
+ * So: no SINK can bypass the boundary, and that is what the boundary is for. "Nothing can" would be
+ * a larger claim than the mechanism supports.
  *
  * RENDERING, NOT RECORD. Everything persisted keeps the original bytes: the witness run logs on
  * disk, the sha256 computed over them, the ledger. What is sanitised is the copy a human reads.

--- a/factory/validate-allowlist.ts
+++ b/factory/validate-allowlist.ts
@@ -1,6 +1,13 @@
 import { readFileSync } from "node:fs";
 import { assertAllowlist, loadAllowlistFile } from "./load-allowlist.ts";
 import { parsePolicyRecords, policyRecordsPath } from "./policy-records.ts";
+import { installTerminalBoundary } from "./terminal.ts";
+
+// Uniform with the other entry points on purpose. What `validate` prints today is ours — repo
+// ids off the roster — but the maintainer prose in `policy-records.json` is one throw away, and
+// an entry point that is exempt "because it only prints our own strings" is the exemption the
+// next print lands behind. Zero exemptions except the test harness; see cli.test.ts.
+installTerminalBoundary();
 
 const parsed = loadAllowlistFile();
 assertAllowlist(parsed);

--- a/factory/verify-ledger.ts
+++ b/factory/verify-ledger.ts
@@ -1,6 +1,7 @@
 import { packetChecks } from "./ledger-check.ts";
 import { revertCheck, syncGithubPr } from "./github-pr.ts";
 import { seedState } from "./seed.ts";
+import { installTerminalBoundary } from "./terminal.ts";
 
 // Clock-side, read-only: the committed seed ledger must match GitHub. A divergence — the published
 // ledger asserting something GitHub contradicts — fails the run visibly, so drift is caught within
@@ -12,6 +13,11 @@ import { seedState } from "./seed.ts";
 // Failing CI on them would leave the default branch red for days with nothing to merge that fixes
 // it, which is the pressure that gets a SHA re-stamped by someone who wants green. Issue #49: the
 // clock says the ledger reconciles AND says the proof is behind, and means both.
+// The clock renders third-party text too: a pull request body, a divergence quoting one, an error
+// string GitHub wrote. Same boundary as `cli.ts`, installed before the first line is printed —
+// this runs unattended every six hours and its output is read as the record of what was checked.
+installTerminalBoundary();
+
 const state = seedState();
 const withPr = state.packets.filter((p) => p.prUrl);
 const fatal: string[] = [];

--- a/factory/witness.ts
+++ b/factory/witness.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { sanitizeTerminalText } from "./terminal.ts";
 import type { EvidenceWitness, SandboxKind, Wave } from "./types.ts";
 
 /**
@@ -104,62 +105,20 @@ export const PREFLIGHT_INVOCATION = "node --experimental-strip-types factory/cli
 export const WITNESS_TAIL_LINES = 40;
 
 /**
- * ANSI/OSC/DCS/APC and friends, as full sequences rather than as a lone `\x1b` (issue #78).
+ * The one boundary between third-party bytes and the operator's terminal now lives in
+ * `terminal.ts`, and this module is one of its CALLERS rather than its owner.
  *
- * Stripping only the introducer would leave `]52;c;<base64>` sitting in the text, one concatenation
- * away from being a working OSC 52 again — so a sequence is removed whole or not at all.
+ * It moved because the name was making the mistake. A sanitiser that lives in `witness.ts` reads as
+ * a witness concern, and issue #78's fix was scoped to witness sinks accordingly — while the freeze
+ * printed a fetched CONTRIBUTING raw, seven `fail()` sites here printed `setupCommand` output raw,
+ * and the class stayed open. The subject was never "the witness"; it is any text a third party
+ * wrote that a human is about to read.
  *
- * Both encodings of each introducer are handled, because a strip that knows only about `\x1b` is a
- * strip a terminal in 8-bit mode walks straight through: `\x9b` IS `\x1b[` and `\x9d` IS `\x1b]`,
- * so they take the same body grammar rather than merely losing their first byte and leaving the
- * parameters behind as text.
- *
- * The string-terminated forms are bounded by `[^\x07\x1b\x9c]*` rather than allowed to run to the
- * end of the input: an unterminated OSC should cost the operator that one sequence, not every line
- * of the run log after it. The final byte of each form is optional so a sequence truncated by the
- * tail slice still loses its introducer and parameters.
+ * The two sanitise calls left in this file are the ones whose result is RECORDED, not merely
+ * printed: `runFailureDetail` splits into lines and counts them, so a `\r` must not become a
+ * "line"; `resolveToolchain` stores `path`/`raw` on the witness, which the evidence page renders
+ * from disk. The stream boundary cannot do either of those — it sees the finished string.
  */
-const TERMINAL_SEQUENCE = new RegExp(
-  [
-    // OSC / DCS / SOS / PM / APC: introducer, string body, string terminator.
-    "(?:\\x1b[\\]PX^_]|[\\x9d\\x90\\x98\\x9e\\x9f])[^\\x07\\x1b\\x9c]*(?:\\x07|\\x1b\\\\|\\x9c)?",
-    // CSI: parameter bytes, intermediate bytes, final byte.
-    "(?:\\x1b\\[|\\x9b)[0-?]*[ -/]*[@-~]?",
-    // Any other two-character escape sequence, and a lone ESC.
-    "\\x1b[@-Z\\\\-_]?",
-  ].join("|"),
-  "g",
-);
-/** Everything else a terminal acts on rather than shows: C0, DEL, C1. `\n` and `\t` are not that. */
-// eslint-disable-next-line no-control-regex
-const CONTROL_CHAR = /[\x00-\x08\x0b-\x1f\x7f-\x9f]/g;
-
-/**
- * Make text produced by a WITNESSED REPOSITORY safe to put in front of an operator.
- *
- * The repository under witness is third-party code from the allowlist, executed in a sandbox
- * precisely because it is not trusted, and its stdout/stderr is therefore attacker-controllable on
- * the one surface whose entire job is to report what actually happened. With control sequences
- * intact that output can repaint a red witness as green (`\r` plus a cursor move), scroll its own
- * failure out of the scrollback, or invoke a terminal action outright (OSC 52 writes the clipboard).
- * #41 added the diagnostic because a silent refusal was indistinguishable from a broken interpreter;
- * printing it raw just moves the question up a level.
- *
- * `\n` and `\t` are kept: they are the shape of a test log, and a diagnostic flattened to one line
- * is the diagnostic thrown away.
- *
- * This is a RENDERING boundary, not a record one. The run logs persisted to disk keep the original
- * bytes and the sha256 on the evidence page is computed over those, so the audit trail is unchanged
- * — what is sanitised is the copy a human reads.
- *
- * `removed` is returned rather than discarded so a caller can say that something was taken out. A
- * sanitiser that silently tidies hostile output is itself a concealment channel: the operator would
- * see a coherent transcript with no sign that the coherence was ours.
- */
-export function sanitizeTerminalText(text: string): { text: string; removed: number } {
-  const stripped = text.replace(TERMINAL_SEQUENCE, "").replace(CONTROL_CHAR, "");
-  return { text: stripped, removed: text.length - stripped.length };
-}
 
 /**
  * The diagnostic block every run-failure refusal ends with.
@@ -391,6 +350,17 @@ export async function witnessEvidence(
 
   const dir = join(tmpdir(), `foundry-witness-${input.repoId.replace("/", "_")}-${Date.now()}`);
   const url = `https://github.com/${input.repoId}.git`;
+  // Every refusal below interpolates a step's raw output, and that output is REPOSITORY-CONTROLLED:
+  // `allowlist.yaml` carries `setupCommand: npm ci`, run with `cwd` set to this clone, so the
+  // repository's own lifecycle scripts author every byte of "setup command failed (exit 1) — …".
+  //
+  // Not sanitised here, and that is deliberate rather than an oversight. Issue #78's round-1 fix was
+  // a sanitise call at each sink, and the list came up seven short — precisely these. The boundary
+  // is now on the operator's terminal streams (`terminal.ts`, installed by every entry point), which
+  // is the one place that cannot be short. Adding calls back here would trade a complete rule for a
+  // list that has to stay complete, and the list is what failed. `runFailureDetail` keeps its own
+  // call because it SPLITS the output into lines and counts them — a `\r` must not become a "line" —
+  // which the stream boundary cannot do; it sees the finished string.
   const fail = async (error: string): Promise<WitnessOutcome> => {
     await runner("cleanup", [dir]);
     return { ok: false, error };

--- a/factory/witness.ts
+++ b/factory/witness.ts
@@ -104,6 +104,64 @@ export const PREFLIGHT_INVOCATION = "node --experimental-strip-types factory/cli
 export const WITNESS_TAIL_LINES = 40;
 
 /**
+ * ANSI/OSC/DCS/APC and friends, as full sequences rather than as a lone `\x1b` (issue #78).
+ *
+ * Stripping only the introducer would leave `]52;c;<base64>` sitting in the text, one concatenation
+ * away from being a working OSC 52 again — so a sequence is removed whole or not at all.
+ *
+ * Both encodings of each introducer are handled, because a strip that knows only about `\x1b` is a
+ * strip a terminal in 8-bit mode walks straight through: `\x9b` IS `\x1b[` and `\x9d` IS `\x1b]`,
+ * so they take the same body grammar rather than merely losing their first byte and leaving the
+ * parameters behind as text.
+ *
+ * The string-terminated forms are bounded by `[^\x07\x1b\x9c]*` rather than allowed to run to the
+ * end of the input: an unterminated OSC should cost the operator that one sequence, not every line
+ * of the run log after it. The final byte of each form is optional so a sequence truncated by the
+ * tail slice still loses its introducer and parameters.
+ */
+const TERMINAL_SEQUENCE = new RegExp(
+  [
+    // OSC / DCS / SOS / PM / APC: introducer, string body, string terminator.
+    "(?:\\x1b[\\]PX^_]|[\\x9d\\x90\\x98\\x9e\\x9f])[^\\x07\\x1b\\x9c]*(?:\\x07|\\x1b\\\\|\\x9c)?",
+    // CSI: parameter bytes, intermediate bytes, final byte.
+    "(?:\\x1b\\[|\\x9b)[0-?]*[ -/]*[@-~]?",
+    // Any other two-character escape sequence, and a lone ESC.
+    "\\x1b[@-Z\\\\-_]?",
+  ].join("|"),
+  "g",
+);
+/** Everything else a terminal acts on rather than shows: C0, DEL, C1. `\n` and `\t` are not that. */
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHAR = /[\x00-\x08\x0b-\x1f\x7f-\x9f]/g;
+
+/**
+ * Make text produced by a WITNESSED REPOSITORY safe to put in front of an operator.
+ *
+ * The repository under witness is third-party code from the allowlist, executed in a sandbox
+ * precisely because it is not trusted, and its stdout/stderr is therefore attacker-controllable on
+ * the one surface whose entire job is to report what actually happened. With control sequences
+ * intact that output can repaint a red witness as green (`\r` plus a cursor move), scroll its own
+ * failure out of the scrollback, or invoke a terminal action outright (OSC 52 writes the clipboard).
+ * #41 added the diagnostic because a silent refusal was indistinguishable from a broken interpreter;
+ * printing it raw just moves the question up a level.
+ *
+ * `\n` and `\t` are kept: they are the shape of a test log, and a diagnostic flattened to one line
+ * is the diagnostic thrown away.
+ *
+ * This is a RENDERING boundary, not a record one. The run logs persisted to disk keep the original
+ * bytes and the sha256 on the evidence page is computed over those, so the audit trail is unchanged
+ * — what is sanitised is the copy a human reads.
+ *
+ * `removed` is returned rather than discarded so a caller can say that something was taken out. A
+ * sanitiser that silently tidies hostile output is itself a concealment channel: the operator would
+ * see a coherent transcript with no sign that the coherence was ours.
+ */
+export function sanitizeTerminalText(text: string): { text: string; removed: number } {
+  const stripped = text.replace(TERMINAL_SEQUENCE, "").replace(CONTROL_CHAR, "");
+  return { text: stripped, removed: text.length - stripped.length };
+}
+
+/**
  * The diagnostic block every run-failure refusal ends with.
  *
  * Before this, `tests are red at head d91fe2f (exit 1) — nothing to witness` was the entire
@@ -115,7 +173,17 @@ export const WITNESS_TAIL_LINES = 40;
 export function runFailureDetail(command: string, output: string, toolchain?: string): string {
   const detail = [`  command: ${command}`];
   if (toolchain) detail.push(`  toolchain: ${toolchain}`);
-  const body = output.replace(/\s+$/, "");
+  // Sanitised BEFORE the trim and the line split, so a `\r` cannot survive into a "line" that the
+  // terminal then repaints, and so the line count the block reports is the count of lines a human
+  // will actually see. `command` and `toolchain` are ours — `allowlist.yaml`'s testCommand and a
+  // tool name plus a digits-only version — so the repository's output is the only untrusted input.
+  const scrubbed = sanitizeTerminalText(output);
+  const body = scrubbed.text.replace(/\s+$/, "");
+  if (scrubbed.removed > 0) {
+    detail.push(
+      `  ${scrubbed.removed} byte(s) of terminal control sequence removed from this repository's output before printing it — a witnessed repo does not get to move your cursor. The persisted run log keeps the original bytes.`,
+    );
+  }
   if (body.length === 0) {
     // The single most misleading case, so it gets a sentence rather than an empty block: a command
     // that dies before printing anything is usually the environment, not the patch.
@@ -202,7 +270,12 @@ export async function resolveToolchain(
       [`command -v ${tool} && ${tool} --version 2>&1 | head -n 1`],
       cwd ? { cwd } : undefined,
     );
-    const lines = probe.output.split("\n").map((l) => l.trim()).filter(Boolean);
+    // The SECOND repository-controlled sink (issue #78). Inside `witnessEvidence` this probe runs
+    // with `cwd` set to the clone, and `TOOL_TOKEN` admits a path — so a repo whose `testCommand`
+    // names something it ships (`./scripts/test.sh`) writes every byte of both lines below. `path`
+    // is printed verbatim by `witness-check`, so it is an operator surface exactly like the failure
+    // detail is. Sanitised before the split for the same reason: a `\r` must not become a "line".
+    const lines = sanitizeTerminalText(probe.output).text.split("\n").map((l) => l.trim()).filter(Boolean);
     const path = probe.exit === 0 ? lines[0] : undefined;
     if (!path) {
       resolved.push({ tool });

--- a/scripts/mutation-audit.ts
+++ b/scripts/mutation-audit.ts
@@ -265,7 +265,7 @@ const MUTANTS: Mutant[] = [
   // #78 — a witnessed third-party repo could write raw control sequences to the operator's console.
   {
     label: "i78-sanitizer",
-    file: "factory/witness.ts",
+    file: "factory/terminal.ts",
     from: '  const stripped = text.replace(TERMINAL_SEQUENCE, "").replace(CONTROL_CHAR, "");',
     to: "  const stripped = text;",
     why: "a sandboxed repo repaints the one surface whose job is to say what happened: `\\r` plus a cursor move turns a red witness green, and OSC 52 reaches the clipboard",
@@ -284,7 +284,7 @@ const MUTANTS: Mutant[] = [
     file: "factory/cli.ts",
     from: "  if (factoryHalt(state)) return applyTick(state);\n",
     to: "",
-    why: "a halted factory spends ~20 GitHub requests per tick before refusing — the retry SPEC.md §6 forbids, against the very limit that wrote the halt",
+    why: "a halted factory spends 24 GitHub requests per tick before refusing (6 per roster row x 4 rows, re-measured on this tree) — the retry SPEC.md §6 forbids, against the very limit that wrote the halt",
   },
   {
     label: "i79-approve-preflight",
@@ -319,7 +319,7 @@ const MUTANTS: Mutant[] = [
   {
     label: "i80-default",
     file: "factory/cli.ts",
-    from: "  return override ? resolve(override) : REPO_ROOT;",
+    from: "  return resolve(override ?? REPO_ROOT);",
     to: "  return override ? resolve(override) : resolve(\".\");",
     why: "the override still works, so every test that passes `--logs-root` stays green while the DEFAULT — the half the bug was in — is back",
   },
@@ -350,8 +350,8 @@ const MUTANTS: Mutant[] = [
   {
     label: "i81-consumer",
     file: "factory/cli.ts",
-    from: "    const result = applyRevert(state, id, { source: \"operator\", why: reason });\n    if (result.error) {\n      console.error(result.error);\n      process.exit(1);\n    }",
-    to: "    const result = applyRevert(state, id, { source: \"operator\", why: reason });\n    if (result.error) {\n      console.error(result.error);\n    }",
+    from: "    const result = applyRevert(state, id, { source: \"operator\", why: reason, at });\n    if (result.error) {\n      console.error(result.error);\n      process.exit(1);\n    }",
+    to: "    const result = applyRevert(state, id, { source: \"operator\", why: reason, at });\n    if (result.error) {\n      console.error(result.error);\n    }",
     why: "the engine refuses and the verb carries on — the operator is told the repo was halted by a run that exited 0 having written nothing",
   },
 
@@ -369,6 +369,174 @@ const MUTANTS: Mutant[] = [
     from: "const RATIO_AS_SLASH = /(?<![/\\w])\\b\\d[\\d,]*\\s*\\/\\s*\\d[\\d,]*\\b(?![/\\w])/;",
     to: "const RATIO_AS_SLASH = /\\b\\d[\\d,]*\\s*\\/\\s*\\d[\\d,]*\\b/;",
     why: "a numeric path segment reads as a ratio, so a valid silent-absence note throws out of a lazy cache and takes `validate` and every packet build with it",
+  },
+
+
+  // ---- SWEEP 2, ROUND 2: the three Requireds a review found in the round-1 fixes themselves ----
+  // The through-line of both rounds is ONE defect: a fix applied to a consumer and not its siblings.
+  // These mutants are therefore written against the CLASS wherever the fix is class-level, and
+  // against each RENDERING wherever a number is shown more than once.
+
+  // REQUIRED 1 — issue #78 was closed at two sinks and left at least nine open (seven raw `fail()`
+  // sites in witness.ts, the freeze excerpt, and policy.matchedPhrases). It is now closed at the
+  // process's terminal streams, so a tenth sink is behind it the day it is written.
+  {
+    label: "r1-boundary-cli",
+    file: "factory/cli.ts",
+    from: "  installTerminalBoundary();\n  await main();",
+    to: "  await main();",
+    why: "every verb prints third-party bytes raw again: a hostile CONTRIBUTING's `\\x1b[8m` hides every disclosure #77 added, and an OSC 52 out of a setupCommand reaches the clipboard",
+  },
+  {
+    label: "r1-boundary-inert",
+    file: "factory/terminal.ts",
+    from: "  for (const stream of streams) {",
+    to: "  for (const stream of [] as TerminalStream[]) {",
+    why: "the boundary is installed by every entry point and wraps nothing — the shape a class-level fix fails in, which a per-sink test would never see",
+  },
+  {
+    label: "r1-boundary-silent",
+    file: "factory/terminal.ts",
+    from: "        scrubbed.removed === 0",
+    to: "        true",
+    why: "the strip happens and is never disclosed — a sanitiser that hands the operator a coherent transcript with no sign the coherence was ours is itself a concealment channel",
+  },
+  {
+    label: "r1-boundary-verify-ledger",
+    file: "factory/verify-ledger.ts",
+    from: "installTerminalBoundary();\n\n",
+    to: "",
+    why: "the unattended 6-hour clock is back outside the boundary — the entry-point invariant is the only thing standing between a new entry point and a tenth sink",
+  },
+
+  // REQUIRED 2 — #77's acceptance is "N characters not shown"; N was pinned nowhere. The round-1
+  // fixture made 883 a substring of 4883, so every assertion matched inside the TOTAL and all four
+  // of these survived a green suite. `0 characters not shown` above a hidden ban is affirmative
+  // false reassurance: worse than the silence #77 replaced.
+  {
+    label: "r2-count-header",
+    file: "factory/packet.ts",
+    from: "(first ${doc.excerpt.length} shown, ${missing} NOT shown)",
+    to: "(first ${doc.excerpt.length} shown, 0 NOT shown)",
+    why: "the header reports 0 characters withheld over a document that withheld 1,234 of them",
+  },
+  {
+    label: "r2-header-clause",
+    file: "factory/packet.ts",
+    from: "${missing > 0 ? ` (first ${doc.excerpt.length} shown, ${missing} NOT shown)` : \"\"}",
+    to: "\"\"",
+    why: "the whole header clause reverts to base — source and size, with the omission gone",
+  },
+  {
+    label: "r2-count-marker",
+    file: "factory/packet.ts",
+    from: "`  ⟪ ${missing} more characters of ${doc.name}",
+    to: "`  ⟪ 0 more characters of ${doc.name}",
+    why: "the marker at the exact place a scrolling reader stops says 0 characters are missing",
+  },
+  {
+    label: "r2-count-closing",
+    file: "factory/packet.ts",
+    from: "      `  BUT ${withheld} of those ${total} characters are not shown above.",
+    to: "      `  BUT 0 of those ${total} characters are not shown above.",
+    why: "the sentence directly above the attest — the one #77 exists for — reads `BUT 0 of those 5234 characters are not shown`",
+  },
+
+  // REQUIRED 3 — the shared window predicate was handed two different SUBJECTS: the classifier the
+  // event's date, the operator's verb the moment they typed. Same rollback, opposite verdicts, in
+  // the safety-relevant direction.
+  {
+    label: "r3-at-dropped",
+    file: "factory/cli.ts",
+    from: "    const result = applyRevert(state, id, { source: \"operator\", why: reason, at });",
+    to: "    const result = applyRevert(state, id, { source: \"operator\", why: reason });",
+    why: "`--at` is parsed, validated, and then not passed — the round-1 shape exactly: a flag the help text promises and the engine never sees, so the window dates from the typing again",
+  },
+  {
+    label: "r3-at-unparseable",
+    file: "factory/cli.ts",
+    from: "    if (at !== undefined && !Number.isFinite(Date.parse(at))) {",
+    to: "    if (false) {",
+    why: "`--at \"last Tuesday\"` reaches `revertWindow` as an unparseable date, which returns `known: false` — so a typo in the flag silently skips the window check entirely",
+  },
+  {
+    label: "r3-refusal-verb",
+    file: "factory/engine.ts",
+    from: "are only writing it down now, re-run with \\`--at <iso>\\` naming the day THEY did it",
+    to: "are only writing it down now, record it as a follow-up note instead",
+    why: "the refusal names a verb that does not exist — 18 verbs in `--help`, none records a note — which is the defect issue #35 was filed against, restored inside the message that fixed it",
+  },
+
+  // ---- ROUND 2 MINORS ----
+  {
+    label: "min-osc-newline",
+    file: "factory/terminal.ts",
+    from: "[^\\\\x07\\\\x1b\\\\x9c\\\\n]*",
+    to: "[^\\\\x07\\\\x1b\\\\x9c]*",
+    why: "the sanitiser swallows the diagnostic it exists to preserve: a run whose output contains a bare `\\x1b]0;t` loses every line after it, including the real failure — #78's own harm, achieved through the sanitiser",
+  },
+  {
+    label: "min-removed-guard",
+    file: "factory/witness.ts",
+    from: "  if (scrubbed.removed > 0) {",
+    to: "  if (scrubbed.removed >= 0) {",
+    why: "every witness failure prints `0 byte(s) of terminal control sequence removed`; a notice that fires every run is one the operator learns to skip",
+  },
+  {
+    label: "min-removed-count",
+    file: "factory/witness.ts",
+    from: "      `  ${scrubbed.removed} byte(s) of terminal control sequence removed",
+    to: "      `  0 byte(s) of terminal control sequence removed",
+    why: "the count is always zero — an affirmative false statement about output that WAS tampered with",
+  },
+  {
+    label: "min-window-deadline",
+    file: "factory/scorecard.ts",
+    from: "    deadline: new Date(deadlineMs).toISOString(),\n",
+    to: "",
+    why: "strip-types erases the field without checking: the refusal reads `past the 30-day window that closed undefined`",
+  },
+  {
+    label: "min-window-days",
+    file: "factory/scorecard.ts",
+    from: "    days: Math.floor((atMs - mergedMs) / 86_400_000),\n",
+    to: "",
+    why: "same, one field over: `undefined days after the merge`, in the message that has to justify a permanent repository stop",
+  },
+  {
+    label: "min-classify-days",
+    file: "factory/scorecard.ts",
+    from: "    const days = window.known ? window.days : 0;",
+    to: "    const days = 0;",
+    why: "the classifier's own late-rollback explanation says a commit landed 0 days after the merge while discarding it for being late",
+  },
+  {
+    label: "min-manifest-anchor",
+    file: "factory/cli.ts",
+    from: "    return readFileSync(resolve(path), \"utf8\");",
+    to: "    return readFileSync(resolve(LOGS_ROOT, path), \"utf8\");",
+    why: "the operator/repo-relative split #80 turns on collapses back: `--manifest ./witness.json` stops meaning the operator's shell. Every fixture passed an ABSOLUTE path, so this survived round 1",
+  },
+  {
+    label: "min-halt-event",
+    file: "factory/engine.ts",
+    from: "    const next = appendEvent(\n      state,\n      ev(\"tick\", `Tick refused — factory halted ${halted.at}: ${halted.reason}`),\n    );\n    return { state: next, packet: null,",
+    to: "    return { state, packet: null,",
+    why: "a halted tick refuses on the terminal and writes nothing to the ledger — the console line evaporates with the exit and the next reader sees a six-hour gap with no cause",
+  },
+  {
+    label: "min-ratio-lookahead",
+    file: "factory/policy-records.ts",
+    from: "const RATIO_AS_SLASH = /(?<![/\\w])\\b\\d[\\d,]*\\s*\\/\\s*\\d[\\d,]*\\b(?![/\\w])/;",
+    to: "const RATIO_AS_SLASH = /(?<![/\\w])\\b\\d[\\d,]*\\s*\\/\\s*\\d[\\d,]*\\b/;",
+    why: "the RIGHT half of the path exclusion: `2026/08/28` at the start of a note reads as a ratio again, and every fixture in round 1 put the numeric segment after a `/`, exercising only the lookbehind",
+  },
+  {
+    label: "min-logs-root-slash",
+    file: "factory/cli.ts",
+    from: "  return resolve(override ?? REPO_ROOT);",
+    to: "  return override ? resolve(override) : REPO_ROOT;",
+    why: "the default branch stops normalising, so `--help` prints `…/oss-foundry//docs/evidence/logs/<packetId>/` — a doubled slash in the one line that says where the run logs are",
   },
 
   // ---- NEGATIVE CONTROL ----

--- a/scripts/mutation-audit.ts
+++ b/scripts/mutation-audit.ts
@@ -232,6 +232,145 @@ const MUTANTS: Mutant[] = [
     why: "a shipped verb goes missing from the only list of them",
   },
 
+  // ---- SWEEP 2 (#77–#82): six review comments a prior sweep merged past without reading ----
+  // Each of these is one call site of a fix, on purpose. The recurring defect in this repository is
+  // a well-tested function behind untested wiring — a fix applied to one consumer and not its
+  // sibling, eight times — so a mutant per FUNCTION would keep reporting a clean sheet over exactly
+  // the gap that keeps shipping. Where a fix touched two consumers, both are listed separately.
+
+  // #77 — the freeze showed 4,000 characters and then claimed a clean scan over the whole document.
+  {
+    label: "i77-claim",
+    file: "factory/packet.ts",
+    from: "  } else if (withheld > 0) {",
+    to: "  } else if (false) {",
+    why: "the freeze closes with `no ban statement matched in N chars` over text the operator was never shown — the sentence directly above the attest, and #37's parked scanner leg is what makes the missed ban real",
+  },
+  {
+    label: "i77-marker",
+    file: "factory/packet.ts",
+    from:
+      "        `  ⟪ ${missing} more characters of ${doc.name} are NOT shown above. The scanner read them; you have not. ⟫`,\n",
+    to: '        "",\n',
+    why: "the omission is announced only in a header 4,000 characters up, so the operator scrolling to where the text stops sees nothing marking the end",
+  },
+  {
+    label: "i77-consumer",
+    file: "factory/cli.ts",
+    from: "    if (packetForFreeze) console.log(renderFreezeEvidence(packetForFreeze));",
+    to: "    if (packetForFreeze) console.log(renderFreezeEvidence(packetForFreeze).split(\"\\n\")[0]);",
+    why: "the render is correct and the verb prints one line of it — the exact untested-wiring shape this audit exists for",
+  },
+
+  // #78 — a witnessed third-party repo could write raw control sequences to the operator's console.
+  {
+    label: "i78-sanitizer",
+    file: "factory/witness.ts",
+    from: '  const stripped = text.replace(TERMINAL_SEQUENCE, "").replace(CONTROL_CHAR, "");',
+    to: "  const stripped = text;",
+    why: "a sandboxed repo repaints the one surface whose job is to say what happened: `\\r` plus a cursor move turns a red witness green, and OSC 52 reaches the clipboard",
+  },
+  {
+    label: "i78-probe-sink",
+    file: "factory/witness.ts",
+    from: '    const lines = sanitizeTerminalText(probe.output).text.split("\\n")',
+    to: '    const lines = probe.output.split("\\n")',
+    why: "the failure detail is clean and the SECOND repo-controlled sink is not — `witness-check` prints the probe's `path` verbatim",
+  },
+
+  // #79 — the halt gate ran after the platform requests it exists to prevent.
+  {
+    label: "i79-tick-preflight",
+    file: "factory/cli.ts",
+    from: "  if (factoryHalt(state)) return applyTick(state);\n",
+    to: "",
+    why: "a halted factory spends ~20 GitHub requests per tick before refusing — the retry SPEC.md §6 forbids, against the very limit that wrote the halt",
+  },
+  {
+    label: "i79-approve-preflight",
+    file: "factory/cli.ts",
+    from: "      const gate = maySelectRepo(state, packetForFreeze.repoId);\n      if (!gate.ok) {\n        console.error(`cannot approve ${id}: ${gate.reason}`);\n        process.exit(1);\n      }\n",
+    to: "",
+    why: "same rule, the approve sibling: three reads go out under a halt and are then thrown away",
+  },
+  {
+    label: "i79-tick-verdict",
+    file: "factory/engine.ts",
+    from: "  const halted = factoryHalt(state);\n  if (halted) {\n    const next = appendEvent(\n      state,\n      ev(\"tick\", `Tick refused — factory halted ${halted.at}: ${halted.reason}`),\n    );\n    return { state: next, packet: null, reason: `Factory halted ${halted.at}: ${halted.reason}` };\n  }\n",
+    to: "",
+    why: "a halted tick reports `idle` and exits 0 — the per-repo gate refuses every candidate and the absence of candidates reads as a quiet roster",
+  },
+
+  // #80 — witness log paths resolved against cwd; the class #43 fixed for STATE_FILE, left in a sibling.
+  {
+    label: "i80-read-anchor",
+    file: "factory/cli.ts",
+    from: "    return readFileSync(resolve(LOGS_ROOT, path), \"utf8\");",
+    to: '    return readFileSync(resolve(path), "utf8");',
+    why: "`attach-witness` run from anywhere but the repo root rejects a perfectly good witness as a missing log",
+  },
+  {
+    label: "i80-write-anchor",
+    file: "factory/cli.ts",
+    from: "  root = LOGS_ROOT,",
+    to: '  root = ".",',
+    why: "the write sibling: run logs land beside the operator's shell while the evidence page keeps promising them inside the checkout",
+  },
+  {
+    label: "i80-default",
+    file: "factory/cli.ts",
+    from: "  return override ? resolve(override) : REPO_ROOT;",
+    to: "  return override ? resolve(override) : resolve(\".\");",
+    why: "the override still works, so every test that passes `--logs-root` stays green while the DEFAULT — the half the bug was in — is back",
+  },
+
+  {
+    label: "i80-test-guard",
+    file: "factory/cli.ts",
+    from: "  if (root === LOGS_ROOT && !LOGS_ROOT_FLAG && process.env.NODE_TEST_CONTEXT) {",
+    to: "  if (false) {",
+    why: "anchoring took away the temp-cwd isolation spawned-CLI tests had for free, so a test that forgets `--logs-root` writes two run logs into the developer's real checkout — which this change already did once before the guard existed",
+  },
+
+  // #81 — the operator revert verb bypassed the deadline the classifier enforces.
+  {
+    label: "i81-gate",
+    file: "factory/engine.ts",
+    from: "  if (window.known && !window.within) {",
+    to: "  if (false) {",
+    why: "a rollback of a merge from a year ago increments `reverts`, and `health()` makes that an unconditional permanent stop only a seed edit lifts",
+  },
+  {
+    label: "i81-predicate",
+    file: "factory/scorecard.ts",
+    from: "    within: atMs <= deadlineMs,",
+    to: "    within: true,",
+    why: "the shared window always says yes — both halves of one documented definition stop enforcing it together, which is the point of sharing it",
+  },
+  {
+    label: "i81-consumer",
+    file: "factory/cli.ts",
+    from: "    const result = applyRevert(state, id, { source: \"operator\", why: reason });\n    if (result.error) {\n      console.error(result.error);\n      process.exit(1);\n    }",
+    to: "    const result = applyRevert(state, id, { source: \"operator\", why: reason });\n    if (result.error) {\n      console.error(result.error);\n    }",
+    why: "the engine refuses and the verb carries on — the operator is told the repo was halted by a run that exited 0 having written nothing",
+  },
+
+  // #82 — the derived-figure guard failed permissively AND strictly.
+  {
+    label: "i82-case",
+    file: "factory/policy-records.ts",
+    from: "const RATIO_IN_WORDS = /\\b\\d[\\d,]*\\s*of\\s*\\d[\\d,]*\\b/i;",
+    to: "const RATIO_IN_WORDS = /\\b\\d[\\d,]*\\s*of\\s*\\d[\\d,]*\\b/;",
+    why: "`141 Of 272 external PRs merged` renders as a maintainer's own words again — the exact defect #44 added the guard to stop, one shift key away",
+  },
+  {
+    label: "i82-path",
+    file: "factory/policy-records.ts",
+    from: "const RATIO_AS_SLASH = /(?<![/\\w])\\b\\d[\\d,]*\\s*\\/\\s*\\d[\\d,]*\\b(?![/\\w])/;",
+    to: "const RATIO_AS_SLASH = /\\b\\d[\\d,]*\\s*\\/\\s*\\d[\\d,]*\\b/;",
+    why: "a numeric path segment reads as a ratio, so a valid silent-absence note throws out of a lazy cache and takes `validate` and every packet build with it",
+  },
+
   // ---- NEGATIVE CONTROL ----
   // The clock's own copy of the line REQUIRED 2 is about. It was already killed before this round,
   // and it must still be — a harness that reported everything as killed would prove nothing, and one

--- a/scripts/mutation-audit.ts
+++ b/scripts/mutation-audit.ts
@@ -490,6 +490,20 @@ const MUTANTS: Mutant[] = [
     why: "the count is always zero — an affirmative false statement about output that WAS tampered with",
   },
   {
+    label: "review-premerge-window",
+    file: "factory/scorecard.ts",
+    from: "    within: atMs >= mergedMs && atMs <= deadlineMs,",
+    to: "    within: atMs <= deadlineMs,",
+    why: "an upper-bound-only window accepts a rollback dated BEFORE the merge: reverts is incremented on an impossible date and health() retires the repository permanently",
+  },
+  {
+    label: "review-premerge-refusal",
+    file: "factory/engine.ts",
+    from: "  if (window.known && !window.within && window.days < 0) {",
+    to: "  if (false && window.known && !window.within && window.days < 0) {",
+    why: "the late-rollback paragraph would tell an operator a pre-merge date is `past the window that closed` and advise re-dating it EARLIER — a refusal that misdescribes what it refused",
+  },
+  {
     label: "min-window-deadline",
     file: "factory/scorecard.ts",
     from: "    deadline: new Date(deadlineMs).toISOString(),\n",

--- a/scripts/mutation-audit.ts
+++ b/scripts/mutation-audit.ts
@@ -539,6 +539,113 @@ const MUTANTS: Mutant[] = [
     why: "the default branch stops normalising, so `--help` prints `…/oss-foundry//docs/evidence/logs/<packetId>/` — a doubled slash in the one line that says where the run logs are",
   },
 
+  // ---- SWEEP 2, ROUND 3: the boundary was thoroughly tested and its SHIPPED CONFIGURATION was not
+  // Every round-2 test handed the mechanism an explicit argument — an explicit stream list, an
+  // explicit `--logs-root`, an explicit C1 byte that was also a sequence introducer — so nothing
+  // bound the defaults an operator actually runs. These are those defaults, one mutant per way each
+  // of the round-3 Requireds could go, including the two that SHIPPED green.
+
+  {
+    label: "r3-default-stderr",
+    file: "factory/terminal.ts",
+    from: "  streams: TerminalStream[] = [process.stdout, process.stderr],",
+    to: "  streams: TerminalStream[] = [process.stdout],",
+    why: "the boundary's stderr half is gone and stderr is issue #78's named sink: a `setupCommand` running inside the untrusted clone authors `setup.output`, witness.ts puts 200 characters of it in a `fail()`, and cli.ts prints that with `console.error`. This SHIPPED green — every boundary test passed its own stream list",
+  },
+  {
+    label: "r3-default-stdout",
+    file: "factory/terminal.ts",
+    from: "  streams: TerminalStream[] = [process.stdout, process.stderr],",
+    to: "  streams: TerminalStream[] = [process.stderr],",
+    why: "the other half of the same default: every freeze excerpt, matched phrase and issue title reaches the operator raw",
+  },
+  {
+    label: "r3-entry-istty",
+    file: "factory/verify-ledger.ts",
+    from: "installTerminalBoundary();",
+    to: "if (process.stdout.isTTY) installTerminalBoundary();",
+    why: "the boundary is off in exactly the place nobody is watching: `isTTY` is false in the Actions runner where the unattended six-hour clock runs, and true on the developer's terminal where it is read",
+  },
+  {
+    label: "r3-entry-validate",
+    file: "factory/validate-allowlist.ts",
+    from: "installTerminalBoundary();",
+    to: "// installTerminalBoundary();",
+    why: "one of the two entry points with no behavioural backup at all. A COMMENTED-OUT call still satisfies a source grep for `installTerminalBoundary()`, which is what round 2 asserted",
+  },
+  {
+    label: "r3-entry-discovery",
+    file: "factory/terminal.test.ts",
+    from: "  const ENTRY_POINT = /factory\\/([A-Za-z0-9_.-]+(?:\\/[A-Za-z0-9_.-]+)*\\.ts)/g;",
+    to: "  const ENTRY_POINT = /factory\\/([A-Za-z0-9-]+\\.ts)/g;",
+    why: "the guard's own discovery, narrowed back: `factory/rogue_verb.ts`, `factory/rogue.verb.ts` and `factory/tools/deep.ts` become invisible to it, so three uninstalled entry points would pass green. A mutant against the guard rather than against production, because the guard IS the production control here",
+  },
+  {
+    label: "r3-sweep-c1",
+    file: "factory/terminal.ts",
+    from: "const CONTROL_CHAR = /[\\x00-\\x08\\x0b-\\x1f\\x7f-\\x9f]/g;",
+    to: "const CONTROL_CHAR = /[\\x00-\\x08\\x0b-\\x1f]/g;",
+    why: "`\\x8d` (RI) scrolls the screen with no `\\x1b` in it — the repaint-a-red-witness-green primitive — and `\\x85` (NEL) and `\\x7f` (DEL) go with it. Every C1 byte the round-2 fixtures carried was ALSO a sequence introducer, so the sweep itself was never the thing under test",
+  },
+  {
+    label: "r3-logs-operator",
+    file: "factory/cli.ts",
+    from: "  if (root === LOGS_ROOT && !LOGS_ROOT_FLAG && process.env.NODE_TEST_CONTEXT) {",
+    to: "  if (root === LOGS_ROOT && !LOGS_ROOT_FLAG) {",
+    why: "the conjunct that makes the write guard \"inert for a real operator\": without it, `evidence <id> --base <sha> --head <sha>` with no `--logs-root` — the only documented spelling — is refused as a test run and the witness is thrown away. Every test passes `--logs-root`, so the conjunction short-circuited before the environment was ever read",
+  },
+  {
+    label: "r3-at-trailing",
+    file: "factory/cli.ts",
+    from: '    refuseValuelessFlag(rest, "--at", "the rollback is dated now");\n',
+    to: "",
+    why: "`revert pkt --reason r --at` reads as no `--at` at all and dates the 30-day window from the typing — the exact failure the flag closes, reached silently by the operator who was trying hardest to avoid it",
+  },
+
+  // ---- ROUND 3: advisories the round-2 review left open, now closed ----
+  {
+    label: "r3-wrapped-weakset",
+    file: "factory/terminal.ts",
+    from: "    if (WRAPPED.has(stream)) continue;\n    WRAPPED.add(stream);\n",
+    to: "",
+    why: "a second install nests a second wrapper. The round-2 test for this was SPURIOUS — it asserted the disclosure does not double, which is true without the WeakSet because sanitising is idempotent — so the guard's own effect, the wrapper count, was pinned by nothing",
+  },
+  {
+    label: "r3-write-passthrough",
+    file: "factory/terminal.ts",
+    from: '      return inner(typeof chunk === "string" ? out : Buffer.from(out, "utf8"), encoding, callback);',
+    to: '      inner(typeof chunk === "string" ? out : Buffer.from(out, "utf8"));\n      return true;',
+    why: "the boundary's own comment promises that \"back-pressure, `drain`, and write callbacks behave exactly as before\": this drops the callback, stranding every `write(chunk, cb)` caller, and reports a full pipe as an empty one",
+  },
+  {
+    label: "r3-csi-final-byte",
+    file: "factory/terminal.ts",
+    from: '    "(?:\\\\x1b\\\\[|\\\\x9b)[0-?]*[ -/]*[@-~]?",',
+    to: '    "(?:\\\\x1b\\\\[|\\\\x9b)[0-?]*[ -/]*[@-~]",',
+    why: "the final byte stops being optional, so a CSI cut by a chunk boundary or by a tail slice keeps its introducer: `write(\"a\\x1b[\")` then `write(\"31mb\")` leaves a live introducer on the terminal, one concatenation from a working sequence",
+  },
+  {
+    label: "r3-write-typedarray",
+    file: "factory/terminal.ts",
+    from: "      if (text === undefined) return inner(chunk, encoding, callback);",
+    to: "      if (text === undefined) return inner(Buffer.from(String(chunk)), encoding, callback);",
+    why: "a non-Buffer typed array is re-encoded through `String()` instead of passed through — raw bytes turned into `[object Uint8Array]` on the way to the stream",
+  },
+  {
+    label: "r3-phrase-precedence",
+    file: "factory/packet.ts",
+    from: "  } else if (packet.policy.matchedPhrases.length > 0) {",
+    to: "  } else if (packet.policy.matchedPhrases.length > 0 && withheld === 0) {",
+    why: "a document that both matched a ban and was truncated loses the matched phrases from the block directly above the attest, replaced by a warning about unshown text — the strictly worse of the two orderings, since the phrases are the reason the verdict is DENY",
+  },
+  {
+    label: "r3-ratio-spaces",
+    file: "factory/policy-records.ts",
+    from: "const RATIO_AS_SLASH = /(?<![/\\w])\\b\\d[\\d,]*\\s*\\/\\s*\\d[\\d,]*\\b(?![/\\w])/;",
+    to: "const RATIO_AS_SLASH = /(?<![/\\w])\\b\\d[\\d,]*\\/\\d[\\d,]*\\b(?![/\\w])/;",
+    why: "`141 / 272` walks through the derived-figure guard: every fixture wrote the ratio tight, so the whitespace either side of the slash was pinned by nothing and a spaced ratio goes into a maintainer's mouth on the evidence page",
+  },
+
   // ---- NEGATIVE CONTROL ----
   // The clock's own copy of the line REQUIRED 2 is about. It was already killed before this round,
   // and it must still be — a harness that reported everything as killed would prove nothing, and one
@@ -574,8 +681,22 @@ function runSuite(): { ok: boolean; firstFailure: string } {
 const wanted = process.argv.slice(2).filter((a) => !a.startsWith("--"));
 const selected = wanted.length > 0 ? MUTANTS.filter((m) => wanted.includes(m.label)) : MUTANTS;
 
+/**
+ * The tally, printed by the table rather than quoted in prose anywhere.
+ *
+ * docs/12-ledger.md used to state a figure ("27 single-line mutations … 26 must die and one must
+ * survive") in the same paragraph that says a mutation score quoted in prose is not evidence. It
+ * had drifted to less than half the real count by the next round, which is what a hand-copied
+ * number does. The count now has exactly one source — this array — and one way to read it.
+ */
+function tally(): string {
+  const controls = MUTANTS.filter((m) => m.expect === "survives").length;
+  return `${MUTANTS.length} mutants: ${MUTANTS.length - controls} expected killed, ${controls} control(s) expected to survive`;
+}
+
 if (process.argv.includes("--list")) {
   for (const m of MUTANTS) console.log(`${m.label.padEnd(24)} ${m.file}\n${" ".repeat(25)}${m.why}`);
+  console.log(`\n${tally()}`);
   process.exit(0);
 }
 
@@ -589,7 +710,7 @@ if (!baseline.ok) {
   console.error("baseline is not green — a mutation audit over a red suite means nothing");
   process.exit(2);
 }
-console.log(`baseline green; ${selected.length} mutant(s)\n`);
+console.log(`baseline green; ${tally()}; running ${selected.length}\n`);
 
 const survived: Mutant[] = [];
 const stale: Mutant[] = [];


### PR DESCRIPTION
Closes #77, #78, #79, #80, #81, #82.

Six review-bot comments from the previous sweep, never read: every PR that run opened was merged **2–9 seconds after opening**, while the bot posted ~2 minutes later. It spent the sweep reviewing already-merged code. Seven of the eight comments were genuine; two were security.

**This PR is not merged until the bot has reviewed it.**

## What ships

| # | fix |
|---|---|
| **#77** | Freeze evidence truncated at 4,000 chars while the scanner read the whole document. The limit is a *ledger* bound (`policyDocs` is stored state), so it stays — but the omission is now unmissable: a withheld count in the header, a marker where the text stops, and a split closing claim. The old line asserted coverage of 4,859 characters while showing 4,000, directly above the attest. |
| **#78** | A witnessed third-party repository could write raw ANSI/OSC to the operator's terminal. Fixed as a **boundary**, not per sink — `installTerminalBoundary()` wraps `write` on the process's own streams, so a `console.log` added tomorrow in any verb is already behind it. |
| **#79** | The halt gate ran *after* platform requests, which is the retry `SPEC.md` §6 forbids. Now 0 requests under a persisted halt (a count, not a verdict). |
| **#80** | `readIfPresent` was cwd-relative — the class #43 fixed for `STATE_FILE`, left in a sibling. Split correctly: `--manifest` is operator-typed and stays cwd-relative. |
| **#81** | The two revert paths shared a predicate but fed it different dates — mechanical passed the event's date, operator passed *now*. `--at <iso>` added; both now agree on the same facts. |
| **#82** | The derived-figure guard failed both ways: `141 Of 272` bypassed it, `docs/2026/08` false-positived. |

## Why it took three rounds

Each round shipped a fix whose *check could not see the case that mattered* — the same defect this batch exists to close:

1. The `LOGS_ROOT` fix left its write sibling unpinned; the sanitizer closed the one sink #78 named and left eight, including the freeze — where a hostile `CONTRIBUTING.md` planting `ESC[8m` hid **every disclosure #77 had just added**, using the mechanism the same commit was filed to close.
2. `assert.match(out, /883 character/)` passed against `4883 characters` on another line, because the fixture made the withheld count a suffix of the total. Four mutants survived behind it.
3. The boundary's *mechanism* was thoroughly tested and its *shipped configuration* was not: deleting `process.stderr` from the default list, or gating the install on `isTTY` (false in Actions, where the unattended clock runs), both left the suite green.

The entry-point guard is now behavioural — it spawns each discovered entry point with a probe printing hostile bytes, rather than grepping source, so it cannot be satisfied by a comment.

## Verification

308 tests / 14 files, `npm run validate` exit 0, `verify-ledger` exit 0 against live GitHub. `scripts/mutation-audit.ts` at 79 rows with controls in both directions — one mutant that must die, one that must survive. Reviewed on isolated standards and test-adequacy axes across three rounds; standards passed at round 2.



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens evidence rendering, terminal output, halt handling, repository-relative witness logs, rollback dating, and derived-policy validation.
- Installs a process-stream boundary that removes terminal control sequences from third-party text.
- Moves persisted-halt checks ahead of platform requests.
- Anchors witness logs to the repository while preserving cwd-relative operator manifest paths.
- Adds event-time rollback recording through `revert --at` and enforces both bounds of the rollback window.
- Makes truncated policy evidence explicit and strengthens policy-figure detection and mutation controls.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| factory/scorecard.ts | The shared rollback-window predicate now rejects timestamps before the merge and after the 30-day deadline. |
| factory/engine.ts | Operator and mechanically detected rollback paths use the shared window predicate before mutating ledger state. |
| factory/cli.ts | Adds early halt gates, event-time rollback parsing, repository-root witness-log handling, and terminal-boundary installation. |
| factory/terminal.ts | Introduces centralized sanitization for textual writes to stdout and stderr while preserving stored evidence bytes. |
| factory/packet.ts | Makes truncated policy evidence and the distinction between displayed and scanned content explicit. |
| factory/policy-records.ts | Strengthens rejection of derived figures in silent policy records. |
| factory/verify-ledger.ts | Installs the terminal boundary before rendering live third-party ledger information. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(revert): the window needs both bound..."](https://github.com/ravidsrk/oss-foundry/commit/9e092323769f010325b5d7761ac8116aebe21c57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58241794)</sub>

<!-- /greptile_comment -->