### PR TITLE
DO NOT MERGE — negative control for the #54 CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+# The suite, machine-enforced. docs/SPEC.md §8 conditions conformance on the implementation's own
+# evidence and names the test suite as the demonstration; until this file existed the demonstration
+# ran only on the machine of whoever remembered to type `npm test` (issue #54).
+#
+# Separate from `oss-tick.yml` on purpose. That workflow is the factory's 6-hour CLOCK: it is
+# `on: schedule`, it reads live GitHub, and it may file a packet issue. This one is a GATE: it is
+# `on: pull_request` / `on: push`, it touches no network, and it never writes anything. Merging the
+# two would put the clock's live-GitHub failure modes on the pull-request path.
+#
+# WHY `verify-ledger.ts` IS NOT HERE. It reconciles the committed ledger against live GitHub, so it
+# fails for reasons that have nothing to do with a diff — a maintainer moving a PR reddens it while
+# every line of the branch is correct, which is exactly what happened in issue #49. Doctrine says a
+# divergence is a real event that should stop the CLOCK; stopping every pull request on it is a
+# different policy, and this is the deliberate choice not to adopt it. It keeps running every 6
+# hours in `oss-tick.yml`, which is where a live-state divergence belongs. Recorded here rather
+# than left as an accident of which file each command landed in.
+
+name: ci
+
+on:
+  pull_request:
+  push:
+    # Pull requests already cover their own branches; restricting pushes to `main` makes this the
+    # post-merge gate (a merge commit is a state no pull-request run ever tested) without running
+    # the same commit twice on every feature-branch push.
+    branches: ["main"]
+
+concurrency:
+  # Supersede an outdated pull-request run, but NEVER cancel a push run. A cancelled push run
+  # leaves a merge commit on `main` with no suite behind it — the same hole this file closes,
+  # reintroduced by a convenience setting. The group keys on the event so the two never share one,
+  # and pushes key on the SHA so a later merge cannot evict an earlier merge's run.
+  group: ci-${{ github.event_name }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  suite:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # Pinned to immutable commits, not `@v4`. A major tag is a moving reference: whoever controls
+      # the upstream repository can retarget it, and these two run BEFORE every check here, so
+      # retargeted code could alter the workspace, swap the toolchain, or change this gate's
+      # verdict. Both SHAs are what `v4` resolved to when they were pinned (v4.4.0), so nothing
+      # about what executes changed — only whether it can change under us. Issue #85 owns keeping
+      # them current; a pin with no update mechanism trades a small risk for certain drift.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          # The floor `package.json` declares (`engines.node: >=22`), and the version the clock
+          # already runs, so CI tests the version the project claims to support rather than
+          # whatever is newest.
+          node-version: "22"
+
+      # No install step: `package.json` declares no dependencies and the repo has no lockfile, so
+      # there is nothing to restore and `npm ci` would fail on the missing lockfile.
+      - name: Test suite
+        run: npm test
+
+      # `run-tests.ts` is the oracle, not `node --test`: it asserts one summary per discovered
+      # `*.test.ts` and refuses a run where any file reported zero tests, so a file whose process
+      # exits mid-run cannot report green. `npm run validate` covers `allowlist.yaml` and
+      # `policy-records.json`, which until now ran only on the clock.
+      - name: Validate allowlist and policy records
+        run: npm run validate

--- a/.github/workflows/oss-tick.yml
+++ b/.github/workflows/oss-tick.yml
@@ -16,8 +16,12 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      # Pinned for the reason given in ci.yml, and it matters more here: this job carries
+      # `issues: write` and a GITHUB_TOKEN, and runs unattended with nobody reading the output.
+      # Hardening the read-only gate and leaving the token-bearing clock on a moving tag would be
+      # theatre. Same commits `v4`/`v7` already resolved to — no behaviour change.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
       - name: Validate allowlist
@@ -31,7 +35,7 @@ jobs:
         run: echo "FOUNDRY_LIVE is not set — clock stays dry. No issues, no PRs."
       - name: Open packet issue
         if: ${{ vars.FOUNDRY_LIVE == 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const title = "tick: next packet (human freeze required)";

--- a/factory/ci.test.ts
+++ b/factory/ci.test.ts
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const WORKFLOW_DIR = join(REPO_ROOT, ".github/workflows");
+
+/**
+ * Issue #54: the suite never ran in CI. `docs/SPEC.md` §8 conditions conformance on the
+ * implementation's own evidence and names the test suite as the demonstration, and the
+ * demonstration ran only on the machine of whoever remembered to type `npm test`.
+ *
+ * WHY A TEST AND NOT JUST THE WORKFLOW FILE. Adding `ci.yml` fixes the gap today; it does nothing
+ * about the gap reopening. Deleting the `npm test` step, or adding a `paths:` filter that happens to
+ * exclude `factory/`, would restore the exact original defect and no red mark anywhere would say so
+ * — and a silently-gutted gate is worse than a missing one, because the green check keeps being
+ * cited as evidence. This repository's own argument for machine enforcement (`docs/SPEC.md` §9, via
+ * RepoComplianceBench) applies to its CI configuration too.
+ *
+ * HONEST LIMITATION, STATED RATHER THAN PAPERED OVER. Every other guard of this shape in the repo
+ * is behavioural — `terminal.test.ts` SPAWNS each entry point rather than grepping for a call,
+ * because "round 2 stated this as a regex and a regex that matches inside a comment is not evidence
+ * that anything runs". That is not available here: GitHub Actions cannot be driven locally, so
+ * there is no process to spawn and no bytes to assert over. This is a text-level check on a config
+ * file and is the strongest oracle available for one. Two things keep it from being satisfied by a
+ * comment: YAML comment lines are stripped before matching, and the trigger assertions parse the
+ * `on:` block's own structure instead of searching the whole document for a keyword.
+ */
+
+/** The workflow files, with YAML comments removed so a commented-out step cannot satisfy a check. */
+function workflows(): { name: string; text: string }[] {
+  return readdirSync(WORKFLOW_DIR)
+    .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
+    .map((name) => {
+      const text = readFileSync(join(WORKFLOW_DIR, name), "utf8")
+        .split("\n")
+        .filter((line) => !/^\s*#/.test(line))
+        .join("\n");
+      return { name, text };
+    });
+}
+
+/**
+ * The `on:` block only, so `pull_request` appearing in a step name or an `if:` expression elsewhere
+ * in the file cannot be mistaken for a trigger. Ends at the next top-level key.
+ */
+function triggerBlock(text: string): string {
+  const lines = text.split("\n");
+  const start = lines.findIndex((l) => /^on:/.test(l));
+  if (start === -1) return "";
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((l) => /^[A-Za-z]/.test(l));
+  return rest.slice(0, end === -1 ? rest.length : end).join("\n");
+}
+
+test("some workflow runs the full test suite on the pull-request path", () => {
+  const gates = workflows().filter((w) => /^\s*pull_request:\s*$/m.test(triggerBlock(w.text)));
+  assert.ok(
+    gates.length > 0,
+    "no workflow triggers on `pull_request` — the suite is not a pull-request gate, which is issue #54 reopened",
+  );
+
+  // `npm test` or the runner directly; either is the whole suite. `node --test` on its own is NOT
+  // accepted: run-tests.ts exists because `node --test` reports a file whose process exits mid-run
+  // as a pass with zero subtests, exit 0.
+  const runsSuite = gates.filter((w) => /run:\s*npm test\b/.test(w.text) || /run-tests\.ts/.test(w.text));
+  assert.ok(
+    runsSuite.length > 0,
+    `workflows trigger on pull_request (${gates.map((g) => g.name).join(", ")}) but none runs the suite`,
+  );
+
+  // The validator too — issue #54's second bullet. It gates `allowlist.yaml` and
+  // `policy-records.json`, and before this it ran only on the six-hour clock.
+  const runsValidator = runsSuite.filter(
+    (w) => /run:\s*npm run validate\b/.test(w.text) || /validate-allowlist\.ts/.test(w.text),
+  );
+  assert.ok(
+    runsValidator.length > 0,
+    `${runsSuite.map((r) => r.name).join(", ")} runs the suite on pull requests but not \`npm run validate\``,
+  );
+});
+
+/**
+ * A `paths:` or `paths-ignore:` filter on the gate's `pull_request` trigger is the quiet version of
+ * deleting the workflow: the check does not fail, it does not run, and a pull request that changes
+ * nothing on the list merges with no suite behind it. This repo has no such filter and should not
+ * acquire one silently — every `*.ts` in `factory/` is load-bearing for every other one.
+ */
+test("the pull-request gate is not narrowed by a path filter", () => {
+  for (const w of workflows()) {
+    const on = triggerBlock(w.text);
+    if (!/^\s*pull_request:\s*$/m.test(on)) continue;
+    if (!/run:\s*npm test\b/.test(w.text) && !/run-tests\.ts/.test(w.text)) continue;
+    const pullRequest = on.slice(on.indexOf("pull_request:"));
+    const next = pullRequest.slice(1).search(/\n\s{2}\w/);
+    const scoped = next === -1 ? pullRequest : pullRequest.slice(0, next + 1);
+    assert.doesNotMatch(
+      scoped,
+      /paths(-ignore)?:/,
+      `${w.name} filters its pull_request trigger by path, so a change outside the filter merges with no suite behind it`,
+    );
+  }
+});
+
+/**
+ * The post-merge half. A merge commit is a state no pull-request run ever tested — the pull request
+ * tests the branch, and with a merge-commit strategy the result is a commit that existed nowhere
+ * until the merge. Issue #54's acceptance asks for both a push and a pull request.
+ */
+test("the suite also runs on push to main, so a merge commit is tested", () => {
+  const pushGates = workflows().filter((w) => {
+    const on = triggerBlock(w.text);
+    if (!/^\s*push:/m.test(on)) return false;
+    return /run:\s*npm test\b/.test(w.text) || /run-tests\.ts/.test(w.text);
+  });
+  assert.ok(
+    pushGates.length > 0,
+    "no workflow runs the suite on push — nothing tests the merge commit that a merge-commit strategy creates",
+  );
+  for (const w of pushGates) {
+    assert.match(
+      triggerBlock(w.text),
+      /branches:\s*\[?\s*["']?main["']?/,
+      `${w.name} runs the suite on push but does not name main, so the post-merge gate may not cover the default branch`,
+    );
+    /**
+     * The validator on the push path, asserted here and not inferred from the pull-request test.
+     * Today both triggers share one job, so removing `npm run validate` reds the pull-request test
+     * too — but that is a property of the current file layout, not of the claim this test makes.
+     * Split the gate into a pull-request workflow and a push workflow, keep the validator only in
+     * the first, and the post-merge path would silently stop checking `allowlist.yaml` and
+     * `policy-records.json` while both tests stayed green.
+     */
+    assert.ok(
+      /run:\s*npm run validate\b/.test(w.text) || /validate-allowlist\.ts/.test(w.text),
+      `${w.name} runs the suite on push but not the validator, so a merge commit is never checked against allowlist.yaml or policy-records.json`,
+    );
+    /**
+     * An unconditional `cancel-in-progress` is the quiet way to lose this gate: two merges landing
+     * close together cancel the earlier run, and the merge commit it was testing keeps a green
+     * check it never earned. Caught in review of this very file, where it was written that way
+     * first. If cancellation is enabled at all it must be conditional on the event.
+     */
+    const concurrency = /^concurrency:$([\s\S]*?)(?=^\S)/m.exec(w.text)?.[1] ?? "";
+    if (/cancel-in-progress:/.test(concurrency)) {
+      assert.match(
+        concurrency,
+        /cancel-in-progress:\s*\$\{\{/,
+        `${w.name} cancels in-progress runs unconditionally, which would cancel a push run and leave a merge commit on main with no suite behind it`,
+      );
+    }
+  }
+});
+
+/**
+ * `verify-ledger.ts` reads live GitHub, so it fails for reasons unrelated to a diff — issue #49 is
+ * the recorded instance where a maintainer moving a PR reddened `main` while every line was
+ * correct. Issue #54 asked for its placement to be "a recorded decision rather than an accident";
+ * this is the decision, enforced. Keeping it off the pull-request path is what makes the gate's red
+ * mean "this diff is wrong" instead of "something moved on github.com".
+ */
+test("the live-GitHub ledger check stays off the pull-request path", () => {
+  for (const w of workflows()) {
+    if (!/^\s*pull_request:\s*$/m.test(triggerBlock(w.text))) continue;
+    assert.doesNotMatch(
+      w.text,
+      /verify-ledger\.ts/,
+      `${w.name} runs verify-ledger.ts on pull requests; it reconciles against live GitHub, so it reddens pull requests for reasons outside the diff (issue #49). It belongs on the clock.`,
+    );
+  }
+});
+
+/**
+ * Every `uses:` in every workflow names an immutable commit, not a moving tag.
+ *
+ * A major tag like `@v4` is a reference the upstream owner can retarget, and these actions run
+ * BEFORE any check in both workflows — so retargeted code could alter the checked-out workspace,
+ * swap the Node toolchain, or change a gate's verdict. Raised by the review of the pull request
+ * that added `ci.yml`, and pinned across BOTH workflows rather than only the new one: `ci.yml` is
+ * read-only and secretless, while `oss-tick.yml` carries `issues: write` and a `GITHUB_TOKEN` and
+ * runs unattended, so it is the higher-value target of the two.
+ *
+ * Stated over every workflow rather than over a list of files, for the reason `run-tests.ts:8`
+ * gives: a hand-maintained roster is the same silent hole. A third workflow added tomorrow with a
+ * mutable ref reds this immediately.
+ *
+ * Issue #85 owns the remaining half — a keep-current mechanism, because a pin nobody updates trades
+ * a small supply-chain risk for certain drift, and that is a policy choice with an ongoing cost.
+ */
+test("every workflow action is pinned to an immutable commit", () => {
+  const seen: string[] = [];
+  for (const w of workflows()) {
+    for (const m of w.text.matchAll(/^\s*-?\s*uses:\s*(\S+)/gm)) {
+      const ref = m[1];
+      seen.push(`${w.name}: ${ref}`);
+      const at = ref.lastIndexOf("@");
+      assert.notEqual(at, -1, `${w.name} uses \`${ref}\` with no ref at all, so it floats on the default branch`);
+      assert.match(
+        ref.slice(at + 1),
+        /^[0-9a-f]{40}$/,
+        `${w.name} uses \`${ref}\`, a mutable ref. Pin the 40-character commit SHA with a trailing \`# vX.Y.Z\` comment; the upstream owner can retarget a tag, and this runs before every check in the job.`,
+      );
+    }
+  }
+  // The scan itself is not vacuous: a rename or an indentation change that made the pattern miss
+  // every `uses:` line would otherwise pass this test by finding nothing to check.
+  assert.ok(seen.length >= 4, `action discovery found only ${seen.length} \`uses:\` lines (${seen.join(", ")})`);
+});

--- a/factory/negative-control.test.ts
+++ b/factory/negative-control.test.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+/**
+ * THROWAWAY. Exists only to prove the CI gate added in #86 actually reds a pull request on a
+ * failing test, which is issue #54's acceptance criterion ("a deliberately broken test fails the
+ * PR"). This branch is never merged and is deleted once the red run is recorded.
+ */
+test("deliberately broken: proves the CI gate reds a pull request", () => {
+  assert.equal(1, 2, "this assertion is meant to fail");
+});


### PR DESCRIPTION
Throwaway. Proves the gate added in #86 reds a pull request on a failing test — issue #54's acceptance criterion. Branches off #86, adds one failing assertion, and will be closed and deleted once the red run is recorded. Not for review.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This throwaway PR adds a GitHub Actions CI gate and an intentional failing test to demonstrate that test failures block pull requests.
- Adds pull-request and main-push execution of the test suite and validators.
- Pins actions used by both CI and the scheduled OSS workflow to immutable commits.
- Adds tests protecting the workflow’s triggers, commands, concurrency behavior, and action pinning.
- Adds the deliberately failing negative-control assertion.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR’s intended negative-control behavior works, with one non-blocking weakness in the workflow regression test’s command matching.

The always-failing test is intentionally reachable through the repository runner and CI gate, while the only accepted concern is that the new textual guard can mistake a narrower `npm test:*` script for execution of the full suite.

**Files Needing Attention:** factory/ci.test.ts
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds the Node 22 pull-request and main-push gate that runs tests and repository validation. |
| .github/workflows/oss-tick.yml | Replaces mutable action tags with immutable commit references without changing the scheduled job’s intended behavior. |
| factory/ci.test.ts | Adds workflow regression checks, but the suite-command matcher also accepts narrower script names such as `npm test:unit`. |
| factory/negative-control.test.ts | Intentionally introduces an always-failing assertion to prove that the new pull-request gate turns red. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20ravidsrk%2Foss-foundry%20PR%20%2387%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=ravidsrk%2Foss-foundry&pr=87&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Afactory%2Fci.test.ts%3A68%0A**Suite%20matcher%20accepts%20narrower%20scripts**%0A%0AThe%20%60npm%20test%5Cb%60%20pattern%20also%20matches%20narrower%20script%20names%20such%20as%20%60npm%20test%3Aunit%60%2C%20allowing%20a%20future%20workflow%20to%20stop%20running%20the%20full%20suite%20while%20this%20enforcement%20test%20continues%20to%20pass.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ravidsrk%2Foss-foundry&pr=87&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
factory/ci.test.ts:68
**Suite matcher accepts narrower scripts**

The `npm test\b` pattern also matches narrower script names such as `npm test:unit`, allowing a future workflow to stop running the full suite while this enforcement test continues to pass.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: deliberately broken test to prove ..."](https://github.com/ravidsrk/oss-foundry/commit/d44cd1a105dc1d17483db1a7dc571857565f3769) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58251874)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->