### PR TITLE
fix: restore revertTruncated on reconcile (main is red)

### DIFF
--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -1128,6 +1128,7 @@ async function main() {
         revert: reverted?.ok ? reverted.verdict : undefined,
         // Same fact the clock reads (issue #39 round 2): a page-capped commit read is not a clean
         // one, and both consumers must say so or the two verbs disagree about what was checked.
+        revertTruncated: reverted?.ok ? reverted.truncated : undefined,
       });
       doctrine.push(...checks.fatal);
       owed.push(...checks.advisory);


### PR DESCRIPTION
`main` is red at `171a6a1`.

The reconcile call site is missing `revertTruncated: reverted?.ok ? reverted.truncated : undefined,` — the exact line that PR #83's round 2 added for its Required 2, and the failing test is the one round 3 added to pin it. **The test caught it correctly; the commit was wrong.**

**Cause:** `scripts/mutation-audit.ts` was running in the same worktree while the previous commit was staged. Its `req2a` row deletes precisely this line, and `git add -A` picked up the mutation instead of the source. The harness mutates tracked files by design — it has to be run in a scratch copy.

Restores the one line. 308 tests, `validate` exit 0, `verify-ledger` exit 0.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Restores propagation of the revert commit-list truncation state into reconciliation checks so a page-capped read is not treated as conclusive.
- Passes `reverted.truncated` to `packetChecks` after a successful revert check.
- Leaves unsuccessful checks represented as `undefined`.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The restored value matches the revert result and reconciliation input contracts, preserving the expected advisory when commit-history inspection is truncated.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| factory/cli.ts | Correctly restores the successful revert result's truncation flag at the reconciliation call site. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: restore revertTruncated on reconcil..."](https://github.com/ravidsrk/oss-foundry/commit/7a085155a2d3e90fc45d996b257bd316eb38cd5f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58246682)</sub>

<!-- /greptile_comment -->