### PR TITLE
fix(witness): let the OS name the clone directory, not the wall clock (#56)

### DIFF
--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -1794,6 +1794,15 @@ test("status does not claim a re-block that the held slot already prevented", ()
   assert.ok(held.includes(a.prUrl!), held);
 });
 
+/**
+ * `mkdtemp` answers with a fixed path unless a case overrides it. The step exists so the protocol
+ * never calls `mkdtempSync` itself (issue #56): a stub that returned nothing would make every
+ * witness here fail closed on the scratch directory, and a stub that created a REAL directory would
+ * leak one per test, which is issue #64. A fixed fake path keeps the `calls` assertions readable —
+ * the dir is interpolated into `git clone …` — while touching no filesystem.
+ */
+const FAKE_SCRATCH = "/tmp/foundry-witness-fake";
+
 function fakeRunner(script: Record<string, { exit: number; output: string }>) {
   const calls: string[] = [];
   /** Parallel to `calls`: the working directory each step was handed, so cwd is assertable too. */
@@ -1803,7 +1812,9 @@ function fakeRunner(script: Record<string, { exit: number; output: string }>) {
     calls.push(line);
     cwds.push(opts?.cwd);
     const hit = Object.entries(script).find(([prefix]) => line.includes(prefix));
-    return hit ? hit[1] : { exit: 0, output: "" };
+    if (hit) return hit[1];
+    if (cmd === "mkdtemp") return { exit: 0, output: FAKE_SCRATCH };
+    return { exit: 0, output: "" };
   };
   return { runner, calls, cwds };
 }
@@ -2108,6 +2119,17 @@ test("no refusal the witness protocol can produce reaches the terminal with cont
       if (cmd === "run-tests@revert") return fail === "control" ? { exit: 0, output: hostile } : { exit: 1, output: hostile };
       if (cmd === "probe") return { exit: 0, output: `${hostile}\nnpm 10.9.2` };
       if (cmd === "cleanup") return { exit: 0, output: "" };
+      /**
+       * The scratch-directory step, and the reason it is a stage rather than a fixed answer: the
+       * refusal added for issue #56 interpolates this step's output, so it is exactly the "eighth
+       * stage tomorrow" this test's docblock promises to cover the day it exists.
+       *
+       * Answering it correctly also matters for the other nine. When this returned the fall-through
+       * `{ exit: 0, output: "" }`, the empty path made the witness fail closed on the scratch
+       * directory FIRST, so every stage in the loop asserted that one refusal and none of the nine
+       * they name — nine passing assertions exercising one code path, and the suite stayed green.
+       */
+      if (cmd === "mkdtemp") return fail === "mkdtemp" ? { exit: 1, output: hostile } : { exit: 0, output: FAKE_SCRATCH };
       const stage =
         line.includes(" clone ") ? "clone"
         : line.includes(" fetch ") ? "fetch"
@@ -2122,7 +2144,7 @@ test("no refusal the witness protocol can produce reaches the terminal with cont
     };
   };
 
-  const stages = ["clone", "fetch", "checkout", "setup", "clean", "setup-rerun", "revert", "head", "control"];
+  const stages = ["mkdtemp", "clone", "fetch", "checkout", "setup", "clean", "setup-rerun", "revert", "head", "control"];
   for (const stage of stages) {
     const outcome = await witnessEvidence(
       { ...WAVE0, testCommand: "npm test", setupCommand: "npm ci" },
@@ -2155,6 +2177,19 @@ test("no refusal the witness protocol can produce reaches the terminal with cont
     );
     // The diagnostic survives the sanitising — this must not be passing by printing nothing.
     assert.ok(stream.text.trim().length > 20, `${stage}: ${JSON.stringify(stream.text)}`);
+    /**
+     * ...and it must be THIS stage's refusal, not another one reached first.
+     *
+     * Every stage above answers its failing step with `hostile`, whose printable remainder after
+     * sanitising contains "repainted". A refusal raised before the stage under test — which is what
+     * happened while the scratch-directory step answered with an empty path — carries none of it.
+     * Without this line all ten stages passed while exercising one code path, and length alone could
+     * not tell the difference.
+     */
+    assert.ok(
+      stream.text.includes("repainted"),
+      `stage ${stage} refused before its own step ran, so this iteration proves nothing about it: ${JSON.stringify(stream.text.slice(0, 200))}`,
+    );
   }
 });
 
@@ -2474,6 +2509,7 @@ test("test-path classifier knows suffix conventions and setup runs before tests"
   const calls: string[] = [];
   const runner = async (step: string, args: string[]) => {
     calls.push([step, ...args].join(" "));
+    if (step === "mkdtemp") return { exit: 0, output: FAKE_SCRATCH };
     if (step === "run-tests@head") return { exit: 0, output: "ok" };
     if (step === "run-tests@revert") return { exit: 1, output: "red" };
     return { exit: 0, output: "" };

--- a/factory/witness-host.test.ts
+++ b/factory/witness-host.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
@@ -100,4 +100,68 @@ test("the toolchain probe reports a missing tool as missing rather than inventin
   assert.equal(probed[0].tool, "foundry-no-such-tool");
   assert.equal(probed[0].path, undefined);
   assert.equal(probed[0].version, undefined);
+});
+
+/**
+ * Issue #56: the witness clone directory was named from `Date.now()` alone —
+ * `foundry-witness-${repoId}-${Date.now()}`, no pid and no randomness. Two witness runs for the
+ * same repository starting in the same millisecond produced the same path, and `git clone` refuses
+ * a destination that exists and is not empty:
+ *
+ *     destination path '...foundry-witness-ravidsrk_orca-fleet-1787981801727' already exists
+ *
+ * Observed as a red suite once in seventeen full runs, on the one surface whose entire job is to be
+ * reproducible. The fix is not a wider clock — it is to stop naming the path ourselves and let the
+ * OS allocate it, which removes the collision class rather than narrowing it.
+ *
+ * THIS TEST IS THE COLLISION, not a proxy for it. A loop is not "the same millisecond" by
+ * assumption: the assertion below requires that at least two of the calls genuinely landed in one
+ * millisecond, so a machine slow enough to space them out reports that rather than passing
+ * vacuously. Under the old naming every one of those same-millisecond calls produced an identical
+ * path; under `mkdtempSync` they cannot, because it creates the directory as it names it and fails
+ * rather than returning a path that already exists.
+ */
+test("two witness scratch directories requested in the same millisecond are distinct and real", async () => {
+  const made: string[] = [];
+  try {
+    const stamps: number[] = [];
+    for (let i = 0; i < 24; i += 1) {
+      stamps.push(Date.now());
+      const result = await hostRunner("mkdtemp", ["foundry-witness-ravidsrk_orca-fleet-"]);
+      assert.equal(result.exit, 0, `mkdtemp refused: ${result.output}`);
+      made.push(result.output);
+    }
+
+    const sameMillisecond = stamps.some((t, i) => i > 0 && t === stamps[i - 1]);
+    assert.ok(
+      sameMillisecond,
+      `no two of the ${stamps.length} requests shared a millisecond, so this run did not exercise the collision (stamps: ${stamps.join(",")})`,
+    );
+
+    assert.equal(new Set(made).size, made.length, `two scratch directories collided: ${made.join(", ")}`);
+    for (const dir of made) {
+      // `mkdtempSync` CREATES the directory, which is what makes the uniqueness the OS's promise
+      // rather than ours. A path that does not exist would mean the name was merely composed.
+      assert.ok(statSync(dir).isDirectory(), `${dir} was named but not created`);
+      assert.ok(dir.startsWith(join(tmpdir(), "foundry-witness-")), `${dir} is not under the tmpdir prefix it asked for`);
+    }
+  } finally {
+    // Issue #64's convention: a test that creates temp dirs removes them. Twenty-four per run would
+    // otherwise be a new instance of the very leak that issue is about.
+    for (const dir of made) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/**
+ * The prefix reaches this function from `repoId`, i.e. from `allowlist.yaml`. A prefix carrying a
+ * path separator would place the scratch directory outside `tmpdir()` — the class of defect issue
+ * #80 was filed for, one layer down. Refused here as well as sanitised by the caller, because a
+ * guard that only exists at the call site is one call site away from not existing.
+ */
+test("the host runner refuses a scratch prefix that would escape the tmpdir", async () => {
+  for (const bad of ["../escape-", "foundry/../../escape-", "a\\b-"]) {
+    const result = await hostRunner("mkdtemp", [bad]);
+    assert.equal(result.exit, 1, `${bad} was accepted: ${result.output}`);
+    assert.match(result.output, /path separator/, result.output);
+  }
 });

--- a/factory/witness-host.test.ts
+++ b/factory/witness-host.test.ts
@@ -3,7 +3,7 @@ import { chmodSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
-import { hostRunner, resolveToolchain } from "./witness.ts";
+import { hostRunner, resolveToolchain, witnessEvidence } from "./witness.ts";
 
 /**
  * `hostRunner` driven against a real shell — the only assertions in the repo that a fake runner
@@ -111,44 +111,112 @@ test("the toolchain probe reports a missing tool as missing rather than inventin
  *     destination path '...foundry-witness-ravidsrk_orca-fleet-1787981801727' already exists
  *
  * Observed as a red suite once in seventeen full runs, on the one surface whose entire job is to be
- * reproducible. The fix is not a wider clock — it is to stop naming the path ourselves and let the
- * OS allocate it, which removes the collision class rather than narrowing it.
+ * reproducible. A test that fails once in seventeen for reasons unrelated to the code teaches the
+ * operator to re-run rather than read, which is the habit that lets a real red through.
  *
- * THIS TEST IS THE COLLISION, not a proxy for it. A loop is not "the same millisecond" by
- * assumption: the assertion below requires that at least two of the calls genuinely landed in one
- * millisecond, so a machine slow enough to space them out reports that rather than passing
- * vacuously. Under the old naming every one of those same-millisecond calls produced an identical
- * path; under `mkdtempSync` they cannot, because it creates the directory as it names it and fails
- * rather than returning a path that already exists.
+ * THE CLOCK IS FROZEN RATHER THAN RACED. The first version of this test sampled `Date.now()` around
+ * each call and asserted that two samples matched — which makes the test itself timing-dependent: a
+ * loaded worker spaces the calls past a millisecond boundary and the suite goes red with the fix
+ * working perfectly. Adding an intermittent test to a change that exists to remove one is the wrong
+ * trade, and it was caught in review of this branch.
+ *
+ * Freezing is also the stronger statement. "Two runs in the same millisecond" is not really a claim
+ * about time; it is a claim that the name does not DEPEND on time. With `Date.now` pinned to the
+ * exact timestamp from the reported failure, the old code produces one path for every call by
+ * construction, and `mkdtempSync` cannot, because it creates the directory as it names it and fails
+ * rather than returning a path that already exists. No scheduling, no flake, and the defect is
+ * reproduced exactly rather than approximated.
  */
-test("two witness scratch directories requested in the same millisecond are distinct and real", async () => {
+const FROZEN_MS = 1787981801727; // the timestamp in the reported collision
+
+async function withFrozenClock<T>(body: () => Promise<T>): Promise<T> {
+  const real = Date.now;
+  Date.now = () => FROZEN_MS;
+  try {
+    return await body();
+  } finally {
+    Date.now = real;
+  }
+}
+
+test("the witness scratch directory does not depend on the clock: frozen time still yields distinct real dirs", async () => {
   const made: string[] = [];
   try {
-    const stamps: number[] = [];
-    for (let i = 0; i < 24; i += 1) {
-      stamps.push(Date.now());
-      const result = await hostRunner("mkdtemp", ["foundry-witness-ravidsrk_orca-fleet-"]);
-      assert.equal(result.exit, 0, `mkdtemp refused: ${result.output}`);
-      made.push(result.output);
-    }
+    await withFrozenClock(async () => {
+      for (let i = 0; i < 8; i += 1) {
+        const result = await hostRunner("mkdtemp", ["foundry-witness-ravidsrk_orca-fleet-"]);
+        assert.equal(result.exit, 0, `mkdtemp refused: ${result.output}`);
+        made.push(result.output);
+      }
+    });
 
-    const sameMillisecond = stamps.some((t, i) => i > 0 && t === stamps[i - 1]);
-    assert.ok(
-      sameMillisecond,
-      `no two of the ${stamps.length} requests shared a millisecond, so this run did not exercise the collision (stamps: ${stamps.join(",")})`,
-    );
-
-    assert.equal(new Set(made).size, made.length, `two scratch directories collided: ${made.join(", ")}`);
+    // The stub is undone, or every later test in this file inherits a frozen clock.
+    assert.notEqual(Date.now(), FROZEN_MS, "withFrozenClock leaked its stub past the body");
+    assert.equal(new Set(made).size, made.length, `scratch directories collided under a frozen clock: ${made.join(", ")}`);
     for (const dir of made) {
-      // `mkdtempSync` CREATES the directory, which is what makes the uniqueness the OS's promise
-      // rather than ours. A path that does not exist would mean the name was merely composed.
+      // `mkdtempSync` CREATES the directory, which is what makes uniqueness the OS's promise rather
+      // than ours. A path that does not exist would mean the name was merely composed.
       assert.ok(statSync(dir).isDirectory(), `${dir} was named but not created`);
-      assert.ok(dir.startsWith(join(tmpdir(), "foundry-witness-")), `${dir} is not under the tmpdir prefix it asked for`);
+      assert.ok(dir.startsWith(join(tmpdir(), "foundry-witness-")), `${dir} is not under the prefix it asked for`);
+      assert.equal(dir.includes(String(FROZEN_MS)), false, `${dir} still carries the wall clock, so the name depends on time`);
     }
   } finally {
-    // Issue #64's convention: a test that creates temp dirs removes them. Twenty-four per run would
-    // otherwise be a new instance of the very leak that issue is about.
+    // Issue #64's convention: a test that creates temp dirs removes them.
     for (const dir of made) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/**
+ * The acceptance criterion in the issue's own words — "two witness runs for the same repo started
+ * in the same millisecond both succeed" — driven through `witnessEvidence` rather than through
+ * `hostRunner` alone, because the protocol is what the operator runs and the protocol is what used
+ * to fail. Raised in review of this branch: a unit test of the naming does not by itself show that
+ * the caller consumes it correctly.
+ *
+ * Hybrid runner on purpose: `mkdtemp` goes to the REAL `hostRunner`, so uniqueness is the OS's
+ * actual behaviour and not a stub's promise, while git and the test phases are faked so no network
+ * or repository is needed. This is the one assertion in the repo that needs both halves.
+ */
+test("two witness runs for the same repo under one frozen millisecond both succeed, in different dirs", async () => {
+  const dirs: string[] = [];
+  try {
+    const outcomes = await withFrozenClock(async () => {
+      const runOnce = async () => {
+        const runner = async (step: string, args: string[]) => {
+          if (step === "mkdtemp") {
+            const real = await hostRunner("mkdtemp", args);
+            if (real.exit === 0) dirs.push(real.output);
+            return real;
+          }
+          if (step === "run-tests@head") return { exit: 0, output: "ok" };
+          if (step === "run-tests@revert") return { exit: 1, output: "red" };
+          if (step === "git" && args.includes("--name-only")) return { exit: 0, output: "src/thing.ts\n" };
+          return { exit: 0, output: "" };
+        };
+        return witnessEvidence(
+          {
+            packetId: "pkt_ravidsrk_orca-fleet_71",
+            repoId: "ravidsrk/orca-fleet",
+            baseSha: "1".repeat(40),
+            headSha: "2".repeat(40),
+            testCommand: "npm test",
+            sandbox: "host",
+            wave: 0,
+          },
+          runner as never,
+          {},
+        );
+      };
+      return [await runOnce(), await runOnce()];
+    });
+
+    for (const [i, outcome] of outcomes.entries()) {
+      assert.equal(outcome.ok, true, `run ${i + 1} failed: ${outcome.ok ? "" : outcome.error}`);
+    }
+    assert.equal(dirs.length, 2, `expected two scratch dirs, got ${dirs.length}`);
+    assert.notEqual(dirs[0], dirs[1], `both witness runs used the same directory ${dirs[0]} — the #56 collision`);
+  } finally {
+    for (const dir of dirs) rmSync(dir, { recursive: true, force: true });
   }
 });
 

--- a/factory/witness.ts
+++ b/factory/witness.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
+import { mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { sanitizeTerminalText } from "./terminal.ts";
@@ -7,9 +8,17 @@ import type { EvidenceWitness, SandboxKind, Wave } from "./types.ts";
 
 /**
  * A witness step is one of: "git" (args passed to git), "run-setup" / "run-tests@head" /
- * "run-tests@revert" / "probe" (args[0] is a shell command line the runner executes), "cleanup"
+ * "run-tests@revert" / "probe" (args[0] is a shell command line the runner executes), "mkdtemp"
+ * (args[0] is a filename prefix; returns the created scratch dir as its `output`), "cleanup"
  * (args[0] is a scratch dir). The runner seam is what makes the protocol testable without a
  * network or a shell.
+ *
+ * "mkdtemp" is a step rather than a `mkdtempSync` call inside the protocol on purpose. Creating the
+ * directory is a filesystem effect, and every other filesystem effect here already crosses this
+ * seam — `cleanup` is `rm -rf` behind it. Calling `mkdtempSync` directly would make each of the
+ * protocol's stubbed tests create a real directory it has no way to remove, which is issue #64's
+ * defect, and would put an unfakeable effect inside the one function this seam exists to keep
+ * fakeable.
  */
 export type WitnessStep =
   | "git"
@@ -17,6 +26,7 @@ export type WitnessStep =
   | "run-tests@head"
   | "run-tests@revert"
   | "probe"
+  | "mkdtemp"
   | "cleanup";
 export type WitnessRunner = (
   step: WitnessStep,
@@ -53,19 +63,46 @@ export type WitnessRunner = (
  * A repo needing anything more than this declares it as `setupCommand` in `allowlist.yaml`, where
  * it is visible, rather than relying on a profile nobody reads.
  */
-export const hostRunner: WitnessRunner = (step, args, opts) =>
-  new Promise((resolveRun) => {
-    const [cmd, cmdArgs] =
-      step === "git"
-        ? ["git", args]
-        : step === "cleanup"
-          ? ["rm", ["-rf", ...args]]
-          : ["bash", ["-c", args[0] ?? "false"]]; // run-setup, probe and both run-tests phases execute the repo's own commands
-    execFile(cmd, cmdArgs, { cwd: opts?.cwd, maxBuffer: 16 * 1024 * 1024 }, (err, stdout, stderr) => {
-      const exit = err && typeof (err as { code?: unknown }).code === "number" ? ((err as { code: number }).code) : err ? 1 : 0;
-      resolveRun({ exit, output: `${stdout}${stderr}` });
-    });
+export const hostRunner: WitnessRunner = (step, args, opts) => {
+  /**
+   * Handled before the `execFile` shapes below because it is the one step with no command: the OS
+   * allocates the name, which is the entire point. `mkdtempSync` appends its own random suffix to
+   * the prefix and fails if the result already exists, so two witness runs starting in the same
+   * millisecond cannot collide — the defect in issue #56, where the directory was named from
+   * `Date.now()` alone and the suite went red once in seventeen runs.
+   *
+   * The prefix is refused if it contains a path separator. It is derived from `repoId`, which comes
+   * from `allowlist.yaml`, and a prefix carrying a `/` would place the scratch directory outside
+   * `tmpdir()` — the same class of path-resolution defect as issue #80, guarded here rather than
+   * trusted to the caller.
+   */
+  if (step === "mkdtemp") {
+    const prefix = args[0] ?? "foundry-witness-";
+    if (prefix.includes("/") || prefix.includes("\\") || prefix.includes("\0")) {
+      return Promise.resolve({ exit: 1, output: `refusing a scratch-directory prefix containing a path separator: ${prefix}` });
+    }
+    try {
+      return Promise.resolve({ exit: 0, output: mkdtempSync(join(tmpdir(), prefix)) });
+    } catch (err) {
+      const why = err instanceof Error ? err.message : String(err);
+      return Promise.resolve({ exit: 1, output: `cannot create a scratch directory: ${why}` });
+    }
+  }
+  const { promise, resolve: resolveRun } = Promise.withResolvers<{ exit: number; output: string }>();
+  const [cmd, cmdArgs] =
+    step === "git"
+      ? ["git", args]
+      : step === "cleanup"
+        ? ["rm", ["-rf", ...args]]
+        : ["bash", ["-c", args[0] ?? "false"]]; // run-setup, probe and both run-tests phases execute the repo's own commands
+  execFile(cmd, cmdArgs, { cwd: opts?.cwd, maxBuffer: 16 * 1024 * 1024 }, (err, stdout, stderr) => {
+    // `ExecException.code` is already typed `number | undefined`, so the shape needs narrowing, not
+    // an assertion: a signal-killed child reports `signal` with no numeric code and must read as 1.
+    const exit = !err ? 0 : typeof err.code === "number" ? err.code : 1;
+    resolveRun({ exit, output: `${stdout}${stderr}` });
   });
+  return promise;
+};
 
 /** The two run logs, returned so the caller can persist them at the paths the witness declares. */
 export interface WitnessLogs {
@@ -348,7 +385,25 @@ export async function witnessEvidence(
     };
   }
 
-  const dir = join(tmpdir(), `foundry-witness-${input.repoId.replace("/", "_")}-${Date.now()}`);
+  /**
+   * The OS allocates this name, not the wall clock. It used to be
+   * `foundry-witness-${repoId}-${Date.now()}`, which collides when two witness runs for the same
+   * repository start in the same millisecond — observed as a red suite once in seventeen runs
+   * (issue #56). The suite is fast and now drives real clones end to end, so two runs landing in
+   * the same millisecond is ordinary rather than exotic, and the failure landed on the one surface
+   * whose whole job is to be reproducible.
+   *
+   * `replaceAll` because `replace` with a string pattern substitutes only the FIRST match, so a
+   * repoId with two separators would have left one in the prefix and put the clone somewhere other
+   * than `tmpdir()`. The runner refuses such a prefix outright; both halves are needed, since the
+   * caller must not depend on the runner's guard to be correct.
+   */
+  const scratch = await runner("mkdtemp", [`foundry-witness-${input.repoId.replaceAll("/", "_")}-`]);
+  const dir = scratch.output.trim();
+  if (scratch.exit !== 0 || dir === "") {
+    // Fail closed. Cloning into an empty path would clone into the process's working directory.
+    return { ok: false, error: `cannot create a scratch directory for the witness: ${scratch.output.slice(0, 200) || "no path returned"}` };
+  }
   const url = `https://github.com/${input.repoId}.git`;
   // Every refusal below interpolates a step's raw output, and that output is REPOSITORY-CONTROLLED:
   // `allowlist.yaml` carries `setupCommand: npm ci`, run with `cwd` set to this clone, so the


### PR DESCRIPTION
Closes #56

## What

The witness clone directory is now allocated by the OS (`mkdtempSync`) instead of named from
`Date.now()`. The allocation crosses the existing `WitnessRunner` seam as a new `mkdtemp` step, so
the protocol stays fakeable.

## Why

`factory/witness.ts` named the clone `foundry-witness-${repoId}-${Date.now()}` — no pid, no
randomness. Two witness runs for the same repository starting in the same millisecond produced the
same path, and `git clone` refuses a destination that exists and is not empty. Observed as a red
suite **once in seventeen** full runs.

It lands on the one surface whose entire job is to be reproducible. A test that fails once in
seventeen for reasons unrelated to the code teaches the operator to re-run rather than read, and
that is the habit that lets a real red through.

`mkdtempSync` removes the collision class rather than narrowing it: it creates the directory as it
names it, and fails rather than returning a path that already exists. The repo-id stays as a prefix
for legibility while debugging, since `mkdtempSync` appends its own suffix.

## How verified

- **tests**: 316 across 15 files, `suite ok`; `npm run validate` exit 0. Worktree baseline before
  any edit was 313/15.
- **the collision, reproduced exactly** — the negative control (restore `Date.now()` naming, keep
  everything else) prints the literal path from the issue report, repeated:
  ```
  scratch directories collided under a frozen clock:
    …/foundry-witness-ravidsrk_orca-fleet-1787981801727,
    …/foundry-witness-ravidsrk_orca-fleet-1787981801727,  (×8)
  ```
  Both new tests red under it; both pass with the fix.
- **soak**: **25 consecutive full-suite runs, 0 failures** (the acceptance criterion), and
  `foundry-witness-*` in `$TMPDIR` at delta **0** across those 25 runs.
- **`Date.now()` no longer composes a filesystem path in `factory/`** — the four remaining uses are
  event ids and a day count, none of them paths.
- **manual**: confirmed `git clone` accepts an existing *empty* directory (exit 0) and refuses a
  non-empty one (exit 128) — the assumption the fix rests on, since `mkdtempSync` creates the
  directory before `clone` is handed it.
- **greptile**: 2 rounds, confidence 5/5, 2 findings fixed, 0 rebutted.

## Notes for review

**A masking bug this change surfaced, which is the most important thing in the diff.**

`no refusal the witness protocol can produce reaches the terminal with control bytes in it` loops
over nine stages, failing one at a time. While the new `mkdtemp` step answered with the stub's
fall-through `{ exit: 0, output: "" }`, the empty path made the witness fail closed on the scratch
directory **first** — so all nine stages asserted that one refusal and none of the nine they name.
Nine green assertions exercising one code path, suite reporting `ok`.

Two things were needed, and only the first is obvious:

1. The stub answers `mkdtemp`, and `mkdtemp` joins the stage list — the docblock already promised
   that "a refusal added at an eighth stage tomorrow is covered by the same loop", and the refusal
   added here is exactly that.
2. The loop now requires each refusal to carry **its own stage's** output. Without that, the
   masking is undetectable: I removed the stub's handler again afterwards to check, and the suite
   stayed green. It now reds with `stage mkdtemp refused before its own step ran, so this iteration
   proves nothing about it`.

**Two review findings, both fixed.**

1. *Collision test depends on timing* (P2). Correct, and the irony was the point — the first
   version sampled `Date.now()` around each call and required two samples to match, so a loaded
   worker reds the suite with the fix working. I had added an intermittent test to a change that
   exists to remove one. Now the clock is **frozen** to the timestamp from the report, which is both
   deterministic and a stronger claim: "two runs in the same millisecond" is really the claim that
   the name does not *depend* on time.
2. *Tests `hostRunner` rather than the protocol* (same finding's second half). Also correct — the
   acceptance is written about witness runs. Added a case that drives `witnessEvidence` twice under
   one frozen millisecond with a hybrid runner: real `hostRunner` for `mkdtemp` so uniqueness is the
   OS's actual behaviour rather than a stub's promise, fakes for git and the test phases so no
   network is needed.

**Design choice worth disagreeing with if you want to.** `mkdtemp` is a runner *step* rather than a
`mkdtempSync` call inside `witnessEvidence`. Creating a directory is a filesystem effect, and every
other filesystem effect in this protocol already crosses that seam (`cleanup` is `rm -rf` behind
it). Calling it directly would have made each of the protocol's stubbed tests create a real
directory it has no way to remove — a new instance of #64 — and put an unfakeable effect inside the
one function the seam exists to keep fakeable. The cost is that stubs must now answer one more step.

**Two guards, not one**, because the prefix is derived from `repoId` and therefore from
`allowlist.yaml`: the caller sanitises with `replaceAll` (string `replace` substitutes only the
*first* match, so a two-separator repoId would have left one in), and the runner refuses a prefix
containing a separator outright. A guard that exists only at the call site is one call site away
from not existing — #80, one layer down. The new refusal fails closed and deliberately does **not**
route through `fail()`, because `fail()` runs `rm -rf` on the directory and the path may be empty at
that point.

**Incidental, disclosed rather than smuggled**: `hostRunner` needed a block body for the early
return, so its `new Promise` became `Promise.withResolvers` and its inline `(err as { code?: unknown })`
cast became a narrowed `typeof err.code === "number"`. Same behaviour; the cast asserted a shape
where the check now proves one.

**Observed and not acted on**: `$TMPDIR` on this machine holds **576,921** `foundry-*` directories,
and the suite adds ~195 per run. Issue #64 reported 41,213, so the leak has grown roughly 14× — the
figure is worth carrying into that issue. Nothing here contributes: both new tests clean up, and the
`foundry-witness-*` delta over 25 runs is 0.

Also filed #88 while here: `factory/halt.ts:19` mints `evt_halt_${Date.now().toString(36)}` while
both siblings in `engine.ts` add `Math.random()`. Same constant in the same uniqueness role, one
type away from this issue's acceptance, so closing this one does not close that.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces wall-clock-derived witness clone paths with OS-allocated temporary directories, removing collisions between same-repository runs started in one millisecond.
- Adds a fakeable `mkdtemp` witness-runner step with prefix validation and closed-failure handling.
- Sanitizes repository identifiers used in temporary-directory prefixes.
- Extends protocol and host-runner tests to verify uniqueness, cleanup, path confinement, and stage-specific refusal coverage.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the new allocation step handled by all reachable runners and covered by deterministic protocol and filesystem tests.

The production runner creates unique scratch directories beneath the system temporary directory, rejects separator-bearing prefixes, and the witness protocol fails closed when allocation does not return a usable path; no actionable changed-code failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| factory/witness.ts | Adds OS-backed scratch-directory allocation through the runner seam and safely propagates the allocated path through existing clone and cleanup behavior. |
| factory/witness-host.test.ts | Adds deterministic real-filesystem coverage for frozen-clock uniqueness, complete witness runs, cleanup, and malicious-prefix refusal. |
| factory/engine.test.ts | Updates witness fakes for the new step and strengthens refusal tests so each iteration proves that its intended stage executed. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(witness): freeze the clock instead ..."](https://github.com/ravidsrk/oss-foundry/commit/96e9d42fd910aeb072fe1bef007fed254ad27bd2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58256299)</sub>

<!-- /greptile_comment -->