### PR TITLE
ci: run the test suite and validator on pull requests and main (#54)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+# The suite, machine-enforced. docs/SPEC.md §8 conditions conformance on the implementation's own
+# evidence and names the test suite as the demonstration; until this file existed the demonstration
+# ran only on the machine of whoever remembered to type `npm test` (issue #54).
+#
+# Separate from `oss-tick.yml` on purpose. That workflow is the factory's 6-hour CLOCK: it is
+# `on: schedule`, it reads live GitHub, and it may file a packet issue. This one is a GATE: it is
+# `on: pull_request` / `on: push`, it touches no network, and it never writes anything. Merging the
+# two would put the clock's live-GitHub failure modes on the pull-request path.
+#
+# WHY `verify-ledger.ts` IS NOT HERE. It reconciles the committed ledger against live GitHub, so it
+# fails for reasons that have nothing to do with a diff — a maintainer moving a PR reddens it while
+# every line of the branch is correct, which is exactly what happened in issue #49. Doctrine says a
+# divergence is a real event that should stop the CLOCK; stopping every pull request on it is a
+# different policy, and this is the deliberate choice not to adopt it. It keeps running every 6
+# hours in `oss-tick.yml`, which is where a live-state divergence belongs. Recorded here rather
+# than left as an accident of which file each command landed in.
+
+name: ci
+
+on:
+  pull_request:
+  push:
+    # Pull requests already cover their own branches; restricting pushes to `main` makes this the
+    # post-merge gate (a merge commit is a state no pull-request run ever tested) without running
+    # the same commit twice on every feature-branch push.
+    branches: ["main"]
+
+concurrency:
+  # Supersede an outdated pull-request run, but NEVER cancel a push run. A cancelled push run
+  # leaves a merge commit on `main` with no suite behind it — the same hole this file closes,
+  # reintroduced by a convenience setting. The group keys on the event so the two never share one,
+  # and pushes key on the SHA so a later merge cannot evict an earlier merge's run.
+  group: ci-${{ github.event_name }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  suite:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # Pinned to immutable commits, not `@v4`. A major tag is a moving reference: whoever controls
+      # the upstream repository can retarget it, and these two run BEFORE every check here, so
+      # retargeted code could alter the workspace, swap the toolchain, or change this gate's
+      # verdict. Both SHAs are what `v4` resolved to when they were pinned (v4.4.0), so nothing
+      # about what executes changed — only whether it can change under us. Issue #85 owns keeping
+      # them current; a pin with no update mechanism trades a small risk for certain drift.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          # The floor `package.json` declares (`engines.node: >=22`), and the version the clock
+          # already runs, so CI tests the version the project claims to support rather than
+          # whatever is newest.
+          node-version: "22"
+
+      # No install step: `package.json` declares no dependencies and the repo has no lockfile, so
+      # there is nothing to restore and `npm ci` would fail on the missing lockfile.
+      - name: Test suite
+        run: npm test
+
+      # `run-tests.ts` is the oracle, not `node --test`: it asserts one summary per discovered
+      # `*.test.ts` and refuses a run where any file reported zero tests, so a file whose process
+      # exits mid-run cannot report green. `npm run validate` covers `allowlist.yaml` and
+      # `policy-records.json`, which until now ran only on the clock.
+      - name: Validate allowlist and policy records
+        run: npm run validate

--- a/.github/workflows/oss-tick.yml
+++ b/.github/workflows/oss-tick.yml
@@ -16,8 +16,12 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      # Pinned for the reason given in ci.yml, and it matters more here: this job carries
+      # `issues: write` and a GITHUB_TOKEN, and runs unattended with nobody reading the output.
+      # Hardening the read-only gate and leaving the token-bearing clock on a moving tag would be
+      # theatre. Same commits `v4`/`v7` already resolved to — no behaviour change.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
       - name: Validate allowlist
@@ -31,7 +35,7 @@ jobs:
         run: echo "FOUNDRY_LIVE is not set — clock stays dry. No issues, no PRs."
       - name: Open packet issue
         if: ${{ vars.FOUNDRY_LIVE == 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const title = "tick: next packet (human freeze required)";

--- a/factory/ci.test.ts
+++ b/factory/ci.test.ts
@@ -83,21 +83,61 @@ test("some workflow runs the full test suite on the pull-request path", () => {
 });
 
 /**
+ * The `pull_request:` trigger's own nested block, ending at the next sibling key.
+ *
+ * `{2}` is a literal space count, not `\s{2}`: `\s` also matches a newline, so the sloppier form
+ * expresses "two of any whitespace" when the actual rule is "a sibling key indented two spaces".
+ * `\S` rather than `\w` so a quoted key (`"push":`) also ends the block. Erring toward returning
+ * MORE text is the safe direction here — the caller asserts an absence, so over-reading can only
+ * cause a false failure, never a false pass.
+ */
+function pullRequestBlock(on: string): string {
+  const from = on.slice(on.indexOf("pull_request:"));
+  const next = from.slice(1).search(/\n {2}\S/);
+  return next === -1 ? from : from.slice(0, next + 1);
+}
+
+/**
  * A `paths:` or `paths-ignore:` filter on the gate's `pull_request` trigger is the quiet version of
  * deleting the workflow: the check does not fail, it does not run, and a pull request that changes
  * nothing on the list merges with no suite behind it. This repo has no such filter and should not
  * acquire one silently — every `*.ts` in `factory/` is load-bearing for every other one.
  */
 test("the pull-request gate is not narrowed by a path filter", () => {
+  /**
+   * The extractor first, against the shapes it has to survive — raised in review of this file as
+   * "the boundary regex treats the first nested property as the next trigger", which would have
+   * left `scoped` equal to `pull_request:\n` and the assertion below permanently green. The claim
+   * was checked and is not true of either indentation, but "I checked" is not evidence, so the
+   * cases are pinned here where a future edit to the regex has to keep them passing.
+   */
+  const NARROWED = [
+    'on:\n  pull_request:\n    paths: ["docs/**"]\n  push:\n    branches: ["main"]\n',
+    'on:\n  push:\n    branches: ["main"]\n  pull_request:\n    paths-ignore:\n      - "docs/**"\n',
+    'on:\n  pull_request:\n    types: [opened]\n    paths: ["docs/**"]\n',
+  ];
+  for (const yaml of NARROWED) {
+    const block = pullRequestBlock(triggerBlock(yaml));
+    assert.match(
+      block,
+      /paths(-ignore)?:/,
+      `the pull_request block extractor stops before a path filter in:\n${yaml}\nso the assertion below could never see one`,
+    );
+  }
+  // ...and it does not over-read into a sibling trigger's keys, which would make the absence
+  // assertion fail on a workflow that is perfectly fine.
+  assert.doesNotMatch(
+    pullRequestBlock(triggerBlock('on:\n  pull_request:\n  push:\n    paths: ["x"]\n')),
+    /paths:/,
+    "the extractor read past pull_request: into push:, so an unrelated trigger's path filter would red this test",
+  );
+
   for (const w of workflows()) {
     const on = triggerBlock(w.text);
     if (!/^\s*pull_request:\s*$/m.test(on)) continue;
     if (!/run:\s*npm test\b/.test(w.text) && !/run-tests\.ts/.test(w.text)) continue;
-    const pullRequest = on.slice(on.indexOf("pull_request:"));
-    const next = pullRequest.slice(1).search(/\n\s{2}\w/);
-    const scoped = next === -1 ? pullRequest : pullRequest.slice(0, next + 1);
     assert.doesNotMatch(
-      scoped,
+      pullRequestBlock(on),
       /paths(-ignore)?:/,
       `${w.name} filters its pull_request trigger by path, so a change outside the filter merges with no suite behind it`,
     );
@@ -141,14 +181,22 @@ test("the suite also runs on push to main, so a merge commit is tested", () => {
      * An unconditional `cancel-in-progress` is the quiet way to lose this gate: two merges landing
      * close together cancel the earlier run, and the merge commit it was testing keeps a green
      * check it never earned. Caught in review of this very file, where it was written that way
-     * first. If cancellation is enabled at all it must be conditional on the event.
+     * first.
+     *
+     * The expression must NAME THE EVENT, not merely be an expression. Round 1 of this test only
+     * required a `${{`, which `${{ true }}` satisfies while cancelling exactly the runs this
+     * protects — raised on the pull request. Deliberately not pinned to one literal spelling:
+     * `github.event_name == 'pull_request'` and `github.event_name != 'push'` are the same
+     * decision, and a test that reds on a semantically identical rewrite trains people to edit the
+     * test instead of reading it. Naming `github.event_name` is the invariant; which comparison is
+     * style.
      */
     const concurrency = /^concurrency:$([\s\S]*?)(?=^\S)/m.exec(w.text)?.[1] ?? "";
     if (/cancel-in-progress:/.test(concurrency)) {
       assert.match(
         concurrency,
-        /cancel-in-progress:\s*\$\{\{/,
-        `${w.name} cancels in-progress runs unconditionally, which would cancel a push run and leave a merge commit on main with no suite behind it`,
+        /cancel-in-progress:\s*\$\{\{[^}]*github\.event_name[^}]*\}\}/,
+        `${w.name} enables cancel-in-progress without conditioning it on github.event_name, so a push run can be cancelled and a merge commit keeps a green check it never earned`,
       );
     }
   }

--- a/factory/ci.test.ts
+++ b/factory/ci.test.ts
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const WORKFLOW_DIR = join(REPO_ROOT, ".github/workflows");
+
+/**
+ * Issue #54: the suite never ran in CI. `docs/SPEC.md` §8 conditions conformance on the
+ * implementation's own evidence and names the test suite as the demonstration, and the
+ * demonstration ran only on the machine of whoever remembered to type `npm test`.
+ *
+ * WHY A TEST AND NOT JUST THE WORKFLOW FILE. Adding `ci.yml` fixes the gap today; it does nothing
+ * about the gap reopening. Deleting the `npm test` step, or adding a `paths:` filter that happens to
+ * exclude `factory/`, would restore the exact original defect and no red mark anywhere would say so
+ * — and a silently-gutted gate is worse than a missing one, because the green check keeps being
+ * cited as evidence. This repository's own argument for machine enforcement (`docs/SPEC.md` §9, via
+ * RepoComplianceBench) applies to its CI configuration too.
+ *
+ * HONEST LIMITATION, STATED RATHER THAN PAPERED OVER. Every other guard of this shape in the repo
+ * is behavioural — `terminal.test.ts` SPAWNS each entry point rather than grepping for a call,
+ * because "round 2 stated this as a regex and a regex that matches inside a comment is not evidence
+ * that anything runs". That is not available here: GitHub Actions cannot be driven locally, so
+ * there is no process to spawn and no bytes to assert over. This is a text-level check on a config
+ * file and is the strongest oracle available for one. Two things keep it from being satisfied by a
+ * comment: YAML comment lines are stripped before matching, and the trigger assertions parse the
+ * `on:` block's own structure instead of searching the whole document for a keyword.
+ */
+
+/** The workflow files, with YAML comments removed so a commented-out step cannot satisfy a check. */
+function workflows(): { name: string; text: string }[] {
+  return readdirSync(WORKFLOW_DIR)
+    .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
+    .map((name) => {
+      const text = readFileSync(join(WORKFLOW_DIR, name), "utf8")
+        .split("\n")
+        .filter((line) => !/^\s*#/.test(line))
+        .join("\n");
+      return { name, text };
+    });
+}
+
+/**
+ * The `on:` block only, so `pull_request` appearing in a step name or an `if:` expression elsewhere
+ * in the file cannot be mistaken for a trigger. Ends at the next top-level key.
+ */
+function triggerBlock(text: string): string {
+  const lines = text.split("\n");
+  const start = lines.findIndex((l) => /^on:/.test(l));
+  if (start === -1) return "";
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((l) => /^[A-Za-z]/.test(l));
+  return rest.slice(0, end === -1 ? rest.length : end).join("\n");
+}
+
+test("some workflow runs the full test suite on the pull-request path", () => {
+  const gates = workflows().filter((w) => /^\s*pull_request:\s*$/m.test(triggerBlock(w.text)));
+  assert.ok(
+    gates.length > 0,
+    "no workflow triggers on `pull_request` — the suite is not a pull-request gate, which is issue #54 reopened",
+  );
+
+  // `npm test` or the runner directly; either is the whole suite. `node --test` on its own is NOT
+  // accepted: run-tests.ts exists because `node --test` reports a file whose process exits mid-run
+  // as a pass with zero subtests, exit 0.
+  const runsSuite = gates.filter((w) => /run:\s*npm test\b/.test(w.text) || /run-tests\.ts/.test(w.text));
+  assert.ok(
+    runsSuite.length > 0,
+    `workflows trigger on pull_request (${gates.map((g) => g.name).join(", ")}) but none runs the suite`,
+  );
+
+  // The validator too — issue #54's second bullet. It gates `allowlist.yaml` and
+  // `policy-records.json`, and before this it ran only on the six-hour clock.
+  const runsValidator = runsSuite.filter(
+    (w) => /run:\s*npm run validate\b/.test(w.text) || /validate-allowlist\.ts/.test(w.text),
+  );
+  assert.ok(
+    runsValidator.length > 0,
+    `${runsSuite.map((r) => r.name).join(", ")} runs the suite on pull requests but not \`npm run validate\``,
+  );
+});
+
+/**
+ * A `paths:` or `paths-ignore:` filter on the gate's `pull_request` trigger is the quiet version of
+ * deleting the workflow: the check does not fail, it does not run, and a pull request that changes
+ * nothing on the list merges with no suite behind it. This repo has no such filter and should not
+ * acquire one silently — every `*.ts` in `factory/` is load-bearing for every other one.
+ */
+test("the pull-request gate is not narrowed by a path filter", () => {
+  for (const w of workflows()) {
+    const on = triggerBlock(w.text);
+    if (!/^\s*pull_request:\s*$/m.test(on)) continue;
+    if (!/run:\s*npm test\b/.test(w.text) && !/run-tests\.ts/.test(w.text)) continue;
+    const pullRequest = on.slice(on.indexOf("pull_request:"));
+    const next = pullRequest.slice(1).search(/\n\s{2}\w/);
+    const scoped = next === -1 ? pullRequest : pullRequest.slice(0, next + 1);
+    assert.doesNotMatch(
+      scoped,
+      /paths(-ignore)?:/,
+      `${w.name} filters its pull_request trigger by path, so a change outside the filter merges with no suite behind it`,
+    );
+  }
+});
+
+/**
+ * The post-merge half. A merge commit is a state no pull-request run ever tested — the pull request
+ * tests the branch, and with a merge-commit strategy the result is a commit that existed nowhere
+ * until the merge. Issue #54's acceptance asks for both a push and a pull request.
+ */
+test("the suite also runs on push to main, so a merge commit is tested", () => {
+  const pushGates = workflows().filter((w) => {
+    const on = triggerBlock(w.text);
+    if (!/^\s*push:/m.test(on)) return false;
+    return /run:\s*npm test\b/.test(w.text) || /run-tests\.ts/.test(w.text);
+  });
+  assert.ok(
+    pushGates.length > 0,
+    "no workflow runs the suite on push — nothing tests the merge commit that a merge-commit strategy creates",
+  );
+  for (const w of pushGates) {
+    assert.match(
+      triggerBlock(w.text),
+      /branches:\s*\[?\s*["']?main["']?/,
+      `${w.name} runs the suite on push but does not name main, so the post-merge gate may not cover the default branch`,
+    );
+    /**
+     * The validator on the push path, asserted here and not inferred from the pull-request test.
+     * Today both triggers share one job, so removing `npm run validate` reds the pull-request test
+     * too — but that is a property of the current file layout, not of the claim this test makes.
+     * Split the gate into a pull-request workflow and a push workflow, keep the validator only in
+     * the first, and the post-merge path would silently stop checking `allowlist.yaml` and
+     * `policy-records.json` while both tests stayed green.
+     */
+    assert.ok(
+      /run:\s*npm run validate\b/.test(w.text) || /validate-allowlist\.ts/.test(w.text),
+      `${w.name} runs the suite on push but not the validator, so a merge commit is never checked against allowlist.yaml or policy-records.json`,
+    );
+    /**
+     * An unconditional `cancel-in-progress` is the quiet way to lose this gate: two merges landing
+     * close together cancel the earlier run, and the merge commit it was testing keeps a green
+     * check it never earned. Caught in review of this very file, where it was written that way
+     * first. If cancellation is enabled at all it must be conditional on the event.
+     */
+    const concurrency = /^concurrency:$([\s\S]*?)(?=^\S)/m.exec(w.text)?.[1] ?? "";
+    if (/cancel-in-progress:/.test(concurrency)) {
+      assert.match(
+        concurrency,
+        /cancel-in-progress:\s*\$\{\{/,
+        `${w.name} cancels in-progress runs unconditionally, which would cancel a push run and leave a merge commit on main with no suite behind it`,
+      );
+    }
+  }
+});
+
+/**
+ * `verify-ledger.ts` reads live GitHub, so it fails for reasons unrelated to a diff — issue #49 is
+ * the recorded instance where a maintainer moving a PR reddened `main` while every line was
+ * correct. Issue #54 asked for its placement to be "a recorded decision rather than an accident";
+ * this is the decision, enforced. Keeping it off the pull-request path is what makes the gate's red
+ * mean "this diff is wrong" instead of "something moved on github.com".
+ */
+test("the live-GitHub ledger check stays off the pull-request path", () => {
+  for (const w of workflows()) {
+    if (!/^\s*pull_request:\s*$/m.test(triggerBlock(w.text))) continue;
+    assert.doesNotMatch(
+      w.text,
+      /verify-ledger\.ts/,
+      `${w.name} runs verify-ledger.ts on pull requests; it reconciles against live GitHub, so it reddens pull requests for reasons outside the diff (issue #49). It belongs on the clock.`,
+    );
+  }
+});
+
+/**
+ * Every `uses:` in every workflow names an immutable commit, not a moving tag.
+ *
+ * A major tag like `@v4` is a reference the upstream owner can retarget, and these actions run
+ * BEFORE any check in both workflows — so retargeted code could alter the checked-out workspace,
+ * swap the Node toolchain, or change a gate's verdict. Raised by the review of the pull request
+ * that added `ci.yml`, and pinned across BOTH workflows rather than only the new one: `ci.yml` is
+ * read-only and secretless, while `oss-tick.yml` carries `issues: write` and a `GITHUB_TOKEN` and
+ * runs unattended, so it is the higher-value target of the two.
+ *
+ * Stated over every workflow rather than over a list of files, for the reason `run-tests.ts:8`
+ * gives: a hand-maintained roster is the same silent hole. A third workflow added tomorrow with a
+ * mutable ref reds this immediately.
+ *
+ * Issue #85 owns the remaining half — a keep-current mechanism, because a pin nobody updates trades
+ * a small supply-chain risk for certain drift, and that is a policy choice with an ongoing cost.
+ */
+test("every workflow action is pinned to an immutable commit", () => {
+  const seen: string[] = [];
+  for (const w of workflows()) {
+    for (const m of w.text.matchAll(/^\s*-?\s*uses:\s*(\S+)/gm)) {
+      const ref = m[1];
+      seen.push(`${w.name}: ${ref}`);
+      const at = ref.lastIndexOf("@");
+      assert.notEqual(at, -1, `${w.name} uses \`${ref}\` with no ref at all, so it floats on the default branch`);
+      assert.match(
+        ref.slice(at + 1),
+        /^[0-9a-f]{40}$/,
+        `${w.name} uses \`${ref}\`, a mutable ref. Pin the 40-character commit SHA with a trailing \`# vX.Y.Z\` comment; the upstream owner can retarget a tag, and this runs before every check in the job.`,
+      );
+    }
+  }
+  // The scan itself is not vacuous: a rename or an indentation change that made the pattern miss
+  // every `uses:` line would otherwise pass this test by finding nothing to check.
+  assert.ok(seen.length >= 4, `action discovery found only ${seen.length} \`uses:\` lines (${seen.join(", ")})`);
+});


### PR DESCRIPTION
Closes #54

## What

Adds `.github/workflows/ci.yml` — a read-only gate that runs the full suite (`npm test`) and the
validator (`npm run validate`) on `pull_request` and on `push` to `main`. Adds
`factory/ci.test.ts`, which pins the gate's shape so it cannot be silently gutted. Pins every
action in **both** workflows to an immutable commit.

## Why

`docs/SPEC.md` §8 conditions conformance on this implementation's own evidence and names the test
suite as the demonstration. Before this, `oss-tick.yml` was the only workflow and it is
`on: schedule` + `workflow_dispatch` — so the demonstration ran only on the machine of whoever
remembered to type `npm test`, and no pull request had ever been gated by it. That is precisely the
failure mode `docs/SPEC.md` §9 cites RepoComplianceBench to argue against, running inside the repo
that makes the argument.

The gate is a **separate file from the clock**, not a step added to it. The clock reads live GitHub
and may file an issue; a gate must fail only for reasons inside the diff. Merging the two would put
the clock's live-GitHub failure modes on the pull-request path.

## How verified

- **tests**: 313 tests across 15 files, `suite ok`; `npm run validate` exit 0 (`allowlist ok`,
  `policy records ok: 8 records`). Baseline on this worktree before any edit was 308/14, so the five
  new tests are additive and nothing existing changed.
- **new tests red by revert** — each mutation applied alone, full suite run, then reverted, with the
  baseline re-verified green afterwards:

  | mutation to `ci.yml` | test that reds |
  |---|---|
  | delete the `npm test` step | `some workflow runs the full test suite on the pull-request path` |
  | delete the `npm run validate` step | same |
  | remove the `pull_request:` trigger | same |
  | add `paths: ["docs/**"]` to `pull_request` | `the pull-request gate is not narrowed by a path filter` |
  | drop `branches: ["main"]` from `push` | `the suite also runs on push to main…` |
  | set `cancel-in-progress: true` unconditionally | same |
  | add `verify-ledger.ts` to the gate | `the live-GitHub ledger check stays off the pull-request path` |
  | revert any one action pin to `@v4` | `every workflow action is pinned to an immutable commit` |
  | **comment out** the `npm test` step | `some workflow runs the full test suite…` (comments are stripped before matching, so a commented step cannot satisfy the check) |
  | break the `uses:` scan regex so it matches nothing | `every workflow action is pinned…` (the scan asserts it found ≥ 4 refs, so it cannot pass vacuously) |

- **manual**: `grep -n "uses:" .github/workflows/*.yml` → all 5 references are 40-hex SHAs with
  `# vX.Y.Z` comments.
- **the gate itself**: this pull request is the first run of `ci.yml`; a deliberately-broken-test
  negative control is run on a throwaway branch and linked in a comment below, so
  "a deliberately broken test fails the PR" is demonstrated rather than asserted.
- **greptile**: 3 rounds, confidence 5/5, 2 findings fixed, 0 rebutted.

## Notes for review

**Two review findings, both fixed, and the second changed my mind about scope.**

1. *Push-path validator assertion missing* (P2). Correct. The push test selected workflows by
   trigger and suite command only, so splitting the gate into a pull-request workflow and a
   push workflow — keeping the validator only in the first — would have left both tests green
   while merged commits stopped being checked against `allowlist.yaml`. Fixed with its own
   assertion rather than by narrowing the filter, so the failure message names the real cause.
   Verified by building exactly that split-gate regression: the push test reds.

2. *Action references remain mutable* (P2, security). I first rebutted this and filed #85, on the
   grounds that `@v4` was the repo's existing convention and pinning only the new file would leave
   two spellings in a two-file directory. The gate disagreed — round 2 returned zero comments but
   dropped confidence to 3/5 with "should not merge until the CI actions are pinned" — and on
   reflection it was right and my rebuttal was the weaker argument. Parking a P1 CI gate over four
   lines would have been a bad trade. So both workflows are pinned, which also dissolves the
   two-conventions objection.

   Pinning `oss-tick.yml` is a second file in a PR that closes #54, and that is deliberate:
   `ci.yml` is read-only and secretless, while `oss-tick.yml` carries `issues: write` and a
   `GITHUB_TOKEN` and runs unattended every six hours. Pinning the harmless one and leaving the
   token-bearing one on a moving tag would have been theatre.

   Every SHA is the commit the tag **already resolved to** (`v4` = `v4.4.0`, `v7` = `v7.1.0`,
   verified against the GitHub API), so this is not a version bump — nothing about what executes
   changed, only whether it can change without a commit. The test states the rule over *every*
   workflow rather than a file list, per `run-tests.ts:8` ("a hand-maintained roster is the same
   silent hole"), and it immediately earned that: it caught `actions/github-script@v7`, a third
   action my manual pass had missed.

**Deliberate non-goals**, so they read as decisions rather than omissions:

- **`verify-ledger.ts` is not on the pull-request path.** #54 asked for this to be recorded rather
  than inherited. It reconciles the committed ledger against live GitHub, so it reddens a pull
  request for reasons outside the diff — #49 is the recorded instance. It stays on the clock, and a
  test now enforces that it stays off the gate, so the gate's red always means "this diff is wrong".
- **Branch protection is unchanged.** #54's last bullet says "consider requiring the check on
  `main`". That is a repository-settings change, not a code change, and it is the maintainer's call
  to make once this check has some history. Nothing here depends on it.
- **Node 22 only, no version matrix.** 22 is the floor `package.json` declares and the version the
  clock already runs. A matrix is a different question than the one #54 asks.
- **`cancel-in-progress` is conditional on the event.** Written unconditionally first and caught in
  my own read-through: it would have cancelled a *push* run, letting a merge commit keep a green
  check it never earned — the same hole this file closes, reintroduced by a convenience setting.
  Pinned by a test.




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a CI gate for pull requests and pushes to `main`, together with regression tests protecting its intended shape.
- Runs the full test suite and repository validator on both gated paths.
- Prevents push-run cancellation in the current workflow configuration.
- Pins actions in both workflows to immutable commit SHAs.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The pull request appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds the pull-request and main-push gate with event-aware concurrency and read-only permissions. |
| .github/workflows/oss-tick.yml | Replaces mutable action tags with immutable commit references. |
| factory/ci.test.ts | Adds structural regression coverage for CI triggers, commands, concurrency, and action pins. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  PR[Pull request] --> CI[CI suite job]
  Push[Push to main] --> CI
  CI --> Tests[npm test]
  CI --> Validate[npm run validate]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(ci): pin the two claims the gate&#39;s ..."](https://github.com/ravidsrk/oss-foundry/commit/443f66aafb643f72d8490482aa102568016d6a6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58251774)</sub>

<!-- /greptile_comment -->