### PR TITLE
test: one home for scratch directories, and it cleans up after itself (#64)

### DIFF
--- a/factory/cli-entry.test.ts
+++ b/factory/cli-entry.test.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { symlinkSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { test } from "node:test";
 import { pathToFileURL } from "node:url";
+import { tmp } from "./tmp-dir.ts";
 
 /**
  * The entry-point guard on `factory/cli.ts`, driven as a process.
@@ -34,7 +34,7 @@ test("importing cli.ts does not run the CLI", () => {
   // exactly the shape `node --test factory/engine.test.ts` presents. If `main()` runs anyway it
   // reaches `usage()`, and the pre-guard code then called `process.exit(0)` from module scope:
   // the marker below would never print and the exit status would still be 0.
-  const dir = mkdtempSync(join(tmpdir(), "foundry-entry-"));
+  const dir = tmp("foundry-entry-");
   const importer = join(dir, "import-cli.mjs");
   writeFileSync(
     importer,
@@ -74,7 +74,7 @@ test("the entry point is recognised through a symlinked checkout", () => {
   // because Node resolves symlinks when it loads a module. Comparing them without canonicalising
   // argv[1] makes the CLI exit 0 having printed nothing whenever the checkout is reached through a
   // link — a silent success, which is worse than the crash the guard replaced.
-  const dir = mkdtempSync(join(tmpdir(), "foundry-symlink-"));
+  const dir = tmp("foundry-symlink-");
   const link = join(dir, "foundry-checkout");
   symlinkSync(REPO_ROOT, link, "dir");
 

--- a/factory/cli.test.ts
+++ b/factory/cli.test.ts
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { join, resolve } from "node:path";
 import { test } from "node:test";
+import { tmp } from "./tmp-dir.ts";
 import { ALLOWLIST } from "./allowlist.ts";
 import { assertDisjointCounts } from "./fixture-counts.ts";
 import { applySecondaryLimitHalt } from "./halt.ts";
@@ -55,7 +56,7 @@ function runCli(
 }
 
 function writeState(state: FactoryState): string {
-  const path = join(mkdtempSync(join(tmpdir(), "foundry-cli-")), "state.json");
+  const path = join(tmp("foundry-cli-"), "state.json");
   writeFileSync(path, JSON.stringify(state, null, 2));
   return path;
 }
@@ -96,7 +97,7 @@ function githubStub(
   mode: "record" | "secondary-limit",
   issues: Record<string, IssueFact> = {},
 ): { preload: string; log: string } {
-  const dir = mkdtempSync(join(tmpdir(), "foundry-stub-"));
+  const dir = tmp("foundry-stub-");
   const log = join(dir, "fetch.log");
   const preload = join(dir, "preload.mjs");
   const create =
@@ -236,7 +237,7 @@ function prFactsStub(
   // a clean one return the same commits and the same verdict — the clock has to tell them apart.
   commitReads: { fail?: string[]; truncate?: string[] } = {},
 ): string {
-  const preload = join(mkdtempSync(join(tmpdir(), "foundry-prfacts-")), "preload.mjs");
+  const preload = join(tmp("foundry-prfacts-"), "preload.mjs");
   writeFileSync(
     preload,
     `const facts = ${JSON.stringify(table)};
@@ -353,7 +354,7 @@ test("the state path is anchored to the repo root, not the cwd", () => {
   // A decoy exactly where the ledger used to be read from. Under the old cwd-relative path this
   // file WAS the state; the canary tick count is what proves it is not consulted now — a path
   // assertion alone would still pass if the CLI printed one path and read another.
-  const decoyDir = mkdtempSync(join(tmpdir(), "foundry-anchor-"));
+  const decoyDir = tmp("foundry-anchor-");
   writeFileSync(
     join(decoyDir, ".foundry-state.json"),
     JSON.stringify({ ...seedState(), ticksRun: 90210 }),
@@ -416,7 +417,7 @@ test("a test that spawns the CLI without --state cannot write the repo-root ledg
 });
 
 test("a seed-backed run says so instead of presenting the seed as live truth", () => {
-  const missing = join(mkdtempSync(join(tmpdir(), "foundry-cli-")), "absent.json");
+  const missing = join(tmp("foundry-cli-"), "absent.json");
   const seeded = runCli(["status", "--state", missing], tmpdir());
   assert.equal(seeded.code, 0);
   assert.match(seeded.out, /no state file/i);
@@ -936,7 +937,7 @@ test("attach-draft binds the same PR once its body carries the verbatim block", 
  * nothing would notice — which is the whole failure class `applyAttachDraft` now guards.
  */
 function createStub(): string {
-  const preload = join(mkdtempSync(join(tmpdir(), "foundry-create-")), "preload.mjs");
+  const preload = join(tmp("foundry-create-"), "preload.mjs");
   writeFileSync(
     preload,
     `let created = null;
@@ -992,7 +993,7 @@ test("open-draft records its own POST through the same disclosure gate", () => {
     JSON.stringify("PLACEHOLDER"),
     JSON.stringify(packet.evidence!.reviewedSha!),
   );
-  const preloadPath = join(mkdtempSync(join(tmpdir(), "foundry-create2-")), "preload.mjs");
+  const preloadPath = join(tmp("foundry-create2-"), "preload.mjs");
   writeFileSync(preloadPath, preload);
 
   const run = runCli(

--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -1,11 +1,12 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { after, test } from "node:test";
+import { tmp } from "./tmp-dir.ts";
 import { ALLOWLIST, CAPS, repoById } from "./allowlist.ts";
 import {
   applyAdvance,
@@ -1670,7 +1671,7 @@ test("a parked packet with a still-open PR never rots invisibly in the ledger ch
 test("the reject warning reaches the operator's terminal, not only the ledger", () => {
   // The reducer-level assertions above all passed while the CLI printed nothing but `rejected <id>`
   // — the exact silence issue #34 opens with. This drives the real binary and reads its streams.
-  const dir = mkdtempSync(join(tmpdir(), "foundry-cli-"));
+  const dir = tmp("foundry-cli-");
   // `--state` is what isolates this, not `cwd`. The ledger path is anchored to the repo root
   // (factory/cli.ts), so a bare spawn would read and rewrite the developer's real state file.
   const statePath = join(dir, ".foundry-state.json");
@@ -1741,7 +1742,7 @@ test("status does not claim a re-block that the held slot already prevented", ()
   // Driven at the reducer level, the reply-owed note was recorded and nothing surfaced it: `status`
   // printed "(maintainer activity re-blocks the tick)" for a packet whose maintainer activity had
   // just re-blocked nothing, and `reconcile` reported divergences=0. Drive the real binary.
-  const dir = mkdtempSync(join(tmpdir(), "foundry-cli-status-"));
+  const dir = tmp("foundry-cli-status-");
   // See the reject test above: `--state` is the isolation, since the default path is the repo root.
   const statePath = join(dir, ".foundry-state.json");
   const cli = join(import.meta.dirname, "cli.ts");
@@ -2379,7 +2380,7 @@ test("the committed evidence page regenerates byte-identical from this tree", ()
  * state by `cwd` alone, which meant every assertion below was silently made against the seed.
  */
 function runCliWithState(args: string[], state: FactoryState) {
-  const dir = mkdtempSync(join(tmpdir(), "foundry-cli-ledger-"));
+  const dir = tmp("foundry-cli-ledger-");
   writeFileSync(join(dir, ".foundry-state.json"), JSON.stringify(state));
   const run = runCli(dir, args);
   return { ...run, out: run.seen, dir };
@@ -2465,7 +2466,7 @@ test("status names the observation its quiet counter was extrapolated from", () 
  */
 test("the halt command, typed in GitHub's casing, actually halts", () => {
   const seed = seedState();
-  const dir = mkdtempSync(join(tmpdir(), "foundry-cli-halt-"));
+  const dir = tmp("foundry-cli-halt-");
   const statePath = join(dir, ".foundry-state.json");
   writeFileSync(statePath, JSON.stringify(seed));
   const cli = join(import.meta.dirname, "cli.ts");
@@ -2598,7 +2599,7 @@ test("a daytona witness loads, is refused at the gate on today's allowlist, and 
       revertLogPath: `docs/evidence/logs/${packet.id}/revert.log`,
     },
   };
-  const path = join(mkdtempSync(join(tmpdir(), "foundry-")), "daytona.json");
+  const path = join(tmp("foundry-"), "daytona.json");
   writeFileSync(path, JSON.stringify({ ...seed, packets: [packet, ...seed.packets.slice(1)] }));
   const loaded = loadFactoryState(path);
   assert.equal(loaded.ok, true);
@@ -2867,7 +2868,7 @@ test("a provenanced e2b witness carries a Wave-1 packet to draft-ready", () => {
 
 test("witness log hashes are recomputable from disk", async () => {
   const witnessModule = await import("./witness.ts");
-  const dir = mkdtempSync(join(tmpdir(), "foundry-logs-"));
+  const dir = tmp("foundry-logs-");
   const testLog = "42 passing\n";
   const revertLog = "3 failing\n";
   writeFileSync(join(dir, "test.log"), testLog);
@@ -3261,7 +3262,7 @@ function ingestFixture(
   logOverrides: Partial<{ test: string; revert: string }> = {},
   filesChanged = 1,
 ) {
-  const dir = mkdtempSync(join(tmpdir(), "foundry-ingest-"));
+  const dir = tmp("foundry-ingest-");
   const { state, id } = reviewingWave1();
   const packet = state.packets[0];
   writeFileSync(join(dir, ".foundry-state.json"), JSON.stringify(state));
@@ -3368,7 +3369,7 @@ test("attach-witness resolves witness logs against the log root, not the operato
   const { dir, id, manifestPath, stub } = ingestFixture();
   // Run from a directory that is neither the fixture nor the repository: the only thing that can
   // make the logs findable is the anchor.
-  const elsewhere = mkdtempSync(join(tmpdir(), "foundry-elsewhere-"));
+  const elsewhere = tmp("foundry-elsewhere-");
   const run = runCli(elsewhere, ["attach-witness", id, "--manifest", manifestPath, "--logs-root", dir], stub, {}, dir);
   assert.equal(run.status, 0, `a valid witness must ingest from any cwd:\n${run.seen}`);
   assert.ok(ledgerAt(dir).packets[0].evidence, "the witness must have reached the ledger");
@@ -3407,7 +3408,7 @@ test("a relative --manifest is the operator's path, resolved against their shell
   const { dir, id, manifestPath, stub } = ingestFixture();
   // The operator's shell: a third directory, holding the manifest under a name the log root does
   // not have. If the manifest call site ever anchors to the log root, this file is invisible.
-  const shell = mkdtempSync(join(tmpdir(), "foundry-shell-"));
+  const shell = tmp("foundry-shell-");
   writeFileSync(join(shell, "operator-witness.json"), readFileSync(manifestPath, "utf8"));
   assert.equal(existsSync(join(dir, "operator-witness.json")), false, "the log root must NOT hold this name");
 
@@ -3464,7 +3465,7 @@ test("the witness log root defaults to the repository root and the state file's 
   // `--help` is the surface, and it is the one an operator reads to find their run logs. Deliberately
   // no `--logs-root` and no `--state`: the DEFAULT is the half the bug was in and the half an
   // override hides.
-  const elsewhere = realpathSync(mkdtempSync(join(tmpdir(), "foundry-help-")));
+  const elsewhere = realpathSync(tmp("foundry-help-"));
   const help = spawnSync(
     process.execPath,
     ["--experimental-strip-types", join(import.meta.dirname, "cli.ts"), "--help"],
@@ -3497,7 +3498,7 @@ test("witnessed run logs are written where the schema says, and land verifiable"
   // the call left the suite green, and a digest whose logs were never written is not evidence.
   const { persistWitnessLogs } = await import("./cli.ts");
   const { witnessLogPaths } = await import("./witness.ts");
-  const root = mkdtempSync(join(tmpdir(), "foundry-persist-"));
+  const root = tmp("foundry-persist-");
   const { runner } = fakeRunner({
     "run-tests@head": { exit: 0, output: "42 passing" },
     "run-tests@revert": { exit: 1, output: "3 failing" },
@@ -3557,7 +3558,7 @@ test("witnessed run logs are written where the schema says, and land verifiable"
  * Both directions, in one test: the operator half on its own is satisfied by deleting the guard.
  */
 test("the repo-root log-write refusal is inert for an operator and fires for a test run", () => {
-  const dir = mkdtempSync(join(tmpdir(), "foundry-operator-logs-"));
+  const dir = tmp("foundry-operator-logs-");
   const script = join(dir, "persist.mjs");
   writeFileSync(
     script,
@@ -3619,23 +3620,13 @@ test("the repo-root log-write refusal is inert for an operator and fires for a t
 // is stubbed, exactly as the ingest tests do.
 
 /**
- * The `evidence` fixtures' temp trees, removed when the file's tests are done.
+ * The `evidence` fixtures' temp trees are registered by `tmp()` itself (factory/tmp-dir.ts).
  *
- * Each of these is a git repo or a work tree with a clone in it, not a stray file, and the two
- * tests added below create one apiece on every run. `mkdtempSync` with no counterpart is how a
- * developer's `$TMPDIR` acquires hundreds of them; the same omission in `witness-host.test.ts` had
- * left ~65 shim directories behind by the time this unit was reviewed. Registered rather than
- * removed per-test because `wave0Origin` is built once and shared by every fixture.
+ * This file used to carry its own `evidenceScratch` list plus an `after()` hook, and
+ * `terminal.test.ts` carried the same six lines again, while the other five test files had no
+ * cleanup at all. One home now — the rule `fixture-counts.ts` states about two copies of one rule
+ * applies to cleanup as much as to fixtures, and issue #64 is what the drift cost.
  */
-const evidenceScratch: string[] = [];
-function evidenceScratchDir(prefix: string): string {
-  const dir = mkdtempSync(join(tmpdir(), prefix));
-  evidenceScratch.push(dir);
-  return dir;
-}
-after(() => {
-  for (const dir of evidenceScratch) rmSync(dir, { recursive: true, force: true });
-});
 
 /**
  * The environment variable `LOGIN_SHELL_PROFILE` exports and `scripts/validate.py` refuses on.
@@ -3673,7 +3664,7 @@ function loginShellProfile(home: string): void {
 let originRepo: { path: string; base: string; head: string } | undefined;
 function wave0Origin(): { path: string; base: string; head: string } {
   if (originRepo) return originRepo;
-  const path = evidenceScratchDir("foundry-origin-");
+  const path = tmp("foundry-origin-");
   const git = (...args: string[]) => {
     const run = spawnSync(
       "git",
@@ -3764,7 +3755,7 @@ function recordingGit(dir: string): { binDir: string; record: string; calls: () 
  */
 function evidenceFixture(filesChanged = 2, message = "fix the answer\n\nFixes #71") {
   const origin = wave0Origin();
-  const dir = evidenceScratchDir("foundry-evidence-");
+  const dir = tmp("foundry-evidence-");
   const { state, id } = reviewing();
   assert.equal(state.packets[0].repoId, "ravidsrk/orca-fleet", "the evidence verb is host/Wave 0 only");
   writeFileSync(join(dir, ".foundry-state.json"), JSON.stringify(state));
@@ -3873,7 +3864,7 @@ test("the evidence verb writes its run logs under the log root, not beside the o
   // sit in whatever directory the operator was standing in. The recompute offer, which is the whole
   // proof, resolves to nothing.
   const { dir, id, logPaths, runEvidence } = evidenceFixture();
-  const elsewhere = evidenceScratchDir("foundry-evidence-cwd-");
+  const elsewhere = tmp("foundry-evidence-cwd-");
 
   const run = runEvidence(elsewhere);
   assert.equal(run.status, 0, run.seen);

--- a/factory/halt.test.ts
+++ b/factory/halt.test.ts
@@ -1,15 +1,15 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { test } from "node:test";
+import { tmp } from "./tmp-dir.ts";
 import { maySelectRepo } from "./engine.ts";
 import { applySecondaryLimitHalt, clearFactoryHalt, factoryHalt } from "./halt.ts";
 import { seedState } from "./seed.ts";
 import { loadFactoryState, saveFactoryState } from "./state.ts";
 
 function tmpStatePath() {
-  return join(mkdtempSync(join(tmpdir(), "foundry-halt-")), "state.json");
+  return join(tmp("foundry-halt-"), "state.json");
 }
 
 test("a secondary-rate-limit halt survives the process that printed the banner", () => {

--- a/factory/state.test.ts
+++ b/factory/state.test.ts
@@ -1,15 +1,15 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { test } from "node:test";
+import { tmp } from "./tmp-dir.ts";
 import { buildPacket } from "./packet.ts";
 import { applyReviewToScorecard, emptyScorecard, health, mergeRate } from "./scorecard.ts";
 import { seedState } from "./seed.ts";
 import { loadFactoryState, saveFactoryState } from "./state.ts";
 
 test("missing state file loads seed and does not invent a file", () => {
-  const path = join(mkdtempSync(join(tmpdir(), "foundry-")), "missing.json");
+  const path = join(tmp("foundry-"), "missing.json");
   const loaded = loadFactoryState(path);
   assert.equal(loaded.ok, true);
   if (!loaded.ok) return;
@@ -18,7 +18,7 @@ test("missing state file loads seed and does not invent a file", () => {
 });
 
 test("malformed state file is refused instead of falling back to seed", () => {
-  const path = join(mkdtempSync(join(tmpdir(), "foundry-")), "bad.json");
+  const path = join(tmp("foundry-"), "bad.json");
   writeFileSync(path, "{not json");
   const loaded = loadFactoryState(path);
   assert.equal(loaded.ok, false);
@@ -29,7 +29,7 @@ test("malformed state file is refused instead of falling back to seed", () => {
 });
 
 test("incompatible state object is refused", () => {
-  const path = join(mkdtempSync(join(tmpdir(), "foundry-")), "v5.json");
+  const path = join(tmp("foundry-"), "v5.json");
   writeFileSync(path, JSON.stringify({ version: 5, packets: [] }));
   const loaded = loadFactoryState(path);
   assert.equal(loaded.ok, false);
@@ -38,7 +38,7 @@ test("incompatible state object is refused", () => {
 });
 
 test("nested malformed packet is refused", () => {
-  const path = join(mkdtempSync(join(tmpdir(), "foundry-")), "nested.json");
+  const path = join(tmp("foundry-"), "nested.json");
   const seed = seedState();
   writeFileSync(
     path,
@@ -66,7 +66,7 @@ test("malformed nested packet fields are refused", () => {
     { ...base, sandboxSession: { status: "dry-run" } },
   ];
   for (const packet of cases) {
-    const path = join(mkdtempSync(join(tmpdir(), "foundry-")), "fields.json");
+    const path = join(tmp("foundry-"), "fields.json");
     writeFileSync(path, JSON.stringify({ ...seed, packets: [packet] }));
     const loaded = loadFactoryState(path);
     assert.equal(loaded.ok, false, JSON.stringify(packet).slice(0, 80));
@@ -97,7 +97,7 @@ test("a stored witness may carry a toolchain string, and nothing else in that sl
     packets: [{ ...base, evidence: { ...base.evidence, witness: { ...witness, ...extra } } }],
   });
   const write = (state: unknown): string => {
-    const path = join(mkdtempSync(join(tmpdir(), "foundry-")), "toolchain.json");
+    const path = join(tmp("foundry-"), "toolchain.json");
     writeFileSync(path, JSON.stringify(state));
     return path;
   };
@@ -139,7 +139,7 @@ test("v6 ledger missing later-required fields is migrated, not stranded", () => 
   const row = { ...(seed.scorecard[0] as Record<string, unknown>) };
   delete row.closedUnmerged;
   delete row.lastTouch;
-  const path = join(mkdtempSync(join(tmpdir(), "foundry-")), "old-v6.json");
+  const path = join(tmp("foundry-"), "old-v6.json");
   writeFileSync(
     path,
     JSON.stringify({
@@ -172,7 +172,7 @@ test("stored scorecard without noReview is migrated to 0, not stranded", () => {
     delete row.noReview;
     return row;
   });
-  const path = join(mkdtempSync(join(tmpdir(), "foundry-")), "no-noreview.json");
+  const path = join(tmp("foundry-"), "no-noreview.json");
   writeFileSync(path, JSON.stringify({ ...seed, scorecard }));
   const loaded = loadFactoryState(path);
   assert.equal(loaded.ok, true);
@@ -183,7 +183,7 @@ test("stored scorecard without noReview is migrated to 0, not stranded", () => {
 });
 
 test("valid state round-trips without becoming seed", () => {
-  const path = join(mkdtempSync(join(tmpdir(), "foundry-")), "ok.json");
+  const path = join(tmp("foundry-"), "ok.json");
   const seed = seedState();
   seed.ticksRun = 99;
   saveFactoryState(path, seed);
@@ -208,7 +208,7 @@ test("merge rate counts terminal outcomes; silence alone cannot trip the halt", 
 test("stored packet with dark-eligible lighting is refused", () => {
   const seed = seedState();
   const packet = { ...seed.packets[0], lighting: "dark-eligible" };
-  const path = join(mkdtempSync(join(tmpdir(), "foundry-")), "dark.json");
+  const path = join(tmp("foundry-"), "dark.json");
   writeFileSync(path, JSON.stringify({ ...seed, packets: [packet, ...seed.packets.slice(1)] }));
   const loaded = loadFactoryState(path);
   assert.equal(loaded.ok, false);
@@ -223,7 +223,7 @@ test("a hand-edited state file with more in-flight packets than the cap is refus
   const packets = seed.packets.map((p) =>
     p.id === secondInflightId ? { ...p, status: "gated" as const, station: "freeze" as const } : p,
   );
-  const path = join(mkdtempSync(join(tmpdir(), "foundry-")), "overcap.json");
+  const path = join(tmp("foundry-"), "overcap.json");
   writeFileSync(path, JSON.stringify({ ...seed, packets }));
   const loaded = loadFactoryState(path);
   assert.equal(loaded.ok, false);
@@ -235,7 +235,7 @@ test("a hand-edited state file with more in-flight packets than the cap is refus
 test("a state file at exactly the in-flight cap still loads", () => {
   const seed = seedState();
   assert.equal(seed.packets.filter((p) => p.status === "submitted").length, 1);
-  const path = join(mkdtempSync(join(tmpdir(), "foundry-")), "atcap.json");
+  const path = join(tmp("foundry-"), "atcap.json");
   writeFileSync(path, JSON.stringify(seed));
   const loaded = loadFactoryState(path);
   assert.equal(loaded.ok, true);
@@ -253,7 +253,7 @@ test("a stored policy document must be well-formed and internally consistent", (
   const base = seed.packets[0];
   const doc = { name: "CONTRIBUTING", chars: 10, excerpt: "0123456789", truncated: false };
   const write = (policyDocs: unknown): string => {
-    const path = join(mkdtempSync(join(tmpdir(), "foundry-")), "policydocs.json");
+    const path = join(tmp("foundry-"), "policydocs.json");
     writeFileSync(path, JSON.stringify({ ...seed, packets: [{ ...base, policyDocs }] }));
     return path;
   };
@@ -310,7 +310,7 @@ test("policy documents survive save and load unchanged", () => {
   assert.equal(built.policyDocs?.length, 2);
   assert.equal(built.policyDocs?.[1].truncated, true);
 
-  const path = join(mkdtempSync(join(tmpdir(), "foundry-")), "roundtrip.json");
+  const path = join(tmp("foundry-"), "roundtrip.json");
   saveFactoryState(path, { ...seed, packets: [built, ...seed.packets.filter((p) => p.status !== "submitted")] });
   const loaded = loadFactoryState(path);
   assert.equal(loaded.ok, true, "a freshly built packet must load back");
@@ -329,7 +329,7 @@ test("a ledger written before the review counters existed migrates to 0, never t
     delete row.humanReviewedPrs;
     return row;
   });
-  const path = join(mkdtempSync(join(tmpdir(), "foundry-")), "pre-39.json");
+  const path = join(tmp("foundry-"), "pre-39.json");
   writeFileSync(path, JSON.stringify({ ...seed, scorecard }));
   const loaded = loadFactoryState(path);
   assert.equal(loaded.ok, true, loaded.ok ? "" : loaded.error);
@@ -352,7 +352,7 @@ test("a scorecard row whose review counters are the wrong type is refused, not c
   for (const field of ["humanReviewedPrs", "humanReviewComments", "reviewCommentsAvg", "noReview", "reverts"]) {
     const seed = seedState();
     const scorecard = seed.scorecard.map((r, i) => (i === 0 ? ({ ...r, [field]: "2" } as unknown) : r));
-    const path = join(mkdtempSync(join(tmpdir(), "foundry-")), `bad-${field}.json`);
+    const path = join(tmp("foundry-"), `bad-${field}.json`);
     writeFileSync(path, JSON.stringify({ ...seed, scorecard }));
     assert.equal(
       loadFactoryState(path).ok,
@@ -361,7 +361,7 @@ test("a scorecard row whose review counters are the wrong type is refused, not c
     );
   }
   // The control: the same seed, untouched, still loads — so the refusals above are about the edit.
-  const clean = join(mkdtempSync(join(tmpdir(), "foundry-")), "clean.json");
+  const clean = join(tmp("foundry-"), "clean.json");
   writeFileSync(clean, JSON.stringify(seedState()));
   assert.equal(loadFactoryState(clean).ok, true);
 });
@@ -382,7 +382,7 @@ test("the review split and merge facts a sync records survive a round trip", () 
         }
       : p,
   );
-  const path = join(mkdtempSync(join(tmpdir(), "foundry-")), "prmeta.json");
+  const path = join(tmp("foundry-"), "prmeta.json");
   saveFactoryState(path, { ...seed, packets });
   const loaded = loadFactoryState(path);
   assert.equal(loaded.ok, true, loaded.ok ? "" : loaded.error);
@@ -396,7 +396,7 @@ test("the review split and merge facts a sync records survive a round trip", () 
   const broken = loaded.state.packets.map((p) =>
     p.prMeta ? { ...p, prMeta: { ...p.prMeta, humanReview: { reviews: "1", comments: 1 } } } : p,
   );
-  const badPath = join(mkdtempSync(join(tmpdir(), "foundry-")), "bad-prmeta.json");
+  const badPath = join(tmp("foundry-"), "bad-prmeta.json");
   writeFileSync(badPath, JSON.stringify({ ...loaded.state, packets: broken }));
   assert.equal(loadFactoryState(badPath).ok, false);
 
@@ -412,7 +412,7 @@ test("the review split and merge facts a sync records survive a round trip", () 
     const corrupt = loaded.state.packets.map((p) =>
       p.prMeta ? { ...p, prMeta: { ...p.prMeta, [field]: bad } } : p,
     );
-    const path = join(mkdtempSync(join(tmpdir(), "foundry-")), `bad-${field}.json`);
+    const path = join(tmp("foundry-"), `bad-${field}.json`);
     writeFileSync(path, JSON.stringify({ ...loaded.state, packets: corrupt }));
     assert.equal(
       loadFactoryState(path).ok,
@@ -426,7 +426,7 @@ test("the review split and merge facts a sync records survive a round trip", () 
       ? { ...p, prMeta: { ...p.prMeta, mergeCommitSha: undefined, mergedAt: undefined, baseRef: undefined } }
       : p,
   );
-  const absentPath = join(mkdtempSync(join(tmpdir(), "foundry-")), "absent-prmeta.json");
+  const absentPath = join(tmp("foundry-"), "absent-prmeta.json");
   writeFileSync(absentPath, JSON.stringify({ ...loaded.state, packets: absent }));
   assert.equal(loadFactoryState(absentPath).ok, true, "optional must still mean optional");
 });

--- a/factory/terminal.test.ts
+++ b/factory/terminal.test.ts
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { join, resolve } from "node:path";
-import { after, test } from "node:test";
+import { test } from "node:test";
+import { tmp } from "./tmp-dir.ts";
 import {
   installTerminalBoundary,
   sanitizeTerminalText,
@@ -49,18 +50,9 @@ const DEFANGED = "concealedrepaintedgreen";
 const DISCLOSED = /byte\(s\) of terminal control sequence removed/;
 
 /**
- * Every temp tree this file makes, removed when it is done. `mkdtempSync` with no counterpart is how
- * a developer's `$TMPDIR` acquires hundreds of them: the drives below build one per run, forever.
+ * Every temp tree this file makes is removed by `tmp()`'s own registry (factory/tmp-dir.ts), which
+ * replaced this file's hand-rolled copy of it and the identical one in `engine.test.ts`.
  */
-const temps: string[] = [];
-function scratch(prefix: string): string {
-  const dir = mkdtempSync(join(tmpdir(), prefix));
-  temps.push(dir);
-  return dir;
-}
-after(() => {
-  for (const dir of temps) rmSync(dir, { recursive: true, force: true });
-});
 
 function spawnNode(script: string, args: string[], opts: { preload?: string } = {}) {
   const nodeArgs = ["--experimental-strip-types"];
@@ -287,7 +279,7 @@ test("an escape split across two writes still loses its introducer", () => {
  * the run.
  */
 test("the default stream list is both halves of the terminal — stdout AND stderr", () => {
-  const dir = scratch("foundry-streams-");
+  const dir = tmp("foundry-streams-");
   const script = join(dir, "default-streams.mjs");
   writeFileSync(
     script,
@@ -345,7 +337,7 @@ test("the default stream list is both halves of the terminal — stdout AND stde
  * 500 is the shortest path from `verify-ledger.ts` to a printed line.
  */
 function boundaryProbe(): string {
-  const dir = scratch("foundry-probe-");
+  const dir = tmp("foundry-probe-");
   const preload = join(dir, "probe.mjs");
   writeFileSync(
     preload,

--- a/factory/tmp-dir.test.ts
+++ b/factory/tmp-dir.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { removeTmpDirs, tmp } from "./tmp-dir.ts";
+
+const FACTORY = fileURLToPath(new URL(".", import.meta.url));
+
+/**
+ * Issue #64: every `mkdtempSync` site in the suite leaked its directory. 41,213 `foundry-*`
+ * directories when the issue was filed; **576,921** on the same machine by the time it was fixed,
+ * with a full run adding 195.
+ *
+ * Measured rather than asserted, because the delta is the acceptance criterion and no test can
+ * observe its own process's exit handler: one full run under a clean `TMPDIR` leaves **0**
+ * `foundry-*` directories on this branch and **195** at `origin/main`. What the tests below can
+ * pin is the mechanism that produces that number, and the door staying the only door.
+ */
+
+test("tmp() creates a real directory and removeTmpDirs() takes it away again", () => {
+  const dir = tmp("foundry-tmpdir-selftest-");
+
+  assert.ok(dir.startsWith(join(tmpdir(), "foundry-tmpdir-selftest-")), `${dir} is not under the requested prefix`);
+  assert.ok(existsSync(dir), `${dir} was named but not created`);
+
+  // Contents too: `rmSync` is recursive, and a registry that only removed empty directories would
+  // leave every fixture in the suite behind — they all write files.
+  const file = join(dir, "fixture.json");
+  writeFileSync(file, "{}");
+  assert.equal(readFileSync(file, "utf8"), "{}");
+
+  removeTmpDirs();
+  assert.equal(existsSync(dir), false, `${dir} survived removeTmpDirs()`);
+
+  // Idempotent, which is what lets a per-test `finally` and this registry coexist: several tests in
+  // the suite still remove their own directory, and the exit handler must not throw over it.
+  removeTmpDirs();
+});
+
+test("tmp() refuses a prefix that is a path rather than a filename fragment", () => {
+  // These are removed RECURSIVELY at exit, so a prefix that escapes `$TMPDIR` would point a
+  // recursive delete somewhere it must never point. Refused, not sanitised — silently rewriting a
+  // caller's path is how the rewritten one gets deleted.
+  for (const bad of ["../escape-", "foundry/nested-", "a\\b-"]) {
+    assert.throws(() => tmp(bad), /filename fragment/, `tmp(${JSON.stringify(bad)}) was accepted`);
+  }
+});
+
+/**
+ * `tmp()` is the only door, enforced over the whole directory rather than a list of files.
+ *
+ * The leak was never one file's oversight — it was a house-wide convention, with two files having
+ * hand-rolled the same registry and five having none. So the guard is stated the way
+ * `run-tests.ts:8` argues for: discovered, not listed. An eighth test file that reaches for
+ * `mkdtempSync` directly reds this the day it is written, which is the only version of this fix that
+ * survives the next contributor.
+ */
+test("no test file calls mkdtempSync directly — tmp() is the only door", () => {
+  const offenders: string[] = [];
+  let scanned = 0;
+  for (const name of readdirSync(FACTORY)) {
+    if (!name.endsWith(".test.ts")) continue;
+    scanned += 1;
+    const source = readFileSync(join(FACTORY, name), "utf8")
+      // Comments discuss `mkdtempSync` by name in several files, including this one.
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/^\s*\/\/.*$/gm, "");
+    if (/\bmkdtempSync\s*\(/.test(source)) offenders.push(name);
+  }
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `these test files create temp directories outside the registry, so they leak: ${offenders.join(", ")}. Use \`tmp("foundry-…-")\` from factory/tmp-dir.ts.`,
+  );
+  // Not vacuous: a rename that made the scan match nothing would otherwise pass.
+  assert.ok(scanned >= 10, `only ${scanned} test files were scanned; the discovery has drifted`);
+});

--- a/factory/tmp-dir.test.ts
+++ b/factory/tmp-dir.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -49,19 +50,32 @@ test("tmp() refuses a prefix that is a path rather than a filename fragment", ()
 });
 
 /**
- * `tmp()` is the only door, enforced over the whole directory rather than a list of files.
+ * `tmp()` is the only door, enforced over every file in the directory rather than a list of files.
  *
  * The leak was never one file's oversight — it was a house-wide convention, with two files having
  * hand-rolled the same registry and five having none. So the guard is stated the way
- * `run-tests.ts:8` argues for: discovered, not listed. An eighth test file that reaches for
- * `mkdtempSync` directly reds this the day it is written, which is the only version of this fix that
- * survives the next contributor.
+ * `run-tests.ts:8` argues for: discovered, not listed.
+ *
+ * SCANNED OVER `*.ts` AND NOT ONLY `*.test.ts`, raised in review of this branch. Test-reachable
+ * support code is not a `.test.ts` — `fixture-counts.ts` is the precedent, and it exists precisely
+ * because shared test support needs a file the runner does not collect. A helper module that reached
+ * for `mkdtempSync` would have leaked on every test that imported it while a `.test.ts`-only scan
+ * stayed green, which is the same one-consumer-fixed-sibling-bare shape as issue #80.
  */
-test("no test file calls mkdtempSync directly — tmp() is the only door", () => {
+const EXEMPT: Record<string, string> = {
+  "tmp-dir.ts": "is the one home; this is the implementation the rule is about",
+  "witness.ts":
+    "production, not test support: `hostRunner`'s scratch dir holds a real clone that must outlive " +
+    "no process-exit registry, and its lifecycle is the protocol's own `cleanup` step. Issue #56 " +
+    "made it `mkdtempSync` deliberately, and a test module is not importable from production.",
+};
+
+test("nothing but tmp() calls mkdtempSync — the door is the only door", () => {
   const offenders: string[] = [];
   let scanned = 0;
   for (const name of readdirSync(FACTORY)) {
-    if (!name.endsWith(".test.ts")) continue;
+    if (!name.endsWith(".ts")) continue;
+    if (Object.hasOwn(EXEMPT, name)) continue;
     scanned += 1;
     const source = readFileSync(join(FACTORY, name), "utf8")
       // Comments discuss `mkdtempSync` by name in several files, including this one.
@@ -73,8 +87,46 @@ test("no test file calls mkdtempSync directly — tmp() is the only door", () =>
   assert.deepEqual(
     offenders,
     [],
-    `these test files create temp directories outside the registry, so they leak: ${offenders.join(", ")}. Use \`tmp("foundry-…-")\` from factory/tmp-dir.ts.`,
+    `these files create temp directories outside the registry, so they leak: ${offenders.join(", ")}. Use \`tmp("foundry-…-")\` from factory/tmp-dir.ts, or add an entry to EXEMPT above with the reason it is not test scratch.`,
   );
-  // Not vacuous: a rename that made the scan match nothing would otherwise pass.
-  assert.ok(scanned >= 10, `only ${scanned} test files were scanned; the discovery has drifted`);
+  // Not vacuous: a rename that made the scan match nothing would otherwise pass. The directory
+  // holds well over thirty `.ts` files, so this floor only trips if discovery itself broke.
+  assert.ok(scanned >= 25, `only ${scanned} files were scanned; the discovery has drifted`);
+});
+
+/**
+ * The exit listener itself, driven in a child process — not `removeTmpDirs()` called by hand.
+ *
+ * Raised in review of this branch, and it is the sharper half of the fix. Every migrated test file
+ * relies on `process.on("exit", …)` firing; the tests above call the cleanup directly, so deleting
+ * the registration would leave all 46 sites leaking again with the suite green. That is the exact
+ * shape #83 was three rounds long over: "the boundary's mechanism was thoroughly tested and its
+ * shipped configuration was not."
+ *
+ * So a child process asks for a directory, prints it, and exits normally. The parent then asserts
+ * the path is gone. Nothing about that can be satisfied by a comment, and it fails if the listener
+ * is removed, registered too late, or registered on the wrong event.
+ */
+test("the exit handler removes the directory without anyone calling cleanup", () => {
+  const script = [
+    `import { tmp } from ${JSON.stringify(join(FACTORY, "tmp-dir.ts"))};`,
+    `process.stdout.write(tmp("foundry-exit-drive-"));`,
+  ].join("\n");
+  const entry = join(tmp("foundry-exit-parent-"), "drive.ts");
+  writeFileSync(entry, script);
+
+  const child = spawnSync(process.execPath, ["--experimental-strip-types", entry], { encoding: "utf8" });
+  assert.equal(child.status, 0, `child failed: ${child.stderr}`);
+
+  const childDir = child.stdout.trim();
+  assert.ok(
+    childDir.startsWith(join(tmpdir(), "foundry-exit-drive-")),
+    `child did not report a scratch directory: ${JSON.stringify(child.stdout)}`,
+  );
+  // The child created it and never removed it itself. If it is gone, the exit handler ran.
+  assert.equal(
+    existsSync(childDir),
+    false,
+    `${childDir} outlived the process that made it — the exit handler did not run, so every migrated call site leaks`,
+  );
 });

--- a/factory/tmp-dir.ts
+++ b/factory/tmp-dir.ts
@@ -1,0 +1,69 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * One home for scratch directories in the test suite, and the only place `mkdtempSync` is called.
+ *
+ * WHAT IT COST TO NOT HAVE THIS. Every `mkdtempSync` site in the suite leaked its directory. Issue
+ * #64 measured 41,213 `foundry-*` directories in one `$TMPDIR`; by the time it was fixed the same
+ * machine held **576,921**, and a full run added about 195 more. That is past a tidiness complaint:
+ * it is enough to slow directory enumeration in `$TMPDIR` for everything else on the machine, and
+ * the per-run cost is growing rather than static, because the suite now drives real clones and real
+ * test commands end to end.
+ *
+ * WHY A MODULE AND NOT A HELPER PER FILE. It was already two — `evidenceScratchDir` in
+ * `engine.test.ts` and `scratch` in `terminal.test.ts`, the same six lines written twice, with the
+ * other five test files having no cleanup at all. `fixture-counts.ts` states the rule this follows:
+ * "Two copies of one rule is the defect this repository keeps shipping: the rule drifts on one side,
+ * the other side keeps passing, and nothing says so because each copy looks correct read on its own."
+ *
+ * WHY `process.on("exit")` AND NOT AN `after()` HOOK IN EACH FILE. An `after()` per file is a
+ * hand-maintained roster of seven files that have to remember, and `run-tests.ts:8` names that shape
+ * as "the same silent hole this runner exists to close from the other end": the eighth test file
+ * would leak, silently, and nothing would say so. Registering inside this module means a call site
+ * cannot forget, because using `tmp()` at all is what installs the cleanup. `rmSync` is synchronous,
+ * which is what makes it legal in an exit handler.
+ *
+ * Deliberately NOT a `.test.ts`: `run-tests.ts` collects every `*.test.ts` in this directory, and
+ * a shared helper that registered itself as a test file would be counted as one.
+ */
+
+/** Every directory handed out this process, newest last. */
+const created: string[] = [];
+let installed = false;
+
+/**
+ * `mkdtempSync(join(tmpdir(), prefix))`, registered for removal when the process exits.
+ *
+ * The prefix is a filename fragment, not a path: a separator in it would place the directory
+ * somewhere other than `$TMPDIR`, and — since these are removed recursively — somewhere other than
+ * `$TMPDIR` is precisely where a recursive remove must never be pointed. Refused rather than
+ * sanitised, because silently rewriting a caller's path is how you end up deleting the rewritten one.
+ */
+export function tmp(prefix: string): string {
+  if (prefix.includes("/") || prefix.includes("\\") || prefix.includes("\0")) {
+    throw new Error(`tmp() prefix must be a filename fragment, not a path: ${JSON.stringify(prefix)}`);
+  }
+  if (!installed) {
+    installed = true;
+    process.on("exit", removeTmpDirs);
+  }
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  created.push(dir);
+  return dir;
+}
+
+/**
+ * Remove every directory `tmp()` handed out, and forget them.
+ *
+ * Exported for the test that proves this module works — the cleanup has to be callable from an
+ * assertion, not only from an exit handler nothing can observe. Idempotent: `rmSync` with
+ * `force: true` is a no-op on a directory a test already removed itself, which is what lets a
+ * per-test `finally` and this registry coexist without either having to know about the other.
+ */
+export function removeTmpDirs(): void {
+  for (const dir of created.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}

--- a/factory/witness-host.test.ts
+++ b/factory/witness-host.test.ts
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict";
-import { chmodSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
+import { tmp } from "./tmp-dir.ts";
 import { hostRunner, resolveToolchain, witnessEvidence } from "./witness.ts";
 
 /**
@@ -18,7 +19,7 @@ import { hostRunner, resolveToolchain, witnessEvidence } from "./witness.ts";
 
 /** A directory on PATH holding one executable that shadows a system tool of the same name. */
 function shimDir(name: string): { dir: string; path: string } {
-  const dir = mkdtempSync(join(tmpdir(), "foundry-path-"));
+  const dir = tmp("foundry-path-");
   const path = join(dir, name);
   writeFileSync(path, `#!/bin/sh\necho SHIMMED\n`);
   chmodSync(path, 0o755);


### PR DESCRIPTION
Closes #64

## What

One home for test scratch directories — `factory/tmp-dir.ts` — and it removes them itself. 46 call
sites across seven test files now go through `tmp()`, which is the only place `mkdtempSync` is
called.

## Why

Every `mkdtempSync` site in the suite leaked. The issue measured 41,213 `foundry-*` directories in
one `$TMPDIR`; the same machine held **576,921** by the time this was written, and one full run adds
**195**.

That is past a tidiness complaint. It is enough to slow directory enumeration in `$TMPDIR` for
everything else on the machine, and the per-run cost grows rather than holding steady, because the
suite now drives real clones and real test commands end to end.

## How verified

- **the acceptance criterion, measured both ways** — one full run under a clean `TMPDIR`:

  | tree | `foundry-*` left behind after one full run |
  |---|---|
  | `origin/main` | **195** |
  | this branch | **0** |

  (The only entry left in the clean `TMPDIR` at all is Node's own `node-compile-cache`.)
- **tests**: 320 across 16 files, `suite ok`; `npm run validate` exit 0. Worktree baseline before
  any edit was 316/15.
- **red by revert**, each applied alone with the baseline re-verified green afterwards:

  | mutation | test that reds |
  |---|---|
  | delete `process.on("exit", removeTmpDirs)` | `the exit handler removes the directory without anyone calling cleanup` |
  | register the handler on `SIGUSR2` instead | same |
  | `tmp()` stops pushing to the registry | `tmp() creates a real directory and removeTmpDirs() takes it away again` |
  | remove the prefix guard | `tmp() refuses a prefix that is a path rather than a filename fragment` |
  | a test file calls `mkdtempSync` directly | `nothing but tmp() calls mkdtempSync — the door is the only door` |
  | a **support** module (non-`.test.ts`) calls `mkdtempSync` | same |

## Notes for review

**Two copies of the fix already existed, so this retires them rather than adding a third.**
`engine.test.ts` had `evidenceScratchDir` + an `after()` hook and `terminal.test.ts` had `scratch` +
an `after()` hook — the same six lines written twice — while the other five test files had no cleanup
at all. `fixture-counts.ts` states the rule this follows: "Two copies of one rule is the defect this
repository keeps shipping: the rule drifts on one side, the other side keeps passing, and nothing
says so because each copy looks correct read on its own."

**Why `process.on("exit")` and not an `after()` hook per file.** An `after()` per file is a
hand-maintained roster of seven files that have to remember, and `run-tests.ts:8` names that shape
as "the same silent hole this runner exists to close from the other end" — the eighth test file
would leak, silently. Using `tmp()` at all is what installs the cleanup, so a call site cannot
forget. `rmSync` is synchronous, which is what makes it legal in an exit handler. The tradeoff is
real and worth naming: a hard kill (`SIGKILL`) still leaks, where an `after()` hook would also have.

**The prefix is refused, not sanitised.** These directories are removed *recursively*, so a prefix
containing a separator would point a recursive delete somewhere other than `$TMPDIR` — and silently
rewriting a caller's path is how the rewritten one gets deleted.

**Two review findings, both fixed.**

1. *Exit cleanup remains untested* (P2). Correct, and the sharper half of the change — the tests
   called `removeTmpDirs()` by hand, so deleting the registration would have put all 46 sites back
   to leaking with the suite green. That is exactly what #83 spent three rounds on: the mechanism
   tested, the shipped configuration not. There is now a child-process drive: the child asks for a
   directory, prints it, exits without cleaning up, and the parent asserts the path is gone.
2. *Guard omits support modules* (P2). The kernel is right and the example is not, so both halves
   are recorded. Right: test-reachable support code is not a `.test.ts` (`fixture-counts.ts` is the
   precedent), so a helper module reaching for `mkdtempSync` would leak on every test importing it
   while a `.test.ts`-only scan stayed green. The guard now covers every `.ts` in the directory.
   Not right: the finding named `factory/witness.ts` as an offender. That is **production** code —
   `hostRunner`'s scratch dir holds a real clone whose lifecycle is the protocol's own `cleanup`
   step, it must not depend on a process-exit registry, and production cannot import a test module.
   It is `EXEMPT` with that reason written down rather than silently out of scope, following the
   `EXEMPT`-with-a-reason convention `terminal.test.ts` already uses.

**Not done, deliberately, and it needs one command from you.** The issue's second proposal bullet is
to sweep the directories that have already accumulated. This PR stops the bleeding — it does not
delete the existing 576,921, because that is an irreversible bulk delete on your machine rather than
a change to this repository, and it is not what the acceptance criterion asks for. When you want it:

```
find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'foundry-*' -type d -print0 | xargs -0 rm -rf
```

Expect it to take a while at that count. Nothing in the suite depends on those directories.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR centralizes test scratch-directory creation and removes registered directories when each test process exits.
- Replaces direct `mkdtempSync` calls across seven test files with the shared `tmp()` helper.
- Adds filename-fragment validation, idempotent recursive cleanup, and normal-exit registration.
- Adds tests for cleanup behavior, prefix rejection, exit-handler wiring, and enforcement of the centralized helper.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The shared helper preserves the migrated tests’ required directory lifetimes, constrains deletion targets to newly created temporary directories, and cleans each process’s registry on normal exit.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| factory/tmp-dir.ts | Introduces the shared scratch-directory registry, guarded creation helper, and synchronous exit cleanup without an identified actionable defect. |
| factory/tmp-dir.test.ts | Verifies helper behavior, normal-exit cleanup, prefix safety, and repository-wide enforcement of centralized temporary-directory creation. |
| factory/engine.test.ts | Migrates test scratch directories to the shared helper while preserving existing test-scoped and process-scoped lifetimes. |
| factory/terminal.test.ts | Replaces the duplicated local scratch registry with the centralized helper and retains explicit cleanup where needed. |
| factory/witness-host.test.ts | Migrates executable-shim and witness scratch directories while retaining idempotent per-test cleanup. |
| factory/cli.test.ts | Routes CLI state, preload, and fixture directories through the shared cleanup registry. |
| factory/cli-entry.test.ts | Migrates importer and symlink fixture directories to centralized cleanup. |
| factory/halt.test.ts | Migrates temporary halt-state fixtures to centralized cleanup. |
| factory/state.test.ts | Migrates temporary state fixtures to centralized cleanup. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(tmp-dir): drive the exit handler, a..."](https://github.com/ravidsrk/oss-foundry/commit/f3c04044745c9be00338d2364f7c475003217934) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58258354)</sub>

<!-- /greptile_comment -->