### PR TITLE
fix(policy): decide a signature per instrument, by polarity, not by accident (#52)

### DIFF
--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -42,6 +42,26 @@ test("an anaphoric requirement lands on the instrument last named, not on every 
   // Both families named BEFORE the anaphor, so "most recently named" and "first named" differ and
   // only the nearest one is right. Without this the rule passes while attributing to whichever
   // instrument happens to appear first.
+  // Both families in ONE clause, so "nearest" cannot be read off the clause order - it is the token
+  // position inside the clause, and the roster order is irrelevant. A P1 from review: the evidence
+  // named whichever instrument the roster lists first.
+  const together = scanPolicyText("No CLA or DCO is required, but is required for code.");
+  assert.deepEqual(
+    together.signatureRequired.map((q) => q.split(":")[0]),
+    ["DCO"],
+    "the DCO's token sits nearest the elided subject",
+  );
+
+  // A family named TWICE in the clause: "nearest" is its last mention, not its first, and reading the
+  // first makes the other instrument look closer. Stilted, and deliberately so - the scanner reads a
+  // stranger's document and the rule has to be the rule.
+  const twice = scanPolicyText("A CLA is not required and no DCO is needed and no CLA is expected, but is required for code.");
+  assert.deepEqual(
+    twice.signatureRequired.map((q) => q.split(":")[0]),
+    ["CLA"],
+    "the CLA's LAST mention is nearest the elided subject",
+  );
+
   const nearest = scanPolicyText("No DCO is needed, no CLA is required for docs, but is required for code.");
   assert.deepEqual(
     nearest.signatureRequired.map((q) => q.split(":")[0]),
@@ -515,6 +535,14 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   // rows fails without one of them. Short-with-a-verb is a statement; long-without-one is too.
   { doc: "No CLA is required for docs, and tests apply, except for code.", want: "waived", why: "3 words but a verb: a statement, so the waiver's span ends" },
   { doc: "No CLA is required for docs, and all other repositories in this organisation, except forks.", want: "waived", why: "verbless but long: also a statement" },
+  // Punctuation is NOT part of the test. Requiring a comma before the conjunction let an unrelated
+  // exception scope the waiver whenever the author omitted one - a fail-closed P1 from review.
+  { doc: "No CLA is required for docs and all patches are welcome except spam.", want: "waived", why: "no comma, still two statements" },
+  { doc: "No DCO is needed for docs and we review everything except vendored trees.", want: "waived", why: "same, other family" },
+  // ...and a statement about THIS instrument does not end the span either, because a limiter past a
+  // second waiver of the same thing still means it is required somewhere. That case is already above
+  // ("limiter scopes the second waiver in ONE clause"); it is the line between these two groups, and
+  // all of them fail if it is drawn anywhere else.
   { doc: "A CLA is not required; except for new dependencies.", want: "required", why: "limiter behind a semicolon" },
   { doc: "Except for new dependencies, a CLA is not required.", want: "required", why: "leading limiter, waiver is the main clause" },
   // ...and it must NOT reach a waiver it has nothing to do with. Reading it from the whole sentence

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -556,6 +556,21 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   // ...and the noun-modifier reading is a NEW statement, not a continuation, in both spellings.
   { doc: "No CLA is required.\nRequired reading is the style guide.", want: "waived", why: "'Required reading' modifies a noun" },
   { doc: "No CLA is required.\nExpected turnaround is one week.", want: "waived", why: "'Expected turnaround' modifies a noun" },
+  // The word between predicate and scope is a CLOSED set of adverbs. It was any word once, so
+  // "It is required reading for new contributors." read as a requirement and held a repository that
+  // waives the CLA outright - a fail-closed P1 from review. `reading` is a noun the predicate
+  // modifies, not an adverb qualifying it, and only the copula branch was missing the guard.
+  { doc: "No CLA is required. It is required reading for new contributors.", want: "waived", why: "copula + noun modifier asserts nothing" },
+  { doc: "No CLA is required. It is required knowledge for reviewers.", want: "waived", why: "same shape, other noun" },
+  { doc: "No DCO is needed.\n- It is expected practice in this organisation.", want: "waived", why: "same, behind a bullet" },
+  // ...and the real copula requirement, which shares every word except the noun, must still hold.
+  { doc: "No CLA is required. It is required for code.", want: "required", why: "copula requirement, scope follows directly" },
+  { doc: "No CLA is required. It is needed only for release.", want: "required", why: "closed-set qualifier between predicate and scope" },
+  // Same shapes with the anaphor in the SAME sentence as its antecedent, which is the only place the
+  // clause-level matcher can reach: across a sentence boundary the fragment has no antecedent to
+  // attach to, so a row split by a full stop leaves that matcher untested.
+  { doc: "No CLA is required, it is required reading for new contributors.", want: "waived", why: "same-sentence copula + noun modifier" },
+  { doc: "No CLA is required, it is required for code.", want: "required", why: "same-sentence copula requirement" },
   // The SAME waiver stated twice, scoped only on the later copy. Position came from asking the
   // sentence where the match was, which answers with the first copy, so the later waiver's forward
   // span was cut at the intervening conjunction and its limiter never seen — ALLOW. Third P1.

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -529,6 +529,19 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   { doc: "A CLA is not required for docs or required for tests.", want: "required", why: "'or' coordinates it too" },
   { doc: "No CLA is required for docs and tests.", want: "waived", why: "'and tests.' is a noun, not a predicate" },
   { doc: "No CLA is required and reviews are quick.", want: "waived", why: "coordination with its own subject" },
+  // A comma splits the clause and leaves the requirement behind "and", which no clause-initial
+  // matcher accepted; and with no comma the copula sits between conjunction and predicate, which the
+  // adjacency rule rejected. Both were fail-open, both P1s, both the same class. Only an elided
+  // subject's own copula may stand in that gap.
+  { doc: "A CLA is not required for documentation, and is required for code contributions.", want: "required", why: "comma, then 'and is required'" },
+  { doc: "No CLA is required for docs and is required for code.", want: "required", why: "no comma, copula after the conjunction" },
+  { doc: "No CLA is required for docs and it is required for code.", want: "required", why: "explicit pronoun subject" },
+  { doc: "No CLA is required, or is required for vendored trees.", want: "required", why: "'or' coordinates it too" },
+  // The fail-CLOSED half of the same shape: with NO punctuation the participle modifies the noun -
+  // "the docs required for code" - so the sentence asserts nothing about the instrument and a rule
+  // that flipped it would hold repositories that waive outright.
+  { doc: "No CLA is required for docs required for code.", want: "waived", why: "no separator: participle modifies 'docs'" },
+  { doc: "No CLA is required for the docs required by the style guide.", want: "waived", why: "same, unmistakably a noun modifier" },
 
   // --- Plain requirements, in the phrasings a real CONTRIBUTING.md uses. ---
   { doc: "Pull requests without a signed Contributor License Agreement will be closed.", want: "required", why: "#50: the phrasing most likely to appear for real" },

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -530,12 +530,19 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   { doc: "No CLA is simply optional.", want: "required", why: "same, adjectival hatch" },
   { doc: "No DCO is under any circumstances waived.", want: "required", why: "three words in the slot" },
   { doc: "No DCO is under any and all circumstances waived.", want: "required", why: "five words: the slot is unbounded, because any cap invites the next one" },
+  // ...but the slot stops at a requirement word. Unbounding it let this reach `optional` across "is
+  // required for" and reverse a plain waiver - a fail-closed P1 caused by the fix before it.
+  { doc: "No CLA is required for optional contributions.", want: "waived", why: "past a predicate this is no longer a 'no X is <permission>' construction" },
   { doc: "No CLA is needed.", want: "waived", why: "the slot cannot over-match: `needed` sits where a hatch word would and is not one" },
   // REBUTTED, and pinned so it cannot be reported a third time: review reported that two spaces
   // between a waiver and a same-family requirement let the absorption window eat the requirement.
   // It does not - the window is one space, so a second space stops it, and this already resolved
   // REQUIRED on the code as reviewed.
   { doc: "No DCO is required  DCO is required for code.", want: "required", why: "two spaces: the one-space window cannot cross them" },
+  { doc: "No DCO is required DCO is required for code.", want: "required", why: "one space, and the span ends with a predicate, so nothing is absorbed" },
+  // The other side of that is already above: "We don't require a DCO sign-off on contributions." still
+  // waives, because there the span ENDS with an instrument and the next token continues its noun
+  // phrase rather than starting a statement.
 
   // --- One verb waives only the instrument it actually reaches. ---
   //

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -496,6 +496,17 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   // because the optional s still needs a word boundary after it.
   { doc: "Add a class for the parser and document the class hierarchy.", want: "silent", why: "'class' is not a plural CLA" },
 
+  // MIXED POLARITY IN ONE CLAUSE. A second P1 from review: polarity was decided once per clause from
+  // the FIRST match, so a waiver joined to a same-family requirement by "and" — not a delimiter, and
+  // it should not have to be — hid the requirement and reached ALLOW. A waiver now governs only the
+  // occurrence it names; any surviving mention is ungoverned and reads as required.
+  { doc: "No CLA is required for documentation and a CLA is required for code contributions.", want: "required", why: "same family, both polarities, joined by 'and'" },
+  { doc: "No DCO is needed for docs and a DCO is needed for code.", want: "required", why: "same shape, DCO family" },
+  { doc: "No CLA is required, and a CLA is required for vendored code.", want: "required", why: "comma and 'and' together" },
+  // ...and the governance rule must not turn one instrument named twice into a requirement:
+  // "a DCO sign-off" is a single thing and both words are DCO-family tokens.
+  { doc: "No CLA and no DCO.", want: "waived", why: "two instruments, both waived, joined by 'and'" },
+
   // --- No signature instrument at all. These must be SILENT: matching them is the over-block. ---
   { doc: "you signal your agreement with the Code of Conduct", want: "silent", why: "#52 mutation 2: a bare /agreement/i would hold this" },
   { doc: "By contributing you agree to the terms of the licence.", want: "silent", why: "agree + licence, no instrument" },
@@ -582,4 +593,31 @@ test("a waived signature does not park the packet", () => {
   const scanned = scanPolicyText("No CLA. No DCO. Conventional commits.");
   assert.equal(scanned.signatureWaived.length, 2, JSON.stringify(scanned));
   assert.equal(scanned.signatureRequired.length, 0);
+});
+
+/**
+ * The quote an operator reads is the CLAUSE, not the whole sentence.
+ *
+ * This is what `clausesOf` is for, and it needs saying because the clause split no longer changes
+ * any VERDICT: the per-occurrence governance rule handles mixed polarity on its own, so removing the
+ * comma from the splitter leaves every row of the corpus above passing. What it does change is what
+ * the freeze shows. "No DCO, contributor agreement required." must point the operator at the six
+ * words that assert the CLA, not hand back the whole sentence with the waiver still in it — a quote
+ * that contains its own contradiction is the thing a human then has to re-read the document to
+ * resolve.
+ *
+ * Pinned rather than deleted, and pinned rather than left as a survivor: an unpinned redundancy is
+ * the shape this repo keeps filing issues about (#75), and the answer is either a reason or a
+ * removal. This is the reason.
+ */
+test("a mixed-polarity sentence quotes each instrument's own clause, not the whole sentence", () => {
+  const s = scanPolicyText("No DCO, contributor agreement required.");
+  assert.deepEqual(s.signatureRequired, ["CLA: contributor agreement required."]);
+  assert.deepEqual(s.signatureWaived, ["DCO: No DCO"]);
+  // Specifically: the CLA's quote does NOT drag the DCO waiver along with it.
+  assert.equal(
+    s.signatureRequired[0].includes("No DCO"),
+    false,
+    "the required-CLA quote carries the waived DCO too, so the operator reads a self-contradicting phrase",
+  );
 });

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -465,6 +465,14 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   { doc: "No DCO is needed, unless you are adding a new module.", want: "required", why: "limiter behind a comma" },
   { doc: "No CLA is required, other than for vendored code.", want: "required", why: "limiter behind a comma" },
   { doc: "A CLA is not required; except for new dependencies.", want: "required", why: "limiter behind a semicolon" },
+  { doc: "Except for new dependencies, a CLA is not required.", want: "required", why: "leading limiter, waiver is the main clause" },
+  // ...and the limiter must NOT reach a waiver it has nothing to do with. Reading it from the whole
+  // sentence over-blocked these, which parks a packet whose policy waives the CLA in as many words
+  // — raised as P1 by review, the mirror image of the fail-open two rows up. A limiter past a
+  // coordinating conjunction belongs to a different statement.
+  { doc: "No CLA is required, and all patches are welcome except spam.", want: "waived", why: "the 'except' is about spam" },
+  { doc: "No DCO is needed, and we review everything except vendored trees.", want: "waived", why: "the 'except' is about review scope" },
+  { doc: "No CLA. Reviews are quick, except during release weeks.", want: "waived", why: "limiter in a later sentence about something else" },
 
   // --- Plain requirements, in the phrasings a real CONTRIBUTING.md uses. ---
   { doc: "Pull requests without a signed Contributor License Agreement will be closed.", want: "required", why: "#50: the phrasing most likely to appear for real" },

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -524,6 +524,17 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   { doc: "No DCO is waived.", want: "required", why: "#52: inflected hatch, `waive` stem" },
   { doc: "No CLA is exempt.", want: "required", why: "`exempt` stem, adjective form" },
   { doc: "No DCO is exempted.", want: "required", why: "same stem, participle" },
+  // An adverb may stand between the copula and the hatch word; these fell through to the broad
+  // matcher and read as waivers - a fail-open P1 from review.
+  { doc: "No DCO is ever waived.", want: "required", why: "#52: adverb before the hatch word" },
+  { doc: "No CLA is simply optional.", want: "required", why: "same, adjectival hatch" },
+  { doc: "No DCO is under any circumstances waived.", want: "required", why: "three words in the slot" },
+  { doc: "No CLA is needed.", want: "waived", why: "the slot cannot over-match: `needed` sits where a hatch word would and is not one" },
+  // REBUTTED, and pinned so it cannot be reported a third time: review reported that two spaces
+  // between a waiver and a same-family requirement let the absorption window eat the requirement.
+  // It does not - the window is one space, so a second space stops it, and this already resolved
+  // REQUIRED on the code as reviewed.
+  { doc: "No DCO is required  DCO is required for code.", want: "required", why: "two spaces: the one-space window cannot cross them" },
 
   // --- One verb waives only the instrument it actually reaches. ---
   //

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -467,6 +467,14 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   { doc: "No CLA is required, and all patches are welcome except spam.", want: "waived", why: "the 'except' is about spam" },
   { doc: "No DCO is needed, and we review everything except vendored trees.", want: "waived", why: "the 'except' is about review scope" },
   { doc: "No CLA. Reviews are quick, except during release weeks.", want: "waived", why: "limiter in a later sentence about something else" },
+  // ...but a sentence that STARTS with a limiter is not a new statement, it is the previous one's
+  // scope. Splitting them left a blanket waiver and a token-less fragment nothing looked at, and the
+  // repo reached ALLOW while requiring a CLA for code. A P1 from review. Sentence-initial is the
+  // whole test, which is what separates these from the row above.
+  { doc: "No CLA is required. Except for code.", want: "required", why: "sentence-initial limiter scopes the waiver before it" },
+  { doc: "No DCO is needed. Unless you are adding a new module.", want: "required", why: "same, with a subject inside the fragment" },
+  { doc: "No CLA is required. Other than for vendored trees.", want: "required", why: "multi-word limiter, sentence-initial" },
+  { doc: "No CLA is required. Reviews are quick.", want: "waived", why: "next sentence is not a limiter at all" },
   // The SAME waiver stated twice, scoped only on the later copy. Position came from asking the
   // sentence where the match was, which answers with the first copy, so the later waiver's forward
   // span was cut at the intervening conjunction and its limiter never seen — ALLOW. Third P1.
@@ -489,6 +497,11 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   // document that waives BOTH scopes. A P1 from review; every waived span comes out now.
   { doc: "No CLA is required for documentation and no CLA is required for code.", want: "waived", why: "same waiver twice in ONE clause" },
   { doc: "No DCO is needed for docs and no DCO is needed for code.", want: "waived", why: "same, DCO family" },
+  // The waiver patterns and the requirement roster were two lists and they drifted: the waivers knew
+  // `expected` and the predicate did not, so this waived the whole sentence and reached ALLOW.
+  // A P1 from review, fixed by giving both one roster rather than by adding the missing word.
+  { doc: "No CLA is expected for docs and expected for code.", want: "required", why: "'expected' must work in both polarities" },
+  { doc: "No CLA is expected.", want: "waived", why: "...and still waive when nothing requires it" },
   // ...and the limiter can scope the SECOND waiver inside that one clause. Deciding from the first
   // occurrence alone cut the forward span at the intervening "and" and reached a blanket waiver.
   // Found by adversarially probing the cross-clause fix above rather than reported - the same shape

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -467,6 +467,24 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   { doc: "No CLA is required, and all patches are welcome except spam.", want: "waived", why: "the 'except' is about spam" },
   { doc: "No DCO is needed, and we review everything except vendored trees.", want: "waived", why: "the 'except' is about review scope" },
   { doc: "No CLA. Reviews are quick, except during release weeks.", want: "waived", why: "limiter in a later sentence about something else" },
+  // The SAME waiver stated twice, scoped only on the later copy. Position came from asking the
+  // sentence where the match was, which answers with the first copy, so the later waiver's forward
+  // span was cut at the intervening conjunction and its limiter never seen — ALLOW. Third P1.
+  { doc: "No CLA is required for docs, and no CLA is required, except for new dependencies.", want: "required", why: "limiter belongs to the SECOND copy of an identical waiver" },
+  { doc: "A CLA is not required for docs, and a CLA is not required, unless you add a dependency.", want: "required", why: "same, in the not-required phrasing" },
+  { doc: "No DCO is needed for docs, and no DCO is needed, other than for vendored code.", want: "required", why: "same, DCO family" },
+  { doc: "No CLA is required, except for new dependencies, and no CLA is required for docs.", want: "required", why: "limiter belongs to the FIRST copy" },
+  // Rows above repeat a waiver but never byte-identically: case or a glued "and" keeps each clause
+  // text unique, so finding one BY its text lands right by luck. Here both copies are exactly
+  // `no CLA is required` with the conjunction between them as its own span, so a by-text search
+  // returns the first and the later copy's span is cut at that "and". Stilted on purpose — this
+  // reads a stranger's CONTRIBUTING.md, and a repo wanting ALLOW while demanding a signature has
+  // every reason to write awkwardly.
+  { doc: "For docs, no CLA is required, and, no CLA is required, except for new dependencies.", want: "required", why: "byte-identical clauses: the later copy must be found at its own offset" },
+  // ...and the repetition must not become an excuse to over-block. These are the fail-closed halves:
+  // identical clauses with no limiter anywhere, and a repeat whose trailing 'except' governs spam.
+  { doc: "No CLA is required, no CLA is required.", want: "waived", why: "verbatim repeat, nothing scopes either copy" },
+  { doc: "No CLA is required for docs, and no CLA is required, and all patches are welcome except spam.", want: "waived", why: "repeat, and the 'except' is still about spam" },
 
   // Anaphora (P1 from review): the requirement's subject is elided, so it lands in a token-less
   // clause the per-clause pass skipped, recording only the waiver.

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -484,6 +484,17 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   // ...and the repetition must not become an excuse to over-block. These are the fail-closed halves:
   // identical clauses with no limiter anywhere, and a repeat whose trailing 'except' governs spam.
   { doc: "No CLA is required, no CLA is required.", want: "waived", why: "verbatim repeat, nothing scopes either copy" },
+  // One clause can waive the same instrument twice - "and" does not split a clause - and removing
+  // only the FIRST waived span left the second reading as an ungoverned requirement, parking a
+  // document that waives BOTH scopes. A P1 from review; every waived span comes out now.
+  { doc: "No CLA is required for documentation and no CLA is required for code.", want: "waived", why: "same waiver twice in ONE clause" },
+  { doc: "No DCO is needed for docs and no DCO is needed for code.", want: "waived", why: "same, DCO family" },
+  // ...and the limiter can scope the SECOND waiver inside that one clause. Deciding from the first
+  // occurrence alone cut the forward span at the intervening "and" and reached a blanket waiver.
+  // Found by adversarially probing the cross-clause fix above rather than reported - the same shape
+  // a repo would use to get ALLOW while demanding a signature, so it is checked per occurrence now.
+  { doc: "No DCO is needed for docs and no DCO is needed for tests, other than vendored trees.", want: "required", why: "limiter scopes the second waiver in ONE clause" },
+  { doc: "No CLA is required for docs and no CLA is required for tests, except for dependencies.", want: "required", why: "same, CLA family" },
   { doc: "No CLA is required for docs, and no CLA is required, and all patches are welcome except spam.", want: "waived", why: "repeat, and the 'except' is still about spam" },
 
   // Anaphora (P1 from review): the requirement's subject is elided, so it lands in a token-less
@@ -493,6 +504,19 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   { doc: "A CLA is not required, however it is mandatory for vendored trees.", want: "required", why: "'it is mandatory' after 'however'" },
   // ...and a later clause with its OWN subject must not flip anything, or the rule over-blocks.
   { doc: "No CLA is required, and tests are required.", want: "waived", why: "'tests' is the subject, not the CLA" },
+  // English drops the copula, and a participle-initial clause was invisible: the waiver read as
+  // blanket and the repo was ALLOWED despite requiring a signature for code. A P1 from review.
+  // With no verb to anchor on, the SCOPE anchors instead - a bare participle counts only when a
+  // scope or the clause end follows, which is what separates it from a participle modifying a noun.
+  { doc: "A CLA is not required for documentation, but required for code.", want: "required", why: "copula elided as well as the subject" },
+  { doc: "No CLA is needed for docs, but required for vendored trees.", want: "required", why: "same shape, needed/required" },
+  { doc: "A CLA is not required for docs, however mandatory for dependencies.", want: "required", why: "copula-less after 'however'" },
+  { doc: "No CLA is required, needed only for release.", want: "required", why: "one adverb between participle and scope" },
+  { doc: "A CLA is not required for docs, but required.", want: "required", why: "bare participle, clause ends" },
+  // ...and the participle must be PREDICATIVE. Modifying a noun asserts nothing about the
+  // instrument, so these must stay waived or the rule over-blocks ordinary prose.
+  { doc: "No CLA is required, required reading is the style guide.", want: "waived", why: "'required reading' modifies a noun" },
+  { doc: "No CLA is required, necessary tooling is listed below.", want: "waived", why: "'necessary tooling' modifies a noun" },
 
   // --- Plain requirements, in the phrasings a real CONTRIBUTING.md uses. ---
   { doc: "Pull requests without a signed Contributor License Agreement will be closed.", want: "required", why: "#50: the phrasing most likely to appear for real" },

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -484,6 +484,18 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   { doc: "We cannot merge your work until the CLA is signed.", want: "required", why: "cannot-merge framing" },
   { doc: "Your PR will not be reviewed without a DCO sign-off.", want: "required", why: "'without' is a requirement context, never a waiver" },
 
+  // PLURALS. A P1 fail-open in the first version of this change, found in review: `\bcla\b` does
+  // not match `CLAs`, so the first row below waived the DCO, saw nothing about the CLA, and reached
+  // ALLOW. The second and third matched NOTHING AT ALL. Same defect as the issue, new spelling.
+  { doc: "No DCO. CLAs are mandatory.", want: "required", why: "plural acronym after a waived sibling" },
+  { doc: "CLAs are required for all contributors.", want: "required", why: "plural acronym, was silent" },
+  { doc: "We require DCOs on every commit.", want: "required", why: "plural DCO, was silent" },
+  { doc: "Contributor license agreements are required from every contributor.", want: "required", why: "plural spelled-out form" },
+  { doc: "No DCO. Contributor agreements are mandatory.", want: "required", why: "plural short form after a waiver" },
+  // ...and the plural must not swallow an ordinary English word: `\bclas?\b` cannot match "class",
+  // because the optional s still needs a word boundary after it.
+  { doc: "Add a class for the parser and document the class hierarchy.", want: "silent", why: "'class' is not a plural CLA" },
+
   // --- No signature instrument at all. These must be SILENT: matching them is the over-block. ---
   { doc: "you signal your agreement with the Code of Conduct", want: "silent", why: "#52 mutation 2: a bare /agreement/i would hold this" },
   { doc: "By contributing you agree to the terms of the licence.", want: "silent", why: "agree + licence, no instrument" },

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -523,6 +523,10 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   // ...and the shape the filler exists for still waives: an infinitive between verb and instrument.
   { doc: "We do not need to sign a contributor license agreement.", want: "waived", why: "the infinitive the filler was added for" },
   { doc: "We do not ask for a contributor agreement.", want: "waived", why: "ask-for phrasing, single instrument" },
+  // The absorption exception is for a COMPOUND NOUN - "a DCO sign-off" is one instrument, so the
+  // second token comes out with the first. A dash separating two statements is not that, and a
+  // three-character window ate the requirement behind one: a fail-open P1 from review.
+  { doc: "No DCO is required - DCO is required for code.", want: "required", why: "a dash separates statements; it is not a compound noun" },
 
   // --- Sentences from real CONTRIBUTING documents, quoted. ---
   //
@@ -638,6 +642,7 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   // The bound on that rule: a pronoun used as an OBJECT qualifies nothing, so it must not hold. The
   // rule needs a pronoun followed by something - a clause - not a pronoun anywhere in the sentence.
   { doc: "No CLA is required for that.", want: "waived", why: "'that' is an object here, not a subject asserting anything" },
+  { doc: "No CLA is required. It, however, is required for code.", want: "required", why: "an aside between pronoun and verb does not detach the clause" },
   // ...and the closed qualifier set still earns its keep with no pronoun in sight: reopening it to
   // any word makes this join and read as a requirement, which is the fail-closed it was added for.
   { doc: "No CLA is required. Required reading for contributors.", want: "waived", why: "'reading' is a noun, not an adverb before the scope" },
@@ -799,6 +804,36 @@ test("the signature corpus classifies every phrasing correctly, in both directio
  * a second visible edit. Both directions are floored separately — an all-must-hold corpus measures
  * only recall and lets the over-block class back in, which is how round 1 of #37 failed.
  */
+/**
+ * The gate reads a stranger's CONTRIBUTING.md, so it must not be possible to hang it with one.
+ *
+ * This is a HANG detector, not a benchmark: the bound is generous and the shapes are the ones that
+ * make backtracking expensive — long filler runs, deep clause lists, a sentence with no punctuation
+ * to stop at, and repetition of every construct the scanner special-cases. Written after this file's
+ * own mutation harness produced a non-terminating run and the residual loop turned out to depend on
+ * the string shrinking rather than being made to.
+ */
+test("no adversarial document can hang the signature scanner", () => {
+  const documents: [string, string][] = [
+    ["long filler run", `We do not require ${"a ".repeat(400)}CLA.`],
+    ["filler reaching no instrument", `We do not require ${"a ".repeat(2000)}`],
+    ["instrument repeated inside the filler", `We do not require ${"a CLA ".repeat(300)}DCO.`],
+    ["deep clause list", `No CLA is required${", or code".repeat(1500)}, except forks.`],
+    ["no punctuation to stop at", `No CLA is required ${"and code ".repeat(2000)}`],
+    ["pronoun repetition", `No CLA is required. ${"It is it is ".repeat(2000)}`],
+    ["whitespace run inside a waiver", `We don't require${" ".repeat(5000)}a DCO sign-off`],
+    ["waiver repeated across sentences", "No CLA is required. ".repeat(2000)],
+    ["markdown bullet repetition", "- No CLA is required\n".repeat(2000)],
+    ["limiter repetition", `No CLA is required ${"except ".repeat(2000)}`],
+  ];
+  for (const [name, doc] of documents) {
+    const started = performance.now();
+    scanPolicyText(doc);
+    const elapsed = performance.now() - started;
+    assert.ok(elapsed < 5000, `${name} (${doc.length} chars) took ${elapsed.toFixed(0)}ms`);
+  }
+});
+
 test("the signature corpus cannot be quietly emptied or made one-sided", () => {
   assert.ok(SIGNATURE_CORPUS.length >= 40, `corpus has ${SIGNATURE_CORPUS.length} rows; the floor is 40`);
   const count = (p: Polarity) => SIGNATURE_CORPUS.filter((r) => r.want === p).length;

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -467,6 +467,13 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   { doc: "A CLA is not required, except for new dependencies.", want: "required", why: "limiter behind a comma" },
   { doc: "No DCO is needed, unless you are adding a new module.", want: "required", why: "limiter behind a comma" },
   { doc: "No CLA is required, other than for vendored code.", want: "required", why: "limiter behind a comma" },
+  // A conjunction ends the waiver's statement only where it BEGINS a clause. Truncating at ANY
+  // conjunction cut this at the `or` - which coordinates two SCOPES, not two statements - and lost
+  // the exception behind it. A P1 from review, and the fail-open mirror of the over-block that put
+  // truncation here to begin with, so both directions are pinned together.
+  { doc: "No CLA is required for documentation or code except for third-party contributions.", want: "required", why: "'or' coordinates scopes; the exception still applies" },
+  { doc: "No DCO is needed for docs or tests, unless vendored.", want: "required", why: "same, with the limiter behind a comma" },
+  { doc: "No CLA is required for docs plus tests, other than for dependencies.", want: "required", why: "'plus' coordinates scopes too" },
   { doc: "A CLA is not required; except for new dependencies.", want: "required", why: "limiter behind a semicolon" },
   { doc: "Except for new dependencies, a CLA is not required.", want: "required", why: "leading limiter, waiver is the main clause" },
   // ...and it must NOT reach a waiver it has nothing to do with. Reading it from the whole sentence
@@ -543,6 +550,14 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   { doc: "A CLA is not required for documentation, but is required for code contributions.", want: "required", why: "elided subject after 'but'" },
   { doc: "No DCO is needed for docs, but is required for code.", want: "required", why: "same shape, DCO family" },
   { doc: "A CLA is not required, however it is mandatory for vendored trees.", want: "required", why: "'it is mandatory' after 'however'" },
+  // The conjunction roster was written out five times and `yet` was in none of them, so this reached
+  // ALLOW. A P1 from review, fixed by giving every site one pair of rosters - contrastive words end
+  // a clause, coordinating words do not - rather than by adding the one missing word.
+  { doc: "No CLA is required for docs, yet required for code.", want: "required", why: "'yet' is contrastive and was unlisted" },
+  { doc: "No CLA is required for docs, though required for code.", want: "required", why: "'though'" },
+  { doc: "No CLA is required for docs, whereas required for code.", want: "required", why: "'whereas'" },
+  { doc: "No CLA is required for docs, nevertheless required for code.", want: "required", why: "'nevertheless'" },
+  { doc: "No CLA is required while the repo is in beta.", want: "waived", why: "temporal 'while' asserts no requirement" },
   // ...and a later clause with its OWN subject must not flip anything, or the rule over-blocks.
   { doc: "No CLA is required, and tests are required.", want: "waived", why: "'tests' is the subject, not the CLA" },
   // English drops the copula, and a participle-initial clause was invisible: the waiver read as

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -23,6 +23,34 @@ test("forbidden phrase beats a welcome repo", () => {
   assert.equal(v.code, "DENY_FORBIDDEN");
 });
 
+test("an anaphoric requirement lands on the instrument last named, not on every family", () => {
+  // The corpus above asserts the VERDICT; this asserts which instrument the record blames, which is
+  // the half a sentence-wide flag got wrong and the half a human reads.
+  const cla = scanPolicyText("No CLA is required for docs, but is required for code, and no DCO is needed.");
+  assert.deepEqual(
+    cla.signatureRequired.map((q) => q.split(":")[0]),
+    ["CLA"],
+    "the CLA is the instrument the elided subject refers to",
+  );
+  assert.deepEqual(cla.signatureWaived.map((q) => q.split(":")[0]), ["DCO"], "the DCO is waived outright");
+
+  // Same sentence with the families swapped, so the rule cannot be passing by ordering luck.
+  const dco = scanPolicyText("No DCO is needed for docs, but is required for code, and no CLA is required.");
+  assert.deepEqual(dco.signatureRequired.map((q) => q.split(":")[0]), ["DCO"]);
+  assert.deepEqual(dco.signatureWaived.map((q) => q.split(":")[0]), ["CLA"]);
+
+  // Both families named BEFORE the anaphor, so "most recently named" and "first named" differ and
+  // only the nearest one is right. Without this the rule passes while attributing to whichever
+  // instrument happens to appear first.
+  const nearest = scanPolicyText("No DCO is needed, no CLA is required for docs, but is required for code.");
+  assert.deepEqual(
+    nearest.signatureRequired.map((q) => q.split(":")[0]),
+    ["CLA"],
+    "the CLA is the instrument named nearest the elided subject",
+  );
+  assert.deepEqual(nearest.signatureWaived.map((q) => q.split(":")[0]), ["DCO"]);
+});
+
 test("CLA parks needs-human", () => {
   const v = evaluatePolicy({
     repoId: "OpenHands/OpenHands",
@@ -578,6 +606,11 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   { doc: "No CLA is required while the repo is in beta.", want: "waived", why: "temporal 'while' asserts no requirement" },
   // ...and a later clause with its OWN subject must not flip anything, or the rule over-blocks.
   { doc: "No CLA is required, and tests are required.", want: "waived", why: "'tests' is the subject, not the CLA" },
+  // An elided subject refers to the instrument most recently NAMED. A sentence-wide flag put the
+  // requirement on both families, so a sentence waiving the DCO outright reported it as required -
+  // a P1 from review, and fail-CLOSED. The verdict was the same because the CLA really is required,
+  // but the freeze evidence named the wrong instrument, and that record is what a human signs off.
+  { doc: "No CLA is required for docs, but is required for code, and no DCO is needed.", want: "required", why: "anaphora belongs to the CLA, not the DCO" },
   // English drops the copula, and a participle-initial clause was invisible: the waiver read as
   // blanket and the repo was ALLOWED despite requiring a signature for code. A P1 from review.
   // With no verb to anchor on, the SCOPE anchors instead - a bare participle counts only when a

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -403,13 +403,13 @@ test("deny-by-default covers the no-evidence case, not the missed-ban case", () 
  * which is what happened to the previous attempt.
  *
  * Two more holes the same measurement found, neither in the issue: "All commits must carry a
- * Signed-off-by line." reached ALLOW matching NOTHING, and the short form `contributor agreement`
- * was unmatched, so "No DCO, contributor agreement required." also held only by the accident.
+ * Signed-off-by line." reached ALLOW matching NOTHING, and the short `contributor agreement` was
+ * unmatched, so "No DCO, contributor agreement required." also held only by the accident.
  *
- * CORPUS PROVENANCE — the part #37's park note says to settle before touching a regex. No row below
- * is derived from a constant in `policy.ts`. They come from the documents quoted in #52 and #50,
- * ordinary CONTRIBUTING.md phrasing, and paraphrase into shapes the implementation does not name. A
- * corpus drawn from the code under test only measures that the code does what it does.
+ * CORPUS PROVENANCE — what #37's park note says to settle before touching a regex. No row below is
+ * derived from a constant in `policy.ts`; they come from the documents quoted in #52 and #50,
+ * ordinary CONTRIBUTING.md phrasing, and paraphrase. A corpus drawn from the code under test only
+ * measures that the code does what it does.
  */
 type Polarity = "required" | "waived" | "silent";
 
@@ -425,11 +425,8 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   { doc: "No DCO, contributor agreement required.", want: "required", why: "#52: the comma case a code comment claimed and no test asserted" },
   { doc: "No CLA, DCO sign-off required.", want: "required", why: "the same shape with the families swapped" },
   { doc: "CLA required, DCO not required.", want: "required", why: "requirement first, waiver second" },
-  // TWO TOKENS OF ONE FAMILY, waiver first. This is the row that pins the comma in `clausesOf`:
-  // without the split the whole sentence is one clause, the first CLA match is the one inside
-  // "No CLA", its waiver fires, and the requirement later in the sentence is never evaluated —
-  // a fail-open. Every other corpus row survives losing the comma, because the waiver patterns are
-  // token-anchored; this one does not.
+  // Two tokens of one family, waiver first: without the comma split the first CLA match is inside
+  // "No CLA", its waiver fires, and the later requirement is never evaluated — a fail-open.
   { doc: "No CLA, a contributor license agreement is required.", want: "required", why: "same family twice, waiver first — pins the comma split" },
 
   // --- Blanket waivers. These must NOT hold: over-blocking parks a legitimate packet. ---
@@ -458,24 +455,21 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   // --- Scoped waivers: it is required somewhere, so it holds. ---
   { doc: "A CLA is not required except for new dependencies.", want: "required", why: "#50 comment: scoped waiver" },
   { doc: "No DCO is needed unless you are adding a new module.", want: "required", why: "unless-scoped" },
-  // The limiter across a clause boundary. The first draft of `signaturePolarity` read the limiter
-  // from the CLAUSE, so a comma before "except" hid it and a scoped requirement came out a blanket
-  // waiver — this issue's own fail-open class, reproduced inside its fix and caught before shipping.
+  // Limiter across a clause boundary: reading it from the CLAUSE let a comma before "except" hide
+  // it, turning a scoped requirement into a blanket waiver.
   { doc: "A CLA is not required, except for new dependencies.", want: "required", why: "limiter behind a comma" },
   { doc: "No DCO is needed, unless you are adding a new module.", want: "required", why: "limiter behind a comma" },
   { doc: "No CLA is required, other than for vendored code.", want: "required", why: "limiter behind a comma" },
   { doc: "A CLA is not required; except for new dependencies.", want: "required", why: "limiter behind a semicolon" },
   { doc: "Except for new dependencies, a CLA is not required.", want: "required", why: "leading limiter, waiver is the main clause" },
-  // ...and the limiter must NOT reach a waiver it has nothing to do with. Reading it from the whole
-  // sentence over-blocked these, which parks a packet whose policy waives the CLA in as many words
-  // — raised as P1 by review, the mirror image of the fail-open two rows up. A limiter past a
-  // coordinating conjunction belongs to a different statement.
+  // ...and it must NOT reach a waiver it has nothing to do with. Reading it from the whole sentence
+  // over-blocked these (P1 from review) — a limiter past a conjunction is a different statement.
   { doc: "No CLA is required, and all patches are welcome except spam.", want: "waived", why: "the 'except' is about spam" },
   { doc: "No DCO is needed, and we review everything except vendored trees.", want: "waived", why: "the 'except' is about review scope" },
   { doc: "No CLA. Reviews are quick, except during release weeks.", want: "waived", why: "limiter in a later sentence about something else" },
 
-  // ANAPHORA. A P1 from review: the requirement's subject is elided, so it lands in a clause with no
-  // instrument token and the per-clause pass skipped it, recording only the waiver.
+  // Anaphora (P1 from review): the requirement's subject is elided, so it lands in a token-less
+  // clause the per-clause pass skipped, recording only the waiver.
   { doc: "A CLA is not required for documentation, but is required for code contributions.", want: "required", why: "elided subject after 'but'" },
   { doc: "No DCO is needed for docs, but is required for code.", want: "required", why: "same shape, DCO family" },
   { doc: "A CLA is not required, however it is mandatory for vendored trees.", want: "required", why: "'it is mandatory' after 'however'" },
@@ -495,9 +489,8 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   { doc: "We cannot merge your work until the CLA is signed.", want: "required", why: "cannot-merge framing" },
   { doc: "Your PR will not be reviewed without a DCO sign-off.", want: "required", why: "'without' is a requirement context, never a waiver" },
 
-  // PLURALS. A P1 fail-open in the first version of this change, found in review: `\bcla\b` does
-  // not match `CLAs`, so the first row below waived the DCO, saw nothing about the CLA, and reached
-  // ALLOW. The second and third matched NOTHING AT ALL. Same defect as the issue, new spelling.
+  // Plurals (P1 from review): `\bcla\b` misses `CLAs`, so row 1 waived the DCO and saw nothing
+  // about the CLA; rows 2-3 matched NOTHING AT ALL. This issue's defect in a new spelling.
   { doc: "No DCO. CLAs are mandatory.", want: "required", why: "plural acronym after a waived sibling" },
   { doc: "CLAs are required for all contributors.", want: "required", why: "plural acronym, was silent" },
   { doc: "We require DCOs on every commit.", want: "required", why: "plural DCO, was silent" },
@@ -507,15 +500,12 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   // because the optional s still needs a word boundary after it.
   { doc: "Add a class for the parser and document the class hierarchy.", want: "silent", why: "'class' is not a plural CLA" },
 
-  // MIXED POLARITY IN ONE CLAUSE. A second P1 from review: polarity was decided once per clause from
-  // the FIRST match, so a waiver joined to a same-family requirement by "and" — not a delimiter, and
-  // it should not have to be — hid the requirement and reached ALLOW. A waiver now governs only the
-  // occurrence it names; any surviving mention is ungoverned and reads as required.
+  // Mixed polarity in one clause (P1 from review): polarity was decided once per clause from the
+  // FIRST match, so a waiver joined by "and" to a same-family requirement hid it and reached ALLOW.
   { doc: "No CLA is required for documentation and a CLA is required for code contributions.", want: "required", why: "same family, both polarities, joined by 'and'" },
   { doc: "No DCO is needed for docs and a DCO is needed for code.", want: "required", why: "same shape, DCO family" },
   { doc: "No CLA is required, and a CLA is required for vendored code.", want: "required", why: "comma and 'and' together" },
-  // ...and the governance rule must not turn one instrument named twice into a requirement:
-  // "a DCO sign-off" is a single thing and both words are DCO-family tokens.
+  // ...and one instrument named twice ("a DCO sign-off") must not read as a requirement.
   { doc: "No CLA and no DCO.", want: "waived", why: "two instruments, both waived, joined by 'and'" },
 
   // --- No signature instrument at all. These must be SILENT: matching them is the over-block. ---
@@ -561,10 +551,9 @@ test("the signature corpus cannot be quietly emptied or made one-sided", () => {
 });
 
 /**
- * The verdict CODE, not just the polarity. #52's acceptance is that these hold as `HOLD_CLA`, and
- * the code used to be re-derived by substring-testing the matched phrase for "cla", "dco" or
- * "certificate" — which is why "Contributor License Agreement" landed in `HOLD_HUMAN`: those three
- * letters never appear consecutively in it (issue #50's root cause, reached from here).
+ * The verdict CODE, not just the polarity. The code used to be re-derived by substring-testing the
+ * matched phrase for "cla"/"dco"/"certificate", which is why "Contributor License Agreement" landed
+ * in `HOLD_HUMAN`: those letters never appear consecutively in it (#50's root cause, from here).
  */
 test("an asserted signature holds as HOLD_CLA, and a human-review gate stays HOLD_HUMAN", () => {
   for (const doc of SIGNATURE_CORPUS.filter((r) => r.want === "required").map((r) => r.doc)) {

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -507,48 +507,60 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   { doc: "No CLA is discretionary.", want: "required", why: "synonym" },
   { doc: "There is no way around the DCO.", want: "required", why: "paraphrased escape hatch" },
 
+  // --- Sentences from real CONTRIBUTING documents, quoted. ---
+  //
+  // Every other row here was invented to probe a rule. These were not: they are verbatim sentences
+  // from upstream policy files, and they are what the gate will actually meet. All of them assert a
+  // signature, which is the finding that shaped this scanner - across 17 such documents, 12 name an
+  // instrument and every one of the 12 requires it. A document with no signature requirement does not
+  // mention a signature at all, so the waiver rows below describe a rarer document than they look.
+  { doc: "We cannot accept code without a signed CLA.", want: "required", why: "angular/angular CONTRIBUTING.md" },
+  { doc: "The CLA bot will provide a prompt to sign the CLA through a comment on the pull-request.", want: "required", why: "dotnet/runtime CONTRIBUTING.md" },
+  { doc: "The sign-off is a simple line at the end of the explanation for the patch.", want: "required", why: "moby/moby CONTRIBUTING.md" },
+  { doc: "Again once your PR is assigned a reviewer, unless you need to fix DCO", want: "required", why: "envoyproxy/envoy - one of only 2 of 88 real sentences pairing an instrument with a limiter" },
+  { doc: "While the Signed-off-by tag is mandatory, there are a number of other tags that are commonly used during QEMU development.", want: "required", why: "qemu code-provenance.rst, backticks stripped" },
+
   // --- Scoped waivers: it is required somewhere, so it holds. ---
   { doc: "A CLA is not required except for new dependencies.", want: "required", why: "#50 comment: scoped waiver" },
   { doc: "No DCO is needed unless you are adding a new module.", want: "required", why: "unless-scoped" },
-  // Limiter across a clause boundary: reading it from the CLAUSE let a comma before "except" hide
-  // it, turning a scoped requirement into a blanket waiver.
   { doc: "A CLA is not required, except for new dependencies.", want: "required", why: "limiter behind a comma" },
   { doc: "No DCO is needed, unless you are adding a new module.", want: "required", why: "limiter behind a comma" },
   { doc: "No CLA is required, other than for vendored code.", want: "required", why: "limiter behind a comma" },
-  // A conjunction ends the waiver's statement only where it BEGINS a clause. Truncating at ANY
-  // conjunction cut this at the `or` - which coordinates two SCOPES, not two statements - and lost
-  // the exception behind it. A P1 from review, and the fail-open mirror of the over-block that put
-  // truncation here to begin with, so both directions are pinned together.
-  { doc: "No CLA is required for documentation or code except for third-party contributions.", want: "required", why: "'or' coordinates scopes; the exception still applies" },
-  { doc: "No DCO is needed for docs or tests, unless vendored.", want: "required", why: "same, with the limiter behind a comma" },
-  { doc: "No CLA is required for docs plus tests, other than for dependencies.", want: "required", why: "'plus' coordinates scopes too" },
-  // A comma before the conjunction is NECESSARY for a statement boundary and not sufficient: in a
-  // scope LIST the item is a bare noun phrase closed by the next comma, and truncating there lost
-  // the exception behind it. A P1 from review. A real statement is longer and carries a verb, which
-  // is the test - so the rows below and the two after them are the same rule from both sides.
-  { doc: "No CLA is required for documentation, or code, except for third-party contributions.", want: "required", why: "comma before 'or', but 'code' is scope" },
-  { doc: "No CLA is required for docs, or tests, or code, unless vendored.", want: "required", why: "three-item scope list" },
-  { doc: "No DCO is needed for docs, and tests, other than vendored trees.", want: "required", why: "'and'-joined scope list" },
-  { doc: "No CLA is required for docs, and we review everything except vendored trees.", want: "waived", why: "a verb after the comma makes it a statement" },
-  { doc: "No CLA is required for docs, but the maintainers apply judgement except for forks.", want: "waived", why: "same, contrastive conjunction" },
-  // Both halves of "is this segment a scope item or a statement" earn their keep, and each of these
-  // rows fails without one of them. Short-with-a-verb is a statement; long-without-one is too.
-  { doc: "No CLA is required for docs, and tests apply, except for code.", want: "waived", why: "3 words but a verb: a statement, so the waiver's span ends" },
-  { doc: "No CLA is required for docs, and all other repositories in this organisation, except forks.", want: "waived", why: "verbless but long: also a statement" },
-  // Punctuation is NOT part of the test. Requiring a comma before the conjunction let an unrelated
-  // exception scope the waiver whenever the author omitted one - a fail-closed P1 from review.
-  { doc: "No CLA is required for docs and all patches are welcome except spam.", want: "waived", why: "no comma, still two statements" },
-  { doc: "No DCO is needed for docs and we review everything except vendored trees.", want: "waived", why: "same, other family" },
-  // ...and a statement about THIS instrument does not end the span either, because a limiter past a
-  // second waiver of the same thing still means it is required somewhere. That case is already above
-  // ("limiter scopes the second waiver in ONE clause"); it is the line between these two groups, and
-  // all of them fail if it is drawn anywhere else.
   { doc: "A CLA is not required; except for new dependencies.", want: "required", why: "limiter behind a semicolon" },
   { doc: "Except for new dependencies, a CLA is not required.", want: "required", why: "leading limiter, waiver is the main clause" },
-  // ...and it must NOT reach a waiver it has nothing to do with. Reading it from the whole sentence
-  // over-blocked these (P1 from review) — a limiter past a conjunction is a different statement.
-  { doc: "No CLA is required, and all patches are welcome except spam.", want: "waived", why: "the 'except' is about spam" },
-  { doc: "No DCO is needed, and we review everything except vendored trees.", want: "waived", why: "the 'except' is about review scope" },
+  { doc: "No CLA is required for documentation or code except for third-party contributions.", want: "required", why: "'or' coordinates two scopes" },
+  { doc: "No DCO is needed for docs or tests, unless vendored.", want: "required", why: "same, limiter behind a comma" },
+  { doc: "No CLA is required for docs plus tests, other than for dependencies.", want: "required", why: "'plus' coordinates scopes too" },
+  { doc: "No CLA is required for documentation, or code, except for third-party contributions.", want: "required", why: "comma before 'or'" },
+  { doc: "No CLA is required for docs, or tests, or code, unless vendored.", want: "required", why: "three-item scope list" },
+  { doc: "No DCO is needed for docs, and tests, other than vendored trees.", want: "required", why: "'and'-joined scope list" },
+
+  // --- And a limiter the waiver has NOTHING to do with holds the packet too. ---
+  //
+  // These nine rows read as waivers to a human: the `except` is about spam, or review scope, or
+  // forks. They are deliberately held anyway, and the reasoning is at `SCOPE_LIMITER`'s use in
+  // `signaturePolarity`: deciding which of two statements an `except` belongs to is a parsing
+  // problem, twelve of this branch's defects were that decision made four different ways, and every
+  // version was correct until someone wrote down one more sentence.
+  //
+  // So the question is no longer asked. A waiver stands only in a sentence with nothing to argue
+  // about. This reverses two review findings that called the over-block a defect, which is a real
+  // cost and is why it is measured rather than asserted: across 17 real CONTRIBUTING-style documents,
+  // 12 name a signature instrument and all 12 already resolve to REQUIRED. No real document waives
+  // an instrument it mentions. Two of 88 instrument-naming sentences carried a limiter, both inside
+  // documents already held. The shape these rows describe did not occur once.
+  { doc: "No CLA is required, and all patches are welcome except spam.", want: "required", why: "the 'except' is about spam - held rather than parsed" },
+  { doc: "No DCO is needed, and we review everything except vendored trees.", want: "required", why: "'except' is about review scope" },
+  { doc: "No CLA is required for docs, and we review everything except vendored trees.", want: "required", why: "unrelated exception, same sentence" },
+  { doc: "No CLA is required for docs, but the maintainers apply judgement except for forks.", want: "required", why: "contrastive conjunction, unrelated exception" },
+  { doc: "No CLA is required for docs, and tests apply, except for code.", want: "required", why: "exception attaches to 'tests apply', not to the CLA" },
+  { doc: "No CLA is required for docs, and all other repositories in this organisation, except forks.", want: "required", why: "exception about repositories" },
+  { doc: "No CLA is required for docs and all patches are welcome except spam.", want: "required", why: "no comma; still an unrelated exception" },
+  { doc: "No DCO is needed for docs and we review everything except vendored trees.", want: "required", why: "same, other family" },
+  { doc: "No CLA is required for docs, and no CLA is required, and all patches are welcome except spam.", want: "required", why: "repeated waiver plus an unrelated exception" },
+  // The limit of the rule, and the reason it is per SENTENCE: a limiter in a DIFFERENT sentence is
+  // not in the waiver's sentence and does not hold it. Without this the rule would swallow whole
+  // documents, since `except` appears in ordinary prose everywhere.
   { doc: "No CLA. Reviews are quick, except during release weeks.", want: "waived", why: "limiter in a later sentence about something else" },
   // ...but a sentence that STARTS with a limiter is not a new statement, it is the previous one's
   // scope. Splitting them left a blanket waiver and a token-less fragment nothing looked at, and the
@@ -632,7 +644,6 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   // a repo would use to get ALLOW while demanding a signature, so it is checked per occurrence now.
   { doc: "No DCO is needed for docs and no DCO is needed for tests, other than vendored trees.", want: "required", why: "limiter scopes the second waiver in ONE clause" },
   { doc: "No CLA is required for docs and no CLA is required for tests, except for dependencies.", want: "required", why: "same, CLA family" },
-  { doc: "No CLA is required for docs, and no CLA is required, and all patches are welcome except spam.", want: "waived", why: "repeat, and the 'except' is still about spam" },
 
   // Anaphora (P1 from review): the requirement's subject is elided, so it lands in a token-less
   // clause the per-clause pass skipped, recording only the waiver.

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -394,27 +394,22 @@ test("deny-by-default covers the no-evidence case, not the missed-ban case", () 
 /**
  * ISSUE #52 — the CLA/DCO fail-open, and the corpus that has to keep it closed.
  *
- * WHAT WAS BROKEN ON `main`, measured rather than described. All five of the realistic
- * "waive the DCO, assert the CLA" documents below did produce a hold — and every one of them did it
- * through `human=["DCO"]`, with nothing matched about the CLA at all. `HUMAN_STATEMENTS` had no bare
- * `\bcla\b`; its only CLA-acronym patterns were `sign(?:ing)?\s+the\s+cla` and
- * `\bcla\s+(?:is\s+)?required\b`, both defeated by an interposed "not". So the correct verdict was an
- * ACCIDENT of an un-negated `\bdco\b` sitting in the same sentence. Making the DCO negation-aware —
- * which the repo needs, because "No CLA. No DCO. Conventional commits." is the live Wave-1 seed text
- * and was being parked — removes the accident, and 8 of 10 such documents fail open with nothing to
- * replace it. That is what happened to the previous attempt.
+ * WHAT WAS BROKEN ON `main`, measured rather than described. All five "waive the DCO, assert the
+ * CLA" documents below did hold — every one through `human=["DCO"]`, with nothing matched about the
+ * CLA. There was no bare `\bcla\b`; the only CLA patterns were `sign(?:ing)?\s+the\s+cla` and
+ * `\bcla\s+(?:is\s+)?required\b`, both defeated by an interposed "not". The correct verdict was an
+ * ACCIDENT. Negating the DCO — which the repo needs, since "No CLA. No DCO. Conventional commits."
+ * is the live Wave-1 seed text and was being parked — removes the accident with nothing behind it,
+ * which is what happened to the previous attempt.
  *
- * Two further holes the same measurement turned up, neither in the issue:
- *   - "All commits must carry a Signed-off-by line." reached ALLOW with EMPTY matched phrases. A
- *     plain signature requirement the scanner could not see.
- *   - "No DCO, contributor agreement required." held only via the DCO accident; the short form
- *     `contributor agreement` was unmatched.
+ * Two more holes the same measurement found, neither in the issue: "All commits must carry a
+ * Signed-off-by line." reached ALLOW matching NOTHING, and the short form `contributor agreement`
+ * was unmatched, so "No DCO, contributor agreement required." also held only by the accident.
  *
- * CORPUS PROVENANCE, which is the part issue #37's park note says to settle before touching a
- * regex. Not one row below is derived from a constant in `policy.ts`. They come from: the documents
- * quoted in #52 and #50, ordinary CONTRIBUTING.md phrasing, and deliberate paraphrase of each into
- * shapes the implementation does not name. A corpus drawn from the code under test measures whether
- * the code does what it does.
+ * CORPUS PROVENANCE — the part #37's park note says to settle before touching a regex. No row below
+ * is derived from a constant in `policy.ts`. They come from the documents quoted in #52 and #50,
+ * ordinary CONTRIBUTING.md phrasing, and paraphrase into shapes the implementation does not name. A
+ * corpus drawn from the code under test only measures that the code does what it does.
  */
 type Polarity = "required" | "waived" | "silent";
 
@@ -534,12 +529,10 @@ test("the signature corpus classifies every phrasing correctly, in both directio
 });
 
 /**
- * Size floors, and they are not decoration. Issue #37's round 3 shipped `suite ok`, exit 0, with its
- * headline corpus EMPTIED and a known regression reintroduced, because `CORPUS` had no floor while
- * `LEXICON` did. Emptying a roster has to cost a second visible edit.
- *
- * Both directions are floored separately, because a corpus that is all must-hold rows measures only
- * recall and would let the over-block class back in — which is how round 1 of #37 failed.
+ * Size floors, not decoration: #37's round 3 shipped `suite ok`, exit 0, with its headline corpus
+ * EMPTIED and a known regression reintroduced, because it had no floor. Emptying a roster must cost
+ * a second visible edit. Both directions are floored separately — an all-must-hold corpus measures
+ * only recall and lets the over-block class back in, which is how round 1 of #37 failed.
  */
 test("the signature corpus cannot be quietly emptied or made one-sided", () => {
   assert.ok(SIGNATURE_CORPUS.length >= 40, `corpus has ${SIGNATURE_CORPUS.length} rows; the floor is 40`);
@@ -596,19 +589,13 @@ test("a waived signature does not park the packet", () => {
 });
 
 /**
- * The quote an operator reads is the CLAUSE, not the whole sentence.
- *
- * This is what `clausesOf` is for, and it needs saying because the clause split no longer changes
- * any VERDICT: the per-occurrence governance rule handles mixed polarity on its own, so removing the
- * comma from the splitter leaves every row of the corpus above passing. What it does change is what
- * the freeze shows. "No DCO, contributor agreement required." must point the operator at the six
- * words that assert the CLA, not hand back the whole sentence with the waiver still in it — a quote
- * that contains its own contradiction is the thing a human then has to re-read the document to
- * resolve.
- *
- * Pinned rather than deleted, and pinned rather than left as a survivor: an unpinned redundancy is
- * the shape this repo keeps filing issues about (#75), and the answer is either a reason or a
- * removal. This is the reason.
+ * The quote an operator reads is the CLAUSE, not the whole sentence — which is what `clausesOf` is
+ * for, and worth saying because it no longer changes any VERDICT: per-occurrence governance handles
+ * mixed polarity alone, so dropping the comma from the splitter leaves every corpus row passing.
+ * What it changes is the freeze. "No DCO, contributor agreement required." must point at the six
+ * words asserting the CLA, not a sentence with the waiver still inside it, because a quote holding
+ * its own contradiction sends a human back to the document. An unpinned redundancy is the #75 shape;
+ * the answer is a reason or a removal, and this is the reason.
  */
 test("a mixed-polarity sentence quotes each instrument's own clause, not the whole sentence", () => {
   const s = scanPolicyText("No DCO, contributor agreement required.");

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -507,6 +507,23 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   { doc: "No CLA is discretionary.", want: "required", why: "synonym" },
   { doc: "There is no way around the DCO.", want: "required", why: "paraphrased escape hatch" },
 
+  // --- One verb waives only the instrument it actually reaches. ---
+  //
+  // The active-voice filler was bounded by punctuation, and `and` is not punctuation, so the filler
+  // crossed a conjunction AND another instrument: "We do not require a CLA and a DCO is required."
+  // waived a DCO the sentence demands. A fail-open P1 from review, and the comment above the pattern
+  // claimed it "stops at any clause break" while no test disagreed - a lie with a green suite.
+  { doc: "We do not require a CLA and a DCO is required.", want: "required", why: "#52: one verb cannot waive across a conjunction" },
+  { doc: "We do not require a CLA or a DCO sign-off.", want: "required", why: "object coordination is indistinguishable from statement coordination here, so it holds" },
+  // Two family tokens adjacent, no conjunction between them. This is the row that makes the temper
+  // ANOTHER INSTRUMENT rather than a conjunction: tempering on conjunctions alone waives both here.
+  // A deliberate hold - "a contributor agreement sign-off" may be one thing or two, and which it is
+  // is exactly the guess this scanner stopped making.
+  { doc: "We do not need a contributor agreement sign-off.", want: "required", why: "cross-family adjacency: held, not guessed" },
+  // ...and the shape the filler exists for still waives: an infinitive between verb and instrument.
+  { doc: "We do not need to sign a contributor license agreement.", want: "waived", why: "the infinitive the filler was added for" },
+  { doc: "We do not ask for a contributor agreement.", want: "waived", why: "ask-for phrasing, single instrument" },
+
   // --- Sentences from real CONTRIBUTING documents, quoted. ---
   //
   // Every other row here was invented to probe a rule. These were not: they are verbatim sentences

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -517,6 +517,18 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   // instrument, so these must stay waived or the rule over-blocks ordinary prose.
   { doc: "No CLA is required, required reading is the style guide.", want: "waived", why: "'required reading' modifies a noun" },
   { doc: "No CLA is required, necessary tooling is listed below.", want: "waived", why: "'necessary tooling' modifies a noun" },
+  // "and" is not a clause delimiter, so a coordinated requirement lives INSIDE the waiver's clause,
+  // where the limiter check finds no limiter and the clause-initial anaphora rule cannot see it.
+  // The waiver read as blanket and the repo was ALLOWED while demanding a signature for code.
+  // A P1 from review. The conjunction must be followed DIRECTLY by the predicate, which is what
+  // separates it from "and tests are required" (own subject) and "and no CLA is required" (a second
+  // waiver) - adjacency, not a word list.
+  { doc: "A DCO is not required for documentation and required for code.", want: "required", why: "coordinated requirement, same elided subject" },
+  { doc: "No CLA is required for docs and required for code.", want: "required", why: "same, CLA family" },
+  { doc: "No CLA is required for docs and also required for dependencies.", want: "required", why: "'also' between conjunction and predicate" },
+  { doc: "A CLA is not required for docs or required for tests.", want: "required", why: "'or' coordinates it too" },
+  { doc: "No CLA is required for docs and tests.", want: "waived", why: "'and tests.' is a noun, not a predicate" },
+  { doc: "No CLA is required and reviews are quick.", want: "waived", why: "coordination with its own subject" },
 
   // --- Plain requirements, in the phrasings a real CONTRIBUTING.md uses. ---
   { doc: "Pull requests without a signed Contributor License Agreement will be closed.", want: "required", why: "#50: the phrasing most likely to appear for real" },

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -506,6 +506,17 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   { doc: "No CLA is voluntary.", want: "required", why: "synonym" },
   { doc: "No CLA is discretionary.", want: "required", why: "synonym" },
   { doc: "There is no way around the DCO.", want: "required", why: "paraphrased escape hatch" },
+  // Plural hatch nouns. Review reported these as a fail-open — that the singular-only vocabulary
+  // misses them and the broad `no <instrument>` matcher then reads them as waivers. It does not: the
+  // hatch nouns carry no trailing word boundary, so `exception` already matches inside `exceptions`.
+  // Verified by mutation rather than by argument — deleting a plural group from the pattern changes
+  // no verdict, so there was nothing to add. These rows exist so the claim cannot be made a third
+  // time without a test contradicting it.
+  { doc: "There are no DCO exceptions.", want: "required", why: "plural noun, matched as a prefix" },
+  { doc: "No CLA waivers are available.", want: "required", why: "plural waiver-of-the-waiver" },
+  { doc: "There are no CLA bypasses.", want: "required", why: "-es plural" },
+  { doc: "No DCO exemptions exist.", want: "required", why: "plural exemption" },
+  { doc: "There are no ways around the DCO.", want: "required", why: "plural of the multi-word hatch" },
 
   // --- One verb waives only the instrument it actually reaches. ---
   //

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -450,6 +450,13 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   { doc: "There is no DCO bypass.", want: "required", why: "#52: escape-hatch framing" },
   { doc: "There is no CLA exception for small patches.", want: "required", why: "exception framing" },
   { doc: "No CLA waiver is available.", want: "required", why: "waiver-of-the-waiver" },
+  // Negating a PERMISSION asserts the requirement, and the adjectival forms were missing: they
+  // matched no waiver predicate and no hatch word, so the broad `no <token>` fallback consumed the
+  // mention and the repo reached ALLOW. A P1 from review.
+  { doc: "No CLA is optional.", want: "required", why: "#52: negated permission, adjectival" },
+  { doc: "No DCO is optional.", want: "required", why: "same, DCO family" },
+  { doc: "No CLA is voluntary.", want: "required", why: "synonym" },
+  { doc: "No CLA is discretionary.", want: "required", why: "synonym" },
   { doc: "There is no way around the DCO.", want: "required", why: "paraphrased escape hatch" },
 
   // --- Scoped waivers: it is required somewhere, so it holds. ---
@@ -487,6 +494,15 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   { doc: "No CLA is required. And we are friendly.", want: "waived", why: "conjunction with nothing required after it" },
   { doc: "No CLA is required. However, reviews are quick.", want: "waived", why: "'however' with its own subject" },
   { doc: "No CLA is required.\n- Please read the style guide.", want: "waived", why: "bullet that asserts nothing" },
+  // A continuation can lead with the PREDICATE itself, and then there is no conjunction to find -
+  // the joined fragment brings its full stop instead. Fixing the fragment without fixing the
+  // separator left this reaching ALLOW. A P1 from review.
+  { doc: "No CLA is required for docs.\nRequired for code.", want: "required", why: "predicate-initial continuation" },
+  { doc: "No CLA is required for docs.\n- Required for code.", want: "required", why: "same, behind a bullet" },
+  { doc: "No DCO is needed for docs.\nMandatory for vendored trees.", want: "required", why: "same, other predicate and family" },
+  // ...and the noun-modifier reading is a NEW statement, not a continuation, in both spellings.
+  { doc: "No CLA is required.\nRequired reading is the style guide.", want: "waived", why: "'Required reading' modifies a noun" },
+  { doc: "No CLA is required.\nExpected turnaround is one week.", want: "waived", why: "'Expected turnaround' modifies a noun" },
   // The SAME waiver stated twice, scoped only on the later copy. Position came from asking the
   // sentence where the match was, which answers with the first copy, so the later waiver's forward
   // span was cut at the intervening conjunction and its limiter never seen — ALLOW. Third P1.

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -517,6 +517,13 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   { doc: "There are no CLA bypasses.", want: "required", why: "-es plural" },
   { doc: "No DCO exemptions exist.", want: "required", why: "plural exemption" },
   { doc: "There are no ways around the DCO.", want: "required", why: "plural of the multi-word hatch" },
+  // Inflections, and the reason the hatch words are STEMS. `waiver` did not cover "waived" and
+  // `exemption` did not cover "exempt", so both fell through to the broad `no <instrument>` matcher
+  // and read as waivers - a fail-open P1 from review. The nouns carry no trailing word boundary, so
+  // a stem covers every inflection at once instead of a list that keeps missing one.
+  { doc: "No DCO is waived.", want: "required", why: "#52: inflected hatch, `waive` stem" },
+  { doc: "No CLA is exempt.", want: "required", why: "`exempt` stem, adjective form" },
+  { doc: "No DCO is exempted.", want: "required", why: "same stem, participle" },
 
   // --- One verb waives only the instrument it actually reaches. ---
   //
@@ -538,6 +545,7 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   // second token comes out with the first. A dash separating two statements is not that, and a
   // three-character window ate the requirement behind one: a fail-open P1 from review.
   { doc: "No DCO is required - DCO is required for code.", want: "required", why: "a dash separates statements; it is not a compound noun" },
+  { doc: "No DCO is required-DCO is required for code.", want: "required", why: "same with no spaces: the window is one space and nothing else" },
 
   // --- Sentences from real CONTRIBUTING documents, quoted. ---
   //

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -474,6 +474,19 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   { doc: "No CLA is required for documentation or code except for third-party contributions.", want: "required", why: "'or' coordinates scopes; the exception still applies" },
   { doc: "No DCO is needed for docs or tests, unless vendored.", want: "required", why: "same, with the limiter behind a comma" },
   { doc: "No CLA is required for docs plus tests, other than for dependencies.", want: "required", why: "'plus' coordinates scopes too" },
+  // A comma before the conjunction is NECESSARY for a statement boundary and not sufficient: in a
+  // scope LIST the item is a bare noun phrase closed by the next comma, and truncating there lost
+  // the exception behind it. A P1 from review. A real statement is longer and carries a verb, which
+  // is the test - so the rows below and the two after them are the same rule from both sides.
+  { doc: "No CLA is required for documentation, or code, except for third-party contributions.", want: "required", why: "comma before 'or', but 'code' is scope" },
+  { doc: "No CLA is required for docs, or tests, or code, unless vendored.", want: "required", why: "three-item scope list" },
+  { doc: "No DCO is needed for docs, and tests, other than vendored trees.", want: "required", why: "'and'-joined scope list" },
+  { doc: "No CLA is required for docs, and we review everything except vendored trees.", want: "waived", why: "a verb after the comma makes it a statement" },
+  { doc: "No CLA is required for docs, but the maintainers apply judgement except for forks.", want: "waived", why: "same, contrastive conjunction" },
+  // Both halves of "is this segment a scope item or a statement" earn their keep, and each of these
+  // rows fails without one of them. Short-with-a-verb is a statement; long-without-one is too.
+  { doc: "No CLA is required for docs, and tests apply, except for code.", want: "waived", why: "3 words but a verb: a statement, so the waiver's span ends" },
+  { doc: "No CLA is required for docs, and all other repositories in this organisation, except forks.", want: "waived", why: "verbless but long: also a statement" },
   { doc: "A CLA is not required; except for new dependencies.", want: "required", why: "limiter behind a semicolon" },
   { doc: "Except for new dependencies, a CLA is not required.", want: "required", why: "leading limiter, waiver is the main clause" },
   // ...and it must NOT reach a waiver it has nothing to do with. Reading it from the whole sentence
@@ -507,6 +520,11 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   { doc: "No CLA is required for docs.\nRequired for code.", want: "required", why: "predicate-initial continuation" },
   { doc: "No CLA is required for docs.\n- Required for code.", want: "required", why: "same, behind a bullet" },
   { doc: "No DCO is needed for docs.\nMandatory for vendored trees.", want: "required", why: "same, other predicate and family" },
+  // A continuation can also lead with the COPULA, which the clause-level anaphora matcher already
+  // accepted and this one did not - the two had drifted. A P1 from review.
+  { doc: "No CLA is required for docs. Is required for code.", want: "required", why: "copula-initial continuation" },
+  { doc: "No CLA is required for docs.\n- Is required for code.", want: "required", why: "same, behind a bullet" },
+  { doc: "No DCO is needed for docs. Are required for code.", want: "required", why: "plural copula" },
   // ...and the noun-modifier reading is a NEW statement, not a continuation, in both spellings.
   { doc: "No CLA is required.\nRequired reading is the style guide.", want: "waived", why: "'Required reading' modifies a noun" },
   { doc: "No CLA is required.\nExpected turnaround is one week.", want: "waived", why: "'Expected turnaround' modifies a noun" },

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { test } from "node:test";
 import { hasDerivedFigure, parsePolicyRecords, policyRecordsPath } from "./policy-records.ts";
-import { evaluatePolicy } from "./policy.ts";
+import { evaluatePolicy, scanPolicyText } from "./policy.ts";
 
 test("denylist always forbids matplotlib", () => {
   const v = evaluatePolicy({
@@ -389,4 +389,185 @@ test("deny-by-default covers the no-evidence case, not the missed-ban case", () 
     evaluatePolicy({ repoId: "mcp-use/mcp-use", issueTitle: "docs typo", contributing: "" }).code,
     "DENY_UNKNOWN_POLICY",
   );
+});
+
+/**
+ * ISSUE #52 — the CLA/DCO fail-open, and the corpus that has to keep it closed.
+ *
+ * WHAT WAS BROKEN ON `main`, measured rather than described. All five of the realistic
+ * "waive the DCO, assert the CLA" documents below did produce a hold — and every one of them did it
+ * through `human=["DCO"]`, with nothing matched about the CLA at all. `HUMAN_STATEMENTS` had no bare
+ * `\bcla\b`; its only CLA-acronym patterns were `sign(?:ing)?\s+the\s+cla` and
+ * `\bcla\s+(?:is\s+)?required\b`, both defeated by an interposed "not". So the correct verdict was an
+ * ACCIDENT of an un-negated `\bdco\b` sitting in the same sentence. Making the DCO negation-aware —
+ * which the repo needs, because "No CLA. No DCO. Conventional commits." is the live Wave-1 seed text
+ * and was being parked — removes the accident, and 8 of 10 such documents fail open with nothing to
+ * replace it. That is what happened to the previous attempt.
+ *
+ * Two further holes the same measurement turned up, neither in the issue:
+ *   - "All commits must carry a Signed-off-by line." reached ALLOW with EMPTY matched phrases. A
+ *     plain signature requirement the scanner could not see.
+ *   - "No DCO, contributor agreement required." held only via the DCO accident; the short form
+ *     `contributor agreement` was unmatched.
+ *
+ * CORPUS PROVENANCE, which is the part issue #37's park note says to settle before touching a
+ * regex. Not one row below is derived from a constant in `policy.ts`. They come from: the documents
+ * quoted in #52 and #50, ordinary CONTRIBUTING.md phrasing, and deliberate paraphrase of each into
+ * shapes the implementation does not name. A corpus drawn from the code under test measures whether
+ * the code does what it does.
+ */
+type Polarity = "required" | "waived" | "silent";
+
+const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
+  // --- The five from #52. Each waives one instrument and asserts the other. ---
+  { doc: "We do not require a DCO. You must sign a CLA before your first PR.", want: "required", why: "#52 row 1" },
+  { doc: "No DCO is required. All contributors need a CLA on file.", want: "required", why: "#52 row 2" },
+  { doc: "There is no DCO. Our CLA must be signed before we can merge.", want: "required", why: "#52 row 3" },
+  { doc: "DCO: not required. CLA: required.", want: "required", why: "#52 row 4" },
+  { doc: "No DCO. CLA mandatory.", want: "required", why: "#52 row 5" },
+
+  // --- The comma boundary. One sentence, a waiver and a requirement. ---
+  { doc: "No DCO, contributor agreement required.", want: "required", why: "#52: the comma case a code comment claimed and no test asserted" },
+  { doc: "No CLA, DCO sign-off required.", want: "required", why: "the same shape with the families swapped" },
+  { doc: "CLA required, DCO not required.", want: "required", why: "requirement first, waiver second" },
+  // TWO TOKENS OF ONE FAMILY, waiver first. This is the row that pins the comma in `clausesOf`:
+  // without the split the whole sentence is one clause, the first CLA match is the one inside
+  // "No CLA", its waiver fires, and the requirement later in the sentence is never evaluated —
+  // a fail-open. Every other corpus row survives losing the comma, because the waiver patterns are
+  // token-anchored; this one does not.
+  { doc: "No CLA, a contributor license agreement is required.", want: "required", why: "same family twice, waiver first — pins the comma split" },
+
+  // --- Blanket waivers. These must NOT hold: over-blocking parks a legitimate packet. ---
+  { doc: "No CLA. No DCO. Conventional commits.", want: "waived", why: "the live Wave-1 seed text, parked on main" },
+  { doc: "No DCO is required.", want: "waived", why: "blanket waiver with the requirement word inside it" },
+  { doc: "A CLA is not required.", want: "waived", why: "post-token negation" },
+  { doc: "We do not require a CLA.", want: "waived", why: "active-voice waiver" },
+  { doc: "We don't require a DCO sign-off on contributions.", want: "waived", why: "#52 names this as forced by cla|dco in the filler" },
+  { doc: "There is no DCO.", want: "waived", why: "existential waiver" },
+  { doc: "There is no CLA to sign.", want: "waived", why: "#52 predicted this would flip to a hold; waiver-first ordering keeps it" },
+  { doc: "Contributors do not need to sign a contributor license agreement.", want: "waived", why: "spelled-out form, waived" },
+  { doc: "No contributor agreement is necessary.", want: "waived", why: "short form, alternate requirement word" },
+  { doc: "We will not ask for a CLA.", want: "waived", why: "future-tense waiver" },
+  // The scope limiter is read from the SENTENCE, so the sentence boundary has to be real. Without
+  // it the whole document is one span, this "except" — which is about spam, not about the CLA —
+  // reaches the waiver, and a blanket waiver reads as scoped. Fail-closed rather than fail-open, but
+  // it parks a legitimate packet, which is the over-block half of this issue.
+  { doc: "No CLA is required. All patches are welcome, except spam.", want: "waived", why: "an 'except' in a LATER sentence must not scope this waiver — pins the sentence splitter" },
+
+  // --- Escape-hatch denials. "no X bypass" asserts X, it does not waive it. ---
+  { doc: "There is no DCO bypass.", want: "required", why: "#52: escape-hatch framing" },
+  { doc: "There is no CLA exception for small patches.", want: "required", why: "exception framing" },
+  { doc: "No CLA waiver is available.", want: "required", why: "waiver-of-the-waiver" },
+  { doc: "There is no way around the DCO.", want: "required", why: "paraphrased escape hatch" },
+
+  // --- Scoped waivers: it is required somewhere, so it holds. ---
+  { doc: "A CLA is not required except for new dependencies.", want: "required", why: "#50 comment: scoped waiver" },
+  { doc: "No DCO is needed unless you are adding a new module.", want: "required", why: "unless-scoped" },
+  // The limiter across a clause boundary. The first draft of `signaturePolarity` read the limiter
+  // from the CLAUSE, so a comma before "except" hid it and a scoped requirement came out a blanket
+  // waiver — this issue's own fail-open class, reproduced inside its fix and caught before shipping.
+  { doc: "A CLA is not required, except for new dependencies.", want: "required", why: "limiter behind a comma" },
+  { doc: "No DCO is needed, unless you are adding a new module.", want: "required", why: "limiter behind a comma" },
+  { doc: "No CLA is required, other than for vendored code.", want: "required", why: "limiter behind a comma" },
+  { doc: "A CLA is not required; except for new dependencies.", want: "required", why: "limiter behind a semicolon" },
+
+  // --- Plain requirements, in the phrasings a real CONTRIBUTING.md uses. ---
+  { doc: "Pull requests without a signed Contributor License Agreement will be closed.", want: "required", why: "#50: the phrasing most likely to appear for real" },
+  { doc: "We require a DCO sign-off.", want: "required", why: "plain DCO requirement" },
+  { doc: "All commits must carry a Signed-off-by line.", want: "required", why: "reached ALLOW on main with empty phrases" },
+  { doc: "Please sign the CLA before opening a pull request.", want: "required", why: "imperative" },
+  { doc: "Every contributor must sign our Contributor Licence Agreement.", want: "required", why: "British spelling of licence" },
+  { doc: "Contributions are accepted once the CLA is on file.", want: "required", why: "on-file phrasing" },
+  { doc: "You will be asked to sign a contributor agreement by our CLA bot.", want: "required", why: "bot-mediated" },
+  { doc: "The Developer Certificate of Origin applies to all patches.", want: "required", why: "spelled-out DCO, no requirement verb but an assertion" },
+  { doc: "Sign-off is mandatory for every commit.", want: "required", why: "sign-off as the subject" },
+  { doc: "We cannot merge your work until the CLA is signed.", want: "required", why: "cannot-merge framing" },
+  { doc: "Your PR will not be reviewed without a DCO sign-off.", want: "required", why: "'without' is a requirement context, never a waiver" },
+
+  // --- No signature instrument at all. These must be SILENT: matching them is the over-block. ---
+  { doc: "you signal your agreement with the Code of Conduct", want: "silent", why: "#52 mutation 2: a bare /agreement/i would hold this" },
+  { doc: "By contributing you agree to the terms of the licence.", want: "silent", why: "agree + licence, no instrument" },
+  { doc: "Please be kind in code review.", want: "silent", why: "ordinary prose" },
+  { doc: "Run the linter before submitting.", want: "silent", why: "a 'before submitting' with no instrument" },
+  { doc: "Squash your commits and sign your work with a clear message.", want: "silent", why: "'sign your work' without naming DCO or a sign-off line" },
+  { doc: "This project uses a licence agreement with its vendors.", want: "silent", why: "'licence agreement' without 'contributor'" },
+  { doc: "Maintainers must review every pull request.", want: "silent", why: "a human gate, but not a signature — HOLD_HUMAN's territory" },
+  { doc: "Documentation changes need no special treatment.", want: "silent", why: "'need no' with no instrument" },
+
+  // --- The documented cost of failing closed on an undecided mention. ---
+  { doc: "See our CLA for details.", want: "required", why: "undecided reads as required: a false hold costs one look, a false allow forges a signature" },
+  { doc: "We dropped the CLA requirement.", want: "required", why: "same fail-closed default; a phrasing the waiver list does not name" },
+];
+
+test("the signature corpus classifies every phrasing correctly, in both directions", () => {
+  const wrong: string[] = [];
+  for (const { doc, want, why } of SIGNATURE_CORPUS) {
+    const s = scanPolicyText(doc);
+    const got: Polarity =
+      s.signatureRequired.length > 0 ? "required" : s.signatureWaived.length > 0 ? "waived" : "silent";
+    if (got !== want) wrong.push(`want ${want}, got ${got}: ${JSON.stringify(doc)} (${why})`);
+  }
+  assert.deepEqual(wrong, [], `\n${wrong.join("\n")}`);
+});
+
+/**
+ * Size floors, and they are not decoration. Issue #37's round 3 shipped `suite ok`, exit 0, with its
+ * headline corpus EMPTIED and a known regression reintroduced, because `CORPUS` had no floor while
+ * `LEXICON` did. Emptying a roster has to cost a second visible edit.
+ *
+ * Both directions are floored separately, because a corpus that is all must-hold rows measures only
+ * recall and would let the over-block class back in — which is how round 1 of #37 failed.
+ */
+test("the signature corpus cannot be quietly emptied or made one-sided", () => {
+  assert.ok(SIGNATURE_CORPUS.length >= 40, `corpus has ${SIGNATURE_CORPUS.length} rows; the floor is 40`);
+  const count = (p: Polarity) => SIGNATURE_CORPUS.filter((r) => r.want === p).length;
+  assert.ok(count("required") >= 15, `only ${count("required")} must-hold rows`);
+  assert.ok(count("waived") >= 10, `only ${count("waived")} must-waive rows`);
+  assert.ok(count("silent") >= 6, `only ${count("silent")} must-be-silent rows`);
+  // Distinct documents: duplicating one row must not be a way to satisfy the floor.
+  assert.equal(new Set(SIGNATURE_CORPUS.map((r) => r.doc)).size, SIGNATURE_CORPUS.length, "corpus holds duplicate documents");
+});
+
+/**
+ * The verdict CODE, not just the polarity. #52's acceptance is that these hold as `HOLD_CLA`, and
+ * the code used to be re-derived by substring-testing the matched phrase for "cla", "dco" or
+ * "certificate" — which is why "Contributor License Agreement" landed in `HOLD_HUMAN`: those three
+ * letters never appear consecutively in it (issue #50's root cause, reached from here).
+ */
+test("an asserted signature holds as HOLD_CLA, and a human-review gate stays HOLD_HUMAN", () => {
+  for (const doc of SIGNATURE_CORPUS.filter((r) => r.want === "required").map((r) => r.doc)) {
+    const v = evaluatePolicy({ repoId: "mcp-use/mcp-use", contributing: doc, issueTitle: "docs fix" });
+    assert.equal(v.code, "HOLD_CLA", `${JSON.stringify(doc)} produced ${v.code}`);
+  }
+  // The spelled-out phrasing specifically, called out by name in #50.
+  const spelled = evaluatePolicy({
+    repoId: "mcp-use/mcp-use",
+    contributing: "Pull requests without a signed Contributor License Agreement will be closed.",
+    issueTitle: "docs fix",
+  });
+  assert.equal(spelled.code, "HOLD_CLA");
+
+  // A human gate that is not a signature keeps its own code: erasing the distinction is #52's
+  // third mutation, and the codes are not cosmetic — HOLD_CLA carries "never forge".
+  const review = evaluatePolicy({
+    repoId: "mcp-use/mcp-use",
+    contributing: "Every pull request must be reviewed by a human maintainer.",
+    issueTitle: "docs fix",
+  });
+  assert.equal(review.code, "HOLD_HUMAN");
+});
+
+test("a waived signature does not park the packet", () => {
+  // The over-block half. This exact string is the live Wave-1 packet's policy text.
+  const v = evaluatePolicy({
+    repoId: "ravidsrk/orca-fleet",
+    contributing: "No CLA. No DCO. Conventional commits.",
+    issueTitle: "[P2] CHANGELOG Unreleased",
+  });
+  assert.equal(v.code, "ALLOW", `${v.code}: ${v.matchedPhrases.join(" | ")}`);
+  // ...and the read is still visible: the waiver is reported, not silently dropped, so a freeze can
+  // show the operator what was read and dismissed rather than an unexplained absence.
+  const scanned = scanPolicyText("No CLA. No DCO. Conventional commits.");
+  assert.equal(scanned.signatureWaived.length, 2, JSON.stringify(scanned));
+  assert.equal(scanned.signatureRequired.length, 0);
 });

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -613,20 +613,34 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   // ...and the noun-modifier reading is a NEW statement, not a continuation, in both spellings.
   { doc: "No CLA is required.\nRequired reading is the style guide.", want: "waived", why: "'Required reading' modifies a noun" },
   { doc: "No CLA is required.\nExpected turnaround is one week.", want: "waived", why: "'Expected turnaround' modifies a noun" },
-  // The word between predicate and scope is a CLOSED set of adverbs. It was any word once, so
-  // "It is required reading for new contributors." read as a requirement and held a repository that
-  // waives the CLA outright - a fail-closed P1 from review. `reading` is a noun the predicate
-  // modifies, not an adverb qualifying it, and only the copula branch was missing the guard.
-  { doc: "No CLA is required. It is required reading for new contributors.", want: "waived", why: "copula + noun modifier asserts nothing" },
-  { doc: "No CLA is required. It is required knowledge for reviewers.", want: "waived", why: "same shape, other noun" },
-  { doc: "No DCO is needed.\n- It is expected practice in this organisation.", want: "waived", why: "same, behind a bullet" },
+  // These four now hold for a DIFFERENT reason than when they were written. They arrived as
+  // fail-closed rows: `SCOPE_FOLLOWS` let any word sit between predicate and scope, so "required
+  // reading for contributors" read as a requirement. That fix stands and is still pinned by the
+  // pronoun-free rows below it. But a later P1 - "It applies to code, except for vendored trees." -
+  // showed a pronoun clause can qualify a waiver with no predicate at all, and resolving what `it`
+  // names is coreference. So a pronoun clause in a waiver's sentence holds, and these hold with it.
+  { doc: "No CLA is required. It is required reading for new contributors.", want: "required", why: "held: what `It` names is coreference, not something a regex resolves" },
+  { doc: "No CLA is required. It is required knowledge for reviewers.", want: "required", why: "same, held for the pronoun not the noun" },
+  { doc: "No DCO is needed.\n- It is expected practice in this organisation.", want: "required", why: "same, behind a bullet" },
   // ...and the real copula requirement, which shares every word except the noun, must still hold.
   { doc: "No CLA is required. It is required for code.", want: "required", why: "copula requirement, scope follows directly" },
   { doc: "No CLA is required. It is needed only for release.", want: "required", why: "closed-set qualifier between predicate and scope" },
   // Same shapes with the anaphor in the SAME sentence as its antecedent, which is the only place the
   // clause-level matcher can reach: across a sentence boundary the fragment has no antecedent to
   // attach to, so a row split by a full stop leaves that matcher untested.
-  { doc: "No CLA is required, it is required reading for new contributors.", want: "waived", why: "same-sentence copula + noun modifier" },
+  { doc: "No CLA is required, it is required reading for new contributors.", want: "required", why: "same-sentence pronoun clause" },
+  // The P1 that established the rule, and the reason it is not a vocabulary of verbs: after joining,
+  // "It applies to code." asserts a requirement with no predicate this file knows. Both the limiter
+  // variant and the bare one hold, so no `applies|covers|extends` roster was needed.
+  { doc: "No CLA is required for docs. It applies to code, except for vendored trees.", want: "required", why: "#52: pronoun continuation carrying a limiter" },
+  { doc: "No CLA is required for docs. It applies to code.", want: "required", why: "same, with no limiter and no known predicate" },
+  { doc: "No CLA is required for docs.\n- This covers code.", want: "required", why: "same, demonstrative behind a bullet" },
+  // The bound on that rule: a pronoun used as an OBJECT qualifies nothing, so it must not hold. The
+  // rule needs a pronoun followed by something - a clause - not a pronoun anywhere in the sentence.
+  { doc: "No CLA is required for that.", want: "waived", why: "'that' is an object here, not a subject asserting anything" },
+  // ...and the closed qualifier set still earns its keep with no pronoun in sight: reopening it to
+  // any word makes this join and read as a requirement, which is the fail-closed it was added for.
+  { doc: "No CLA is required. Required reading for contributors.", want: "waived", why: "'reading' is a noun, not an adverb before the scope" },
   { doc: "No CLA is required, it is required for code.", want: "required", why: "same-sentence copula requirement" },
   // The SAME waiver stated twice, scoped only on the later copy. Position came from asking the
   // sentence where the match was, which answers with the first copy, so the later waiver's forward

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -474,6 +474,14 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   { doc: "No DCO is needed, and we review everything except vendored trees.", want: "waived", why: "the 'except' is about review scope" },
   { doc: "No CLA. Reviews are quick, except during release weeks.", want: "waived", why: "limiter in a later sentence about something else" },
 
+  // ANAPHORA. A P1 from review: the requirement's subject is elided, so it lands in a clause with no
+  // instrument token and the per-clause pass skipped it, recording only the waiver.
+  { doc: "A CLA is not required for documentation, but is required for code contributions.", want: "required", why: "elided subject after 'but'" },
+  { doc: "No DCO is needed for docs, but is required for code.", want: "required", why: "same shape, DCO family" },
+  { doc: "A CLA is not required, however it is mandatory for vendored trees.", want: "required", why: "'it is mandatory' after 'however'" },
+  // ...and a later clause with its OWN subject must not flip anything, or the rule over-blocks.
+  { doc: "No CLA is required, and tests are required.", want: "waived", why: "'tests' is the subject, not the CLA" },
+
   // --- Plain requirements, in the phrasings a real CONTRIBUTING.md uses. ---
   { doc: "Pull requests without a signed Contributor License Agreement will be closed.", want: "required", why: "#50: the phrasing most likely to appear for real" },
   { doc: "We require a DCO sign-off.", want: "required", why: "plain DCO requirement" },

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -475,6 +475,18 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   { doc: "No DCO is needed. Unless you are adding a new module.", want: "required", why: "same, with a subject inside the fragment" },
   { doc: "No CLA is required. Other than for vendored trees.", want: "required", why: "multi-word limiter, sentence-initial" },
   { doc: "No CLA is required. Reviews are quick.", want: "waived", why: "next sentence is not a limiter at all" },
+  // The same defect at three more punctuations, all P1s from review: a continuation is not a new
+  // statement. A conjunction-initial fragment carries the REQUIREMENT rather than the scope, and a
+  // markdown list marker hid both - including an ordered marker, which the boundary rule splits off
+  // as its own fragment so that it stood between the waiver and its scope.
+  { doc: "A CLA is not required for documentation. But is required for code.", want: "required", why: "conjunction-initial requirement fragment" },
+  { doc: "No CLA is required.\n- Except for code contributions.", want: "required", why: "limiter behind a markdown bullet" },
+  { doc: "No CLA is required.\n1. Except for code.", want: "required", why: "ordered marker, split off on its own" },
+  { doc: "No CLA is required.\n> But required for code.", want: "required", why: "blockquote marker" },
+  // ...and a conjunction that asserts nothing must still not flip the waiver.
+  { doc: "No CLA is required. And we are friendly.", want: "waived", why: "conjunction with nothing required after it" },
+  { doc: "No CLA is required. However, reviews are quick.", want: "waived", why: "'however' with its own subject" },
+  { doc: "No CLA is required.\n- Please read the style guide.", want: "waived", why: "bullet that asserts nothing" },
   // The SAME waiver stated twice, scoped only on the later copy. Position came from asking the
   // sentence where the match was, which answers with the first copy, so the later waiver's forward
   // span was cut at the intervening conjunction and its limiter never seen — ALLOW. Third P1.

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -529,6 +529,7 @@ const SIGNATURE_CORPUS: { doc: string; want: Polarity; why: string }[] = [
   { doc: "No DCO is ever waived.", want: "required", why: "#52: adverb before the hatch word" },
   { doc: "No CLA is simply optional.", want: "required", why: "same, adjectival hatch" },
   { doc: "No DCO is under any circumstances waived.", want: "required", why: "three words in the slot" },
+  { doc: "No DCO is under any and all circumstances waived.", want: "required", why: "five words: the slot is unbounded, because any cap invites the next one" },
   { doc: "No CLA is needed.", want: "waived", why: "the slot cannot over-match: `needed` sits where a hatch word would and is not one" },
   // REBUTTED, and pinned so it cannot be reported a third time: review reported that two spaces
   // between a waiver and a same-family requirement let the absorption window eat the requirement.
@@ -855,6 +856,10 @@ test("no adversarial document can hang the signature scanner", () => {
     ["waiver repeated across sentences", "No CLA is required. ".repeat(2000)],
     ["markdown bullet repetition", "- No CLA is required\n".repeat(2000)],
     ["limiter repetition", `No CLA is required ${"except ".repeat(2000)}`],
+    // The escape hatch's modifier slot is unbounded, so it gets its own shapes: a long run that does
+    // reach a hatch word, and a longer one that never does and must fail without backtracking.
+    ["long run reaching a hatch word", `No DCO is ${"very ".repeat(500)}waived.`],
+    ["long run reaching nothing", `No DCO is ${"very ".repeat(2000)}required.`],
   ];
   for (const [name, doc] of documents) {
     const started = performance.now();

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -140,10 +140,37 @@ function signaturePolarity(clause: string, sentence: string, token: string): "re
     String.raw`\bno\s+${T}\b`,
   ];
   for (const w of waivers) {
-    if (!new RegExp(w, "i").test(clause)) continue;
+    const hit = new RegExp(w, "i").exec(clause);
+    if (!hit) continue;
     // A scoped waiver is a requirement wearing a waiver's clothes: "not required EXCEPT for new
     // dependencies" means a packet touching one needs it. Read from the sentence, not the clause.
-    return SCOPE_LIMITER.test(sentence) ? "required" : "waived";
+    if (SCOPE_LIMITER.test(sentence)) return "required";
+    /**
+     * A WAIVER GOVERNS ONLY THE OCCURRENCE IT NAMES. Raised as P1 by review: polarity was decided
+     * once for the whole clause from the FIRST match, so
+     *
+     *   "No CLA is required for documentation and a CLA is required for code contributions."
+     *
+     * matched the waiver, never looked at the second occurrence, and reached ALLOW for a repository
+     * that requires a signature. "and" is not a clause delimiter and should not have to be: taking
+     * the waived text out and asking whether the instrument is still mentioned answers it without
+     * guessing at English conjunctions. Any surviving mention is an occurrence no waiver spoke for,
+     * and under this repo's asymmetry that reads as required.
+     */
+    /**
+     * One instrument can be NAMED TWICE in a row — "a DCO sign-off" is a single thing, and both
+     * "DCO" and "sign-off" are DCO-family tokens. So a mention abutting the waiver's own span is
+     * absorbed into it before the leftovers are inspected; without that,
+     * "We don't require a DCO sign-off on contributions." saw "sign-off" as an ungoverned second
+     * occurrence and flipped a plain waiver into a hold.
+     */
+    let tail = clause.slice(hit.index + hit[0].length);
+    for (let abut = new RegExp(String.raw`^[\s\-]{0,3}${T}`, "i").exec(tail); abut; ) {
+      tail = tail.slice(abut[0].length);
+      abut = new RegExp(String.raw`^[\s\-]{0,3}${T}`, "i").exec(tail);
+    }
+    if (new RegExp(T, "i").test(`${clause.slice(0, hit.index)} ${tail}`)) return "required";
+    return "waived";
   }
   /**
    * Undecided reads as REQUIRED, which is the repo's stated asymmetry rather than a shrug: a false

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -74,8 +74,21 @@ const ANY_INSTRUMENT = `(?:${SIGNATURE_FAMILIES.map(({ token }) => token).join("
  * a PERMISSION is asserting the requirement — the same sentence as "no CLA waiver is available",
  * written with an adjective instead of a noun, which is why they share this check rather than
  * getting a rule of their own.
+ *
+ * An adverb may stand between the copula and the hatch word — "No DCO is ever waived.", "No CLA is
+ * simply optional." — which a P1 from review found falling through to the broad `no <instrument>`
+ * matcher. The slot is any word rather than a roster, because it is only reachable when a hatch word
+ * follows it: "No CLA is needed." puts `needed` where the hatch word would be, matches nothing here,
+ * and stays a waiver. An open slot in front of a required anchor cannot over-match.
+ *
+ * KNOWN LIMIT, found while fixing the above and not reported: an aside with commas — "No CLA is,
+ * under our policy, optional." — still reads as a waiver, because the comma defeats the copula and
+ * `clausesOf` has already split the clause at it. Reading the hatch from the whole sentence was tried
+ * and measured: zero corpus change and it does not fix this either, so it was not taken. Closing it
+ * needs punctuation tolerance inside the copula, which is one more widening in a pattern that has
+ * produced a new gap for every widening so far. Recorded rather than fixed, and rather than hidden.
  */
-const ESCAPE_HATCH = String.raw`(?:is\s+|are\s+)?(?:bypass|except|exempt|waive|opt[-\s]?out|workaround|ways?\s+around|optional|voluntary|discretionary|up\s+to\s+you|at\s+your\s+discretion)`;
+const ESCAPE_HATCH = String.raw`(?:is\s+|are\s+)?(?:\w+\s+){0,4}?(?:bypass|except|exempt|waive|opt[-\s]?out|workaround|ways?\s+around|optional|voluntary|discretionary|up\s+to\s+you|at\s+your\s+discretion)`;
 
 /** Words that turn a waiver into a conditional requirement: it IS required, somewhere. */
 const SCOPE_LIMITER = /\b(?:except|unless|other\s+than|apart\s+from|save\s+for)\b/i;

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -78,6 +78,17 @@ const ESCAPE_HATCH = String.raw`(?:is\s+|are\s+)?(?:bypass|exception|exemption|w
 const SCOPE_LIMITER = /\b(?:except|unless|other\s+than|apart\s+from|save\s+for)\b/i;
 
 /**
+ * ONE conjunction roster, because there were five hand-written copies and a P1 from review found
+ * `yet` missing from all of them. Adding the word to five places would have left the sixth.
+ *
+ * Deliberately NOT split into contrastive and coordinating words. That distinction was written here
+ * and then deleted: a mutant merging the two changed no verdict across every enumeration on this
+ * branch, because a comma already ends the clause wherever one of these words starts a new statement,
+ * and `COORDINATED` already reads the ones that do not. An unfalsifiable rule is worse than none.
+ */
+const CONJUNCTION_WORDS = String.raw`(?:and|or|plus|but|however|yet|though|although|whereas|while|nevertheless|nonetheless)`;
+
+/**
  * The words a requirement is asserted WITH, when its subject has been elided.
  *
  * ONE roster, because there were two and they drifted: the waiver patterns knew `expected` and this
@@ -165,10 +176,25 @@ function signaturePolarity(clause: string, clauseAt: number, sentence: string, t
      * the limiter behind it was never in view, and a scoped requirement reached ALLOW. Third P1 from
      * review, and the third wrong span for this one decision.
      */
-    for (const span of spans) {
+    {
+      // ANY occurrence in the clause will do, and this is the one place that deserves a note saying
+      // so, because a loop over all of them lived here first.
+      //
+      // A clause holds no comma or semicolon — those are what split it — so every occurrence inside
+      // it shares one downstream truncation point. `forward` therefore covers the clause from an
+      // occurrence rightwards and `leading` covers it leftwards, and between them the pair sees the
+      // whole clause from either end. Picking the earliest, the latest, or the first match found all
+      // give the same verdict; that was measured across every enumeration here, in both directions,
+      // rather than reasoned about and hoped for.
+      const span = spans[0]!;
       const at = clauseAt + span.at;
       const after = sentence.slice(at + span.length);
-      const conjunction = after.search(/\b(?:and|or|but|however)\b/i);
+      // A conjunction ends this statement only where it BEGINS a clause, which is where a comma
+      // or semicolon puts it. Truncating at any conjunction cut "for documentation or code except
+      // for third-party contributions" at the `or` — a scope coordination, not a new statement —
+      // and lost the exception behind it: a P1 from review, and the fail-open mirror of the
+      // over-block that put truncation here in the first place.
+      const conjunction = after.search(new RegExp(String.raw`[,;]\s*${CONJUNCTION_WORDS}\b`, "i"));
       const forward = conjunction === -1 ? after : after.slice(0, conjunction);
       const leading = at > 0 && SCOPE_LIMITER.test(sentence.slice(0, at).replace(/^[\s"'(\[]*/, "").split(/[,;]/)[0] ?? "");
       if (SCOPE_LIMITER.test(forward) || leading) return "required";
@@ -193,7 +219,7 @@ function signaturePolarity(clause: string, clauseAt: number, sentence: string, t
     // "No CLA is required for docs. Required for code." has no conjunction to find. A P1 from review
     // reached ALLOW on exactly that, the fix for the fragment having stopped one step short.
     // A list marker may stand after the separator too, since the joined fragment keeps its bullet.
-    const COORDINATED = String.raw`(?:\b(?:and|or|but|however)\s+|[.;:]\s+)(?:(?:[-*+>]|\d+[.)])\s*)?(?:(?:it|they)\s+)?(?:is|are)?\s*(?:also\s+)?(?:still\s+)?${PREDICATE}\b${SCOPE_FOLLOWS}`;
+    const COORDINATED = String.raw`(?:\b${CONJUNCTION_WORDS}\s+|[.;:]\s+)(?:(?:[-*+>]|\d+[.)])\s*)?(?:(?:it|they)\s+)?(?:is|are)?\s*(?:also\s+)?(?:still\s+)?${PREDICATE}\b${SCOPE_FOLLOWS}`;
     if (new RegExp(COORDINATED, "i").test(clause)) {
       return "required";
     }
@@ -268,7 +294,7 @@ function signaturePolarity(clause: string, clauseAt: number, sentence: string, t
  * guide.", where the participle modifies a noun and the sentence genuinely is a new statement.
  */
 const CONTINUATION = new RegExp(
-  String.raw`^(?:[-*+>]|\d+[.)])?[\s"'(\[]*(?:(?:${SCOPE_LIMITER.source.replace(/^\\b|\\b$/g, "")}|and|or|but|however)\b|${PREDICATE}\b${SCOPE_FOLLOWS})`,
+  String.raw`^(?:[-*+>]|\d+[.)])?[\s"'(\[]*(?:(?:${SCOPE_LIMITER.source.replace(/^\\b|\\b$/g, "")}|${CONJUNCTION_WORDS})\b|${PREDICATE}\b${SCOPE_FOLLOWS})`,
   "i",
 );
 
@@ -308,7 +334,7 @@ function sentencesOf(text: string): string[] {
 function clausesOf(sentence: string): { text: string; at: number }[] {
   const out: { text: string; at: number }[] = [];
   let cursor = 0;
-  for (const part of sentence.split(/[,;]|\bbut\b|\bhowever\b/i)) {
+  for (const part of sentence.split(/[,;]/)) {
     const text = part.trim();
     if (!text) continue;
     // Only the splitting delimiter lies between `cursor` and this clause, so the first match from
@@ -359,7 +385,7 @@ export function scanPolicyText(text: string): {
      * signature for code: a P1 from review, and this issue's fail-open class again. `SCOPE_FOLLOWS`
      * is what keeps a bare participle from matching a noun modifier.
      */
-    const CONJUNCTION = String.raw`(?:(?:and|or|but|however)\s+)?`;
+    const CONJUNCTION = String.raw`(?:${CONJUNCTION_WORDS}\s+)?`;
     const anaphoric = parts.some(
       ({ text: c }) =>
         (new RegExp(String.raw`^${CONJUNCTION}(?:is|are|it\s+is|they\s+are)\s+(?:still\s+)?${PREDICATE}\b`, "i").test(c) ||

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -211,11 +211,31 @@ export function scanPolicyText(text: string): {
     if (m) humanReview.push(quoteOf(m));
   }
   for (const sentence of sentencesOf(text)) {
-    for (const clause of clausesOf(sentence)) {
+    const parts = clausesOf(sentence);
+    /**
+     * An ANAPHORIC requirement: a clause that asserts one while naming no instrument, because its
+     * subject was elided and is the instrument named earlier —
+     *
+     *   "A CLA is not required for documentation, but is required for code contributions."
+     *
+     * The requirement lands in a clause with no token, so the per-clause pass skipped it and only
+     * the waiver was recorded. P1 from review.
+     *
+     * The clause must START with the verb, which is what elision looks like. "and tests are
+     * required" has its own subject and must NOT flip the CLA — testing for the keywords alone
+     * would over-block that, and over-blocking parks a legitimate packet.
+     */
+    const anaphoric = parts.some(
+      (c) =>
+        /^(?:is|are|it\s+is|they\s+are)\s+(?:still\s+)?(?:required|needed|necessary|mandatory|obligatory|compulsory)\b/i.test(c) &&
+        !SIGNATURE_FAMILIES.some(({ token }) => new RegExp(token, "i").test(c)),
+    );
+    for (const clause of parts) {
       for (const { family, token } of SIGNATURE_FAMILIES) {
         if (!new RegExp(token, "i").test(clause)) continue;
         const quote = `${family}: ${clause.replace(/\s+/g, " ").trim().slice(0, 140)}`;
-        if (signaturePolarity(clause, sentence, token) === "required") signatureRequired.push(quote);
+        const polarity = signaturePolarity(clause, sentence, token);
+        if (polarity === "required" || anaphoric) signatureRequired.push(quote);
         else signatureWaived.push(quote);
       }
     }

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -118,19 +118,13 @@ function signaturePolarity(clause: string, sentence: string, token: string): "re
     const hit = new RegExp(w, "i").exec(clause);
     if (!hit) continue;
     /**
-     * A scoped waiver is a requirement in a waiver's clothes: "not required EXCEPT for new
-     * dependencies" means a packet touching one needs it. But the limiter has to belong to THIS
-     * waiver, and both ways of getting that wrong are fail-modes this branch actually shipped:
-     *
-     * - Reading it from the CLAUSE missed "A CLA is not required, except for new dependencies.",
-     *   because the limiter sits in the next clause. Fail-open.
-     * - Reading it from the whole SENTENCE over-blocked "No CLA is required, and all patches are
-     *   welcome except spam", where the "except" is about spam. Fail-closed, and it parks a packet
-     *   whose policy waives the CLA in as many words. Raised as P1 by review.
-     *
-     * So the span is the waiver's own statement: its clause, plus what follows the waiver up to the
-     * first coordinating conjunction — a limiter past an "and" belongs to a different statement —
-     * plus a leading "Except for X, ..." that the waiver is the main clause of.
+     * A scoped waiver is a requirement in a waiver's clothes. The limiter must belong to THIS
+     * waiver, and both wrong spans shipped here: the CLAUSE missed "A CLA is not required, except
+     * for new dependencies." (fail-open), the whole SENTENCE reclassified "No CLA is required, and
+     * all patches are welcome except spam", where the except is about spam (fail-closed, parking a
+     * packet that waives the CLA outright — P1 from review). So the span is the waiver's own
+     * statement: its clause, what follows up to the first coordinating conjunction, and a leading
+     * "Except for X, ..." it is the main clause of.
      */
     const at = sentence.toLowerCase().indexOf(hit[0].toLowerCase());
     const after = at === -1 ? "" : sentence.slice(at + hit[0].length);

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -59,10 +59,25 @@ const HUMAN_REVIEW_STATEMENTS: RegExp[] = [
  * phrases — a real signature requirement the scanner could not see at all.
  */
 const SIGNATURE_FAMILIES: { family: string; token: string }[] = [
-  { family: "CLA", token: String.raw`(?:\bcla\b|contributor\s+licen[cs]e\s+agreement|contributor\s+agreement)` },
+  /**
+   * The acronyms are PLURAL-TOLERANT, and that was a P1 fail-open in the first version of this
+   * change: `\bcla\b` does not match `CLAs`, so "No DCO. CLAs are mandatory." waived the DCO, saw
+   * nothing about the CLA, and reached ALLOW for a repository that demands a signature — the exact
+   * defect this issue exists to close, reintroduced in its own fix in a new spelling. Measured:
+   * "CLAs are required for all contributors." and "We require DCOs on every commit." were both
+   * SILENT, matching nothing at all.
+   *
+   * `\bclas?\b` cannot match "class": the optional `s` still needs a word boundary after it, and
+   * "class" has another letter there. The spelled-out forms already matched inside their own plurals
+   * by substring; the explicit `s?` says so rather than leaving it to be rediscovered.
+   */
+  {
+    family: "CLA",
+    token: String.raw`(?:\bclas?\b|contributor\s+licen[cs]e\s+agreements?|contributor\s+agreements?)`,
+  },
   {
     family: "DCO",
-    token: String.raw`(?:\bdco\b|developer\s+certificate\s+of\s+origin|signed[-\s]?off[-\s]?by|sign[-\s]?offs?\b)`,
+    token: String.raw`(?:\bdcos?\b|developer\s+certificates?\s+of\s+origin|signed[-\s]?off[-\s]?by|sign[-\s]?offs?\b)`,
   },
 ];
 

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -128,13 +128,29 @@ const SCOPE_FOLLOWS = String.raw`(?=\s*(?:$|[.;,]|(?:${QUALIFIER}\s+)?(?:for|on|
  */
 const FINITE_VERB = /\b(?:is|are|was|were|be|been|being|has|have|had|do|does|did|will|would|can|could|may|might|must|should|shall|need|needs|require|requires|review|reviews|accept|accepts|welcome|apply|applies|ask|asks|expect|expects)\b/i;
 
-function truncateAtStatement(after: string): string {
-  const boundary = new RegExp(String.raw`[,;]\s*${CONJUNCTION_WORDS}\b`, "gi");
+function truncateAtStatement(after: string, token: string): string {
+  const boundary = new RegExp(String.raw`\b${CONJUNCTION_WORDS}\b`, "gi");
   for (let hit = boundary.exec(after); hit; hit = boundary.exec(after)) {
-    const segment = after.slice(hit.index + hit[0].length).split(/[,;.]/)[0] ?? "";
+    // What the conjunction introduces, up to the next punctuation OR the next limiter — whichever
+    // comes first. Stopping at the limiter is what keeps "or code except for third-party
+    // contributions" from reading as a six-word statement: the item is "code".
+    const rest = after.slice(hit.index + hit[0].length);
+    const end = rest.search(/[,;.]/);
+    const lim = rest.search(SCOPE_LIMITER);
+    const cut = [end, lim].filter((n) => n >= 0);
+    const segment = cut.length > 0 ? rest.slice(0, Math.min(...cut)) : rest;
     const words = segment.trim().split(/\s+/).filter(Boolean);
-    // A scope item: short, and asserting nothing. Keep looking for a real statement boundary.
+    // A scope item is short and asserts nothing. Anything else is a new statement, and the waiver's
+    // own span ends there. Punctuation is NOT part of this test: "No CLA is required for docs and all
+    // patches are welcome except spam." has no comma and is still two statements, and requiring one
+    // let the unrelated `except spam` scope the waiver — a fail-closed P1 from review.
     if (words.length <= 3 && !FINITE_VERB.test(segment)) continue;
+    // A statement about THIS instrument does not end the waiver's reach either. "No DCO is needed
+    // for docs and no DCO is needed for tests, other than vendored trees." coordinates two waivers
+    // of one instrument, and the limiter past the second still means the DCO is required somewhere.
+    // Only a statement about something ELSE closes the span — that is the difference between this
+    // and "and all patches are welcome except spam", where the exception is about spam.
+    if (new RegExp(token, "i").test(segment)) continue;
     return after.slice(0, hit.index);
   }
   return after;
@@ -220,6 +236,12 @@ function signaturePolarity(clause: string, clauseAt: number, sentence: string, t
       // give the same verdict; that was measured across every enumeration here, in both directions,
       // rather than reasoned about and hoped for.
       const span = spans[0]!;
+      // `clauseAt + span.at` rather than asking the sentence where this text is, which answers with
+      // the first copy of it. That was a P1 and had a failing row; the row no longer fails, because
+      // `truncateAtStatement` now continues through a statement about this same instrument and so
+      // reaches the limiter from either position. Measured, not assumed — the mutant survives the
+      // whole corpus today. Kept because a clause's position is not something to compute wrongly and
+      // rely on a neighbouring rule to cover, and that neighbouring rule has been redrawn four times.
       const at = clauseAt + span.at;
       const after = sentence.slice(at + span.length);
       // A conjunction ends this statement only where it BEGINS a new one. A comma is necessary for
@@ -231,7 +253,7 @@ function signaturePolarity(clause: string, clauseAt: number, sentence: string, t
       // something. A continued scope is a short noun phrase closed by the next comma. That is the
       // test: skip a candidate whose following segment is a bare scope item, keep looking, and
       // truncate at the first one that reads as a statement.
-      const forward = truncateAtStatement(after);
+      const forward = truncateAtStatement(after, T);
       const leading = at > 0 && SCOPE_LIMITER.test(sentence.slice(0, at).replace(/^[\s"'(\[]*/, "").split(/[,;]/)[0] ?? "");
       if (SCOPE_LIMITER.test(forward) || leading) return "required";
     }
@@ -450,8 +472,21 @@ export function scanPolicyText(text: string): {
     const anaphoricFamilies = new Set<string>();
     let named: string | undefined;
     for (const { text: c } of parts) {
-      const here = SIGNATURE_FAMILIES.find(({ token }) => new RegExp(token, "i").test(c));
-      if (here) named = here.family;
+      // The family whose token sits LAST in the clause, not the first in the roster: one clause can
+      // name both ("No CLA or DCO is required"), and the elided subject refers to the nearest — a
+      // P1 from review, because the freeze evidence otherwise blames whichever the roster lists
+      // first, which has nothing to do with what the sentence says.
+      let here: string | undefined;
+      let furthest = -1;
+      for (const { family, token } of SIGNATURE_FAMILIES) {
+        let last = -1;
+        for (const m of c.matchAll(new RegExp(token, "gi"))) last = m.index;
+        if (last > furthest) {
+          furthest = last;
+          here = family;
+        }
+      }
+      if (here) named = here;
       else if (isAnaphoric(c) && named !== undefined) anaphoricFamilies.add(named);
     }
     for (const { text: clause, at: clauseAt } of parts) {

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -270,15 +270,15 @@ function signaturePolarity(clause: string, sentence: string, token: string): "re
      * words are DCO-family tokens, so a mention abutting a removed span is absorbed with it.
      * Without that, "We don't require a DCO sign-off on contributions." became a hold.
      */
-    // ONE SPACE, and nothing else. "a DCO sign-off" is one instrument reached across a space, so the
-    // second token is absorbed with the first; a hyphen inside a token is already part of the token
-    // itself (`signed[-\s]?off`), so this window never needed one.
+    // One space. A hyphen inside an instrument is already part of the instrument's own pattern
+    // (`signed[-\s]?off`), so this window never needed to spell one.
     //
-    // Two fail-open P1s from review taught that, one per width. A three-character space-or-hyphen
-    // window ate the requirement in "No DCO is required - DCO is required for code."; narrowing it to
-    // one space OR one hyphen still ate "No DCO is required-DCO is required for code.", because an
-    // unspaced dash joins statements at least as often as it joins words. A window this narrow cannot
-    // reach across either.
+    // The WIDTH is no longer what decides anything, and that is worth saying because three commits
+    // were spent narrowing it — three characters, then one space or hyphen, then one space — chasing
+    // a fail-open each time. The `compound` gate below is the actual rule, and it subsumes width: a
+    // mutant widening this window back to allow a hyphen now changes no verdict, because a span
+    // ending in "required" is refused before the window is ever consulted. What the window still
+    // earns is the space itself — "a DCO sign-off" needs it, and a mutant removing it reds.
     const abuts = new RegExp(String.raw`^[ \t]?${T}`, "i");
     let residual = clause;
     for (let removed = true; removed; ) {

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -114,49 +114,6 @@ const QUALIFIER = String.raw`(?:only|also|still|always|never|sometimes|generally
 const SCOPE_FOLLOWS = String.raw`(?=\s*(?:$|[.;,]|(?:${QUALIFIER}\s+)?(?:for|on|in|when|with|of|from)\b))`;
 
 /**
- * A waiver's own statement ends where the NEXT statement begins, and the text between them is scope.
- *
- * The boundary is a conjunction behind a comma or semicolon — necessary, not sufficient. "for
- * documentation, or code, except for third-party contributions" puts a comma before the `or`, and
- * "code" is still scope: a bare noun phrase closed by the next comma. A new statement is longer than
- * that and carries a verb. So each candidate boundary is examined, scope items are skipped, and the
- * span ends at the first candidate that reads as a statement.
- *
- * Both directions cost a P1 on this branch: truncating at every conjunction lost the exception,
- * truncating at none of them reclassified "and all patches are welcome except spam" as a scoped
- * requirement.
- */
-const FINITE_VERB = /\b(?:is|are|was|were|be|been|being|has|have|had|do|does|did|will|would|can|could|may|might|must|should|shall|need|needs|require|requires|review|reviews|accept|accepts|welcome|apply|applies|ask|asks|expect|expects)\b/i;
-
-function truncateAtStatement(after: string, token: string): string {
-  const boundary = new RegExp(String.raw`\b${CONJUNCTION_WORDS}\b`, "gi");
-  for (let hit = boundary.exec(after); hit; hit = boundary.exec(after)) {
-    // What the conjunction introduces, up to the next punctuation OR the next limiter — whichever
-    // comes first. Stopping at the limiter is what keeps "or code except for third-party
-    // contributions" from reading as a six-word statement: the item is "code".
-    const rest = after.slice(hit.index + hit[0].length);
-    const end = rest.search(/[,;.]/);
-    const lim = rest.search(SCOPE_LIMITER);
-    const cut = [end, lim].filter((n) => n >= 0);
-    const segment = cut.length > 0 ? rest.slice(0, Math.min(...cut)) : rest;
-    const words = segment.trim().split(/\s+/).filter(Boolean);
-    // A scope item is short and asserts nothing. Anything else is a new statement, and the waiver's
-    // own span ends there. Punctuation is NOT part of this test: "No CLA is required for docs and all
-    // patches are welcome except spam." has no comma and is still two statements, and requiring one
-    // let the unrelated `except spam` scope the waiver — a fail-closed P1 from review.
-    if (words.length <= 3 && !FINITE_VERB.test(segment)) continue;
-    // A statement about THIS instrument does not end the waiver's reach either. "No DCO is needed
-    // for docs and no DCO is needed for tests, other than vendored trees." coordinates two waivers
-    // of one instrument, and the limiter past the second still means the DCO is required somewhere.
-    // Only a statement about something ELSE closes the span — that is the difference between this
-    // and "and all patches are welcome except spam", where the exception is about spam.
-    if (new RegExp(token, "i").test(segment)) continue;
-    return after.slice(0, hit.index);
-  }
-  return after;
-}
-
-/**
  * There is deliberately NO "asserts a requirement" roster. One was written, and the injection pass
  * showed the harness could not see it deleted: an occurrence matching no waiver already returns
  * `"required"`, so the list and the fallback gave the same answer and it was unreachable — the #75
@@ -179,7 +136,7 @@ function truncateAtStatement(after: string, token: string): string {
  * clause. The previous attempt negated the DCO and left the CLA invisible — 8 of 10 documents
  * regressed to ALLOW.
  */
-function signaturePolarity(clause: string, clauseAt: number, sentence: string, token: string): "required" | "waived" {
+function signaturePolarity(clause: string, sentence: string, token: string): "required" | "waived" {
   const T = token;
   if (new RegExp(String.raw`\bno\s+${T}\s+${ESCAPE_HATCH}`, "i").test(clause)) return "required";
   const waivers = [
@@ -192,71 +149,41 @@ function signaturePolarity(clause: string, clauseAt: number, sentence: string, t
     String.raw`\bthere\s+(?:is|are)\s+no\s+${T}`,
     String.raw`\bno\s+${T}\b`,
   ];
-  /**
-   * EVERY waiver occurrence in the clause, in the patterns' priority order. One is not enough: the
-   * limiter can scope the second waiver in a single clause ("no DCO is needed for docs and no DCO is
-   * needed for tests, other than vendored trees"), and deciding from the first occurrence alone cut
-   * the forward span at the intervening "and" and reached a blanket waiver. Found by adversarially
-   * probing the fix for the cross-clause version of exactly this, which is the shape a repo would
-   * use to get ALLOW while demanding a signature.
-   *
-   * The patterns overlap by design, so the same text yields several spans; that costs a few
-   * iterations and changes no verdict, because a limiter scoping ANY occurrence means the instrument
-   * is required somewhere.
-   */
-  const spans: { at: number; length: number }[] = [];
-  for (const w of waivers) {
-    const re = new RegExp(w, "gi");
-    for (let m = re.exec(clause); m; m = re.exec(clause)) spans.push({ at: m.index, length: m[0].length });
-  }
-  if (spans.length > 0) {
+  // Undecided reads as REQUIRED — the repo's asymmetry, not a shrug. A false hold costs one look; a
+  // false allow opens a draft into a repo demanding a signature, and PRODUCT.md §3 says never forge.
+  // This is the only place that decision is taken. A second copy sat at the end of the function and a
+  // mutation showed it unreachable once this branch existed, so it is gone.
+  if (!waivers.some((w) => new RegExp(w, "i").test(clause))) return "required";
+  {
     /**
-     * A scoped waiver is a requirement in a waiver's clothes. The limiter must belong to THIS
-     * waiver, and both wrong spans shipped here: the CLAUSE missed "A CLA is not required, except
-     * for new dependencies." (fail-open), the whole SENTENCE reclassified "No CLA is required, and
-     * all patches are welcome except spam", where the except is about spam (fail-closed, parking a
-     * packet that waives the CLA outright — P1 from review). So the span is the waiver's own
-     * statement: its clause, what follows up to the first coordinating conjunction, and a leading
-     * "Except for X, ..." it is the main clause of.
+     * A LIMITER ANYWHERE IN THE SENTENCE HOLDS THE PACKET. Not "a limiter this waiver's span
+     * reaches" — anywhere.
      *
-     * The position is the clause's offset plus the match's offset inside it. Asking the SENTENCE
-     * where the matched text is answers with the first copy, so a repeated waiver measured the later
-     * one from the earlier one's position: the forward span stopped at the intervening conjunction,
-     * the limiter behind it was never in view, and a scoped requirement reached ALLOW. Third P1 from
-     * review, and the third wrong span for this one decision.
+     * Twelve of the twenty-two defects on this branch lived in the span that used to be computed
+     * here, and every one was the same mistake in a new dress: deciding which of two statements an
+     * `except` belongs to. Four different spans shipped, each correct on the corpus of the day, each
+     * broken by the next sentence a reviewer wrote down. Attaching a limiter is a parsing problem and
+     * this is a regex.
+     *
+     * So it is not attached. A waiver stands only in a sentence with nothing to argue about, and a
+     * sentence holding both a waived instrument and an `except` goes to a human instead. That is a
+     * deliberate over-block, and it reverses two findings that called the over-block a defect — named
+     * here so nobody has to guess whether it was noticed.
+     *
+     * It is affordable because it is nearly unreachable. Measured over 17 real CONTRIBUTING-style
+     * documents (Kubernetes, Node, Angular, .NET, Envoy, QEMU, gRPC, Podman, Gitea, Prometheus,
+     * Superset, Moby and the allowlist's own targets): 12 name a signature instrument, and all 12
+     * resolve to REQUIRED already. Not one real document waives an instrument it bothers to mention —
+     * documents with no signature requirement simply never name one. Of 88 sentences naming an
+     * instrument, 2 also carried a limiter, and both sit in documents that were already held.
+     *
+     * The waiver path therefore exists for bare denials — "No CLA. No DCO.", the Wave-1 seed shape —
+     * which carry no limiter and are untouched by this. What is given up is a sentence that waives an
+     * instrument AND discusses an exception to something else, which no document in the sample does.
+     * What is bought is that a scoped requirement can no longer be read as a blanket waiver, by any
+     * phrasing, because the question is never asked.
      */
-    {
-      // ANY occurrence in the clause will do, and this is the one place that deserves a note saying
-      // so, because a loop over all of them lived here first.
-      //
-      // A clause holds no comma or semicolon — those are what split it — so every occurrence inside
-      // it shares one downstream truncation point. `forward` therefore covers the clause from an
-      // occurrence rightwards and `leading` covers it leftwards, and between them the pair sees the
-      // whole clause from either end. Picking the earliest, the latest, or the first match found all
-      // give the same verdict; that was measured across every enumeration here, in both directions,
-      // rather than reasoned about and hoped for.
-      const span = spans[0]!;
-      // `clauseAt + span.at` rather than asking the sentence where this text is, which answers with
-      // the first copy of it. That was a P1 and had a failing row; the row no longer fails, because
-      // `truncateAtStatement` now continues through a statement about this same instrument and so
-      // reaches the limiter from either position. Measured, not assumed — the mutant survives the
-      // whole corpus today. Kept because a clause's position is not something to compute wrongly and
-      // rely on a neighbouring rule to cover, and that neighbouring rule has been redrawn four times.
-      const at = clauseAt + span.at;
-      const after = sentence.slice(at + span.length);
-      // A conjunction ends this statement only where it BEGINS a new one. A comma is necessary for
-      // that and not sufficient: "for documentation, or code, except for third-party contributions"
-      // has a comma before the `or`, yet "code" is another SCOPE, not another statement — truncating
-      // there lost the exception behind it. Two P1s from review, one for each half.
-      //
-      // A new statement carries a subject and a verb, so it is longer than a list item and it says
-      // something. A continued scope is a short noun phrase closed by the next comma. That is the
-      // test: skip a candidate whose following segment is a bare scope item, keep looking, and
-      // truncate at the first one that reads as a statement.
-      const forward = truncateAtStatement(after, T);
-      const leading = at > 0 && SCOPE_LIMITER.test(sentence.slice(0, at).replace(/^[\s"'(\[]*/, "").split(/[,;]/)[0] ?? "");
-      if (SCOPE_LIMITER.test(forward) || leading) return "required";
-    }
+    if (SCOPE_LIMITER.test(sentence)) return "required";
     /**
      * A COORDINATED requirement on the same elided subject: "no CLA is required for docs and
      * required for code." `and` is not a clause delimiter, so this requirement lives inside the
@@ -315,9 +242,6 @@ function signaturePolarity(clause: string, clauseAt: number, sentence: string, t
     if (new RegExp(T, "i").test(residual)) return "required";
     return "waived";
   }
-  // Undecided reads as REQUIRED — the repo's asymmetry, not a shrug. A false hold costs one look; a
-  // false allow opens a draft into a repo demanding a signature, and PRODUCT.md §3 says never forge.
-  return "required";
 }
 
 /**
@@ -381,8 +305,7 @@ function sentencesOf(text: string): string[] {
 }
 
 /**
- * Clause-sized spans, so two instruments in one sentence are judged separately, each with its own
- * offset into the sentence.
+ * Clause-sized spans, so two instruments in one sentence are judged separately.
  *
  * "No DCO, contributor agreement required." is the case that makes this necessary: one sentence
  * holding a waiver and a requirement. Splitting on the comma is what lets the DCO read as waived and
@@ -390,29 +313,16 @@ function sentencesOf(text: string): string[] {
  * in the previous attempt claimed a `NEG_FILLER` regex handled the comma and nothing tested it;
  * this is the same guarantee made structural.
  *
- * The offset is carried, not recovered later: a sentence can repeat a clause verbatim, and searching
- * for its text answers with the first copy. The cursor only moves forward, so identical clauses still
- * get their own positions.
+ * Clause OFFSETS were carried here for most of this branch's life, to place a limiter span inside the
+ * sentence. Nothing measures position now — a limiter is read from the whole sentence and never
+ * attached — so the offsets, the cursor that kept identical clauses apart, and the two defects that
+ * lived in them all went at once.
  */
-function clausesOf(sentence: string): { text: string; at: number }[] {
-  const out: { text: string; at: number }[] = [];
-  let cursor = 0;
-  for (const part of sentence.split(/[,;]/)) {
-    const text = part.trim();
-    if (!text) continue;
-    // Only the splitting delimiter lies between `cursor` and this clause, so the first match from
-    // `cursor` is this clause rather than a later repeat of it.
-    //
-    // Behaviourally inert as the code stands, and said plainly rather than implied by a test that
-    // does not exist: a mutant searching from 0 changes no verdict here. It can only widen a later
-    // clause's span to an earlier clause's, and a wider span only ever ADDS a hold, so it cannot
-    // open the gate. Kept because measuring one clause at another clause's offset is wrong however
-    // the limiter rules are drawn, and `truncateAtStatement` above has already been redrawn twice.
-    const at = sentence.indexOf(text, cursor);
-    out.push({ text, at });
-    cursor = at + text.length;
-  }
-  return out;
+function clausesOf(sentence: string): string[] {
+  return sentence
+    .split(/[,;]/)
+    .map((c) => c.trim())
+    .filter(Boolean);
 }
 
 function quoteOf(match: RegExpExecArray): string {
@@ -471,7 +381,7 @@ export function scanPolicyText(text: string): {
      */
     const anaphoricFamilies = new Set<string>();
     let named: string | undefined;
-    for (const { text: c } of parts) {
+    for (const c of parts) {
       // The family whose token sits LAST in the clause, not the first in the roster: one clause can
       // name both ("No CLA or DCO is required"), and the elided subject refers to the nearest — a
       // P1 from review, because the freeze evidence otherwise blames whichever the roster lists
@@ -489,11 +399,11 @@ export function scanPolicyText(text: string): {
       if (here) named = here;
       else if (isAnaphoric(c) && named !== undefined) anaphoricFamilies.add(named);
     }
-    for (const { text: clause, at: clauseAt } of parts) {
+    for (const clause of parts) {
       for (const { family, token } of SIGNATURE_FAMILIES) {
         if (!new RegExp(token, "i").test(clause)) continue;
         const quote = `${family}: ${clause.replace(/\s+/g, " ").trim().slice(0, 140)}`;
-        const polarity = signaturePolarity(clause, clauseAt, sentence, token);
+        const polarity = signaturePolarity(clause, sentence, token);
         if (polarity === "required" || anaphoricFamilies.has(family)) signatureRequired.push(quote);
         else signatureWaived.push(quote);
       }

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -70,8 +70,15 @@ const ESCAPE_HATCH = String.raw`(?:bypass|exception|exemption|waiver|opt[-\s]?ou
 /** Words that turn a waiver into a conditional requirement: it IS required, somewhere. */
 const SCOPE_LIMITER = /\b(?:except|unless|other\s+than|apart\s+from|save\s+for)\b/i;
 
-/** The words a requirement is asserted WITH, when its subject has been elided. */
-const PREDICATE = String.raw`(?:required|needed|necessary|mandatory|obligatory|compulsory)`;
+/**
+ * The words a requirement is asserted WITH, when its subject has been elided.
+ *
+ * ONE roster, because there were two and they drifted: the waiver patterns knew `expected` and this
+ * did not, so "No CLA is expected for docs and expected for code." waived the whole sentence and
+ * reached ALLOW — a P1 from review. A waiver and a requirement are the same vocabulary under
+ * opposite polarity, so a word this factory can waive is a word it must be able to require.
+ */
+const PREDICATE = String.raw`(?:required|needed|necessary|expected|mandatory|obligatory|compulsory)`;
 
 /**
  * What must follow a bare `PREDICATE` for it to be a requirement rather than a noun modifier.
@@ -109,8 +116,8 @@ function signaturePolarity(clause: string, clauseAt: number, sentence: string, t
   const T = token;
   if (new RegExp(String.raw`\bno\s+${T}\s+${ESCAPE_HATCH}`, "i").test(clause)) return "required";
   const waivers = [
-    String.raw`\bno\s+${T}\s+(?:is\s+|are\s+)?(?:required|needed|necessary|expected)\b`,
-    String.raw`${T}\s*:?\s*(?:is\s+|are\s+)?not\s+(?:required|needed|necessary|expected)\b`,
+    String.raw`\bno\s+${T}\s+(?:is\s+|are\s+)?${PREDICATE}\b`,
+    String.raw`${T}\s*:?\s*(?:is\s+|are\s+)?not\s+${PREDICATE}\b`,
     // Bounded filler, stopping at any clause break so it cannot borrow a neighbour's waiver. It
     // exists because "do not need TO SIGN a contributor license agreement" puts an infinitive
     // between verb and token — a shape the corpus caught and the first draft of this list missed.
@@ -223,12 +230,27 @@ function signaturePolarity(clause: string, clauseAt: number, sentence: string, t
  * Requiring the capital keeps `e.g.` and `i.e.` from ending a sentence mid-clause — the hazard the
  * `W` window above spells out abbreviation by abbreviation. A newline ends one too: these are
  * markdown, and a list item is a sentence whether or not it carries a full stop.
+ *
+ * A sentence STARTING with a scope limiter is not a new statement, it is the previous one's scope:
+ * "No CLA is required. Except for code." Splitting them left a blanket waiver and a token-less
+ * fragment nothing looked at, and the repo reached ALLOW while requiring a CLA for code — a P1 from
+ * review. Joining it back is what lets every existing scope rule see it, rather than adding a second
+ * way to decide scope.
+ *
+ * Sentence-INITIAL is the whole test, and it is what separates this from "No CLA. Reviews are quick,
+ * except during release weeks.", where the limiter sits mid-sentence with its own subject and must
+ * not reach the waiver. Where a fragment is genuinely ambiguous, joining over-blocks rather than
+ * over-allows, which is the asymmetry `signaturePolarity` closes with.
  */
 function sentencesOf(text: string): string[] {
-  return text
-    .split(/(?<=[.!?])\s+(?=["'(\[]?[A-Z])|\n+/)
-    .map((s) => s.trim())
-    .filter(Boolean);
+  const out: string[] = [];
+  for (const sentence of text.split(/(?<=[.!?])\s+(?=["'(\[]?[A-Z])|\n+/).map((s) => s.trim()).filter(Boolean)) {
+    const anaphoricScope = new RegExp(String.raw`^["'(\[]*${SCOPE_LIMITER.source.replace(/^\\b|\\b$/g, "")}\b`, "i").test(sentence);
+    const previous = out.at(-1);
+    if (anaphoricScope && previous !== undefined) out[out.length - 1] = `${previous} ${sentence}`;
+    else out.push(sentence);
+  }
+  return out;
 }
 
 /**

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -102,10 +102,16 @@ const PREDICATE = String.raw`(?:required|needed|necessary|expected|mandatory|obl
  * What must follow a bare `PREDICATE` for it to be a requirement rather than a noun modifier.
  *
  * Without a copula there is no verb to anchor on, so the SCOPE anchors instead: "required for code"
- * asserts something about the instrument, "required reading is the style guide" does not. One adverb
- * may intervene, so "needed only for release" still counts.
+ * asserts something about the instrument, "required reading is the style guide" does not.
+ *
+ * The word that may stand between predicate and scope is a CLOSED set of adverbs, not any word. It
+ * was any word once, so "It is required reading for new contributors." read as a requirement and
+ * held a repository that waives the CLA outright — a fail-closed P1 from review. "needed only for
+ * release" still counts; "required reading for contributors" does not, because `reading` is a noun
+ * this predicate is modifying rather than an adverb qualifying it.
  */
-const SCOPE_FOLLOWS = String.raw`(?=\s*(?:$|[.;,]|(?:\w+\s+)?(?:for|on|in|when|with|of|from)\b))`;
+const QUALIFIER = String.raw`(?:only|also|still|always|never|sometimes|generally|usually|normally|strictly|explicitly|absolutely)`;
+const SCOPE_FOLLOWS = String.raw`(?=\s*(?:$|[.;,]|(?:${QUALIFIER}\s+)?(?:for|on|in|when|with|of|from)\b))`;
 
 /**
  * A waiver's own statement ends where the NEXT statement begins, and the text between them is scope.
@@ -322,9 +328,14 @@ function signaturePolarity(clause: string, clauseAt: number, sentence: string, t
  * for code." — which a P1 from review found detached, leaving a blanket waiver and a token-less
  * fragment. `SCOPE_FOLLOWS` is what keeps that from swallowing "Required reading is the style
  * guide.", where the participle modifies a noun and the sentence genuinely is a new statement.
+ *
+ * On the COPULA branch that same guard is inert, and measured to be: joining is the safe direction,
+ * and `COORDINATED` re-applies `SCOPE_FOLLOWS` to whatever gets joined, so a noun modifier cannot
+ * survive being pulled in. It is kept because these two matchers drifting apart was itself a P1, and
+ * a reader comparing them should find them saying the same thing.
  */
 const CONTINUATION = new RegExp(
-  String.raw`^(?:[-*+>]|\d+[.)])?[\s"'(\[]*(?:(?:${SCOPE_LIMITER.source.replace(/^\\b|\\b$/g, "")}|${CONJUNCTION_WORDS})\b|(?:is|are|it\s+is|they\s+are)\s+(?:still\s+)?${PREDICATE}\b|${PREDICATE}\b${SCOPE_FOLLOWS})`,
+  String.raw`^(?:[-*+>]|\d+[.)])?[\s"'(\[]*(?:(?:${SCOPE_LIMITER.source.replace(/^\\b|\\b$/g, "")}|${CONJUNCTION_WORDS})\b|(?:is|are|it\s+is|they\s+are)\s+(?:still\s+)?${PREDICATE}\b${SCOPE_FOLLOWS}|${PREDICATE}\b${SCOPE_FOLLOWS})`,
   "i",
 );
 
@@ -426,7 +437,7 @@ export function scanPolicyText(text: string): {
     // no family token matched, so the guard that used to live here was unreachable — a mutant
     // deleting it changed nothing, which is how it was found.
     const isAnaphoric = (c: string) =>
-      new RegExp(String.raw`^${CONJUNCTION}(?:is|are|it\s+is|they\s+are)\s+(?:still\s+)?${PREDICATE}\b`, "i").test(c) ||
+      new RegExp(String.raw`^${CONJUNCTION}(?:is|are|it\s+is|they\s+are)\s+(?:still\s+)?${PREDICATE}\b${SCOPE_FOLLOWS}`, "i").test(c) ||
       new RegExp(String.raw`^${CONJUNCTION}(?:also\s+)?(?:still\s+)?${PREDICATE}\b${SCOPE_FOLLOWS}`, "i").test(c);
     /**
      * An elided subject refers to the instrument most recently NAMED, so the requirement lands on

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -106,9 +106,24 @@ function signaturePolarity(clause: string, clauseAt: number, sentence: string, t
     String.raw`\bthere\s+(?:is|are)\s+no\s+${T}`,
     String.raw`\bno\s+${T}\b`,
   ];
+  /**
+   * EVERY waiver occurrence in the clause, in the patterns' priority order. One is not enough: the
+   * limiter can scope the second waiver in a single clause ("no DCO is needed for docs and no DCO is
+   * needed for tests, other than vendored trees"), and deciding from the first occurrence alone cut
+   * the forward span at the intervening "and" and reached a blanket waiver. Found by adversarially
+   * probing the fix for the cross-clause version of exactly this, which is the shape a repo would
+   * use to get ALLOW while demanding a signature.
+   *
+   * The patterns overlap by design, so the same text yields several spans; that costs a few
+   * iterations and changes no verdict, because a limiter scoping ANY occurrence means the instrument
+   * is required somewhere.
+   */
+  const spans: { at: number; length: number }[] = [];
   for (const w of waivers) {
-    const hit = new RegExp(w, "i").exec(clause);
-    if (!hit) continue;
+    const re = new RegExp(w, "gi");
+    for (let m = re.exec(clause); m; m = re.exec(clause)) spans.push({ at: m.index, length: m[0].length });
+  }
+  if (spans.length > 0) {
     /**
      * A scoped waiver is a requirement in a waiver's clothes. The limiter must belong to THIS
      * waiver, and both wrong spans shipped here: the CLAUSE missed "A CLA is not required, except
@@ -119,17 +134,19 @@ function signaturePolarity(clause: string, clauseAt: number, sentence: string, t
      * "Except for X, ..." it is the main clause of.
      *
      * The position is the clause's offset plus the match's offset inside it. Asking the SENTENCE
-     * where `hit[0]` is answers with the first copy, so a repeated waiver measured the later one from
-     * the earlier one's position: the forward span stopped at the intervening conjunction, the
-     * limiter behind it was never in view, and a scoped requirement reached ALLOW. Third P1 from
+     * where the matched text is answers with the first copy, so a repeated waiver measured the later
+     * one from the earlier one's position: the forward span stopped at the intervening conjunction,
+     * the limiter behind it was never in view, and a scoped requirement reached ALLOW. Third P1 from
      * review, and the third wrong span for this one decision.
      */
-    const at = clauseAt + hit.index;
-    const after = sentence.slice(at + hit[0].length);
-    const conjunction = after.search(/\b(?:and|or|but|however)\b/i);
-    const forward = conjunction === -1 ? after : after.slice(0, conjunction);
-    const leading = at > 0 && SCOPE_LIMITER.test(sentence.slice(0, at).replace(/^[\s"'(\[]*/, "").split(/[,;]/)[0] ?? "");
-    if (SCOPE_LIMITER.test(clause) || SCOPE_LIMITER.test(forward) || leading) return "required";
+    for (const span of spans) {
+      const at = clauseAt + span.at;
+      const after = sentence.slice(at + span.length);
+      const conjunction = after.search(/\b(?:and|or|but|however)\b/i);
+      const forward = conjunction === -1 ? after : after.slice(0, conjunction);
+      const leading = at > 0 && SCOPE_LIMITER.test(sentence.slice(0, at).replace(/^[\s"'(\[]*/, "").split(/[,;]/)[0] ?? "");
+      if (SCOPE_LIMITER.test(forward) || leading) return "required";
+    }
     /**
      * A WAIVER GOVERNS ONLY THE OCCURRENCE IT NAMES — a P1 from review. Polarity was decided once
      * per clause from the first match, so "No CLA is required for documentation and a CLA is
@@ -137,16 +154,31 @@ function signaturePolarity(clause: string, clauseAt: number, sentence: string, t
      * Removing the waived span and asking whether the instrument is still mentioned settles it
      * without guessing at conjunctions; any surviving mention is ungoverned, so it reads as required.
      *
-     * One instrument can be named twice in a row, though: "a DCO sign-off" is a single thing and
-     * both words are DCO-family tokens, so a mention abutting the waiver's span is absorbed first.
+     * EVERY waived span comes out, not just this one — another P1, the mirror of the fix above. One
+     * clause can waive the same instrument twice ("no CLA is required for docs and no CLA is required
+     * for code", one span because "and" does not split a clause), and removing only the first left
+     * the second reading as an ungoverned requirement: a document waiving BOTH scopes was parked.
+     * Fail-closed rather than open, so it cost a look rather than a signature, but it was wrong.
+     *
+     * One instrument can also be named twice in a row: "a DCO sign-off" is a single thing and both
+     * words are DCO-family tokens, so a mention abutting a removed span is absorbed with it.
      * Without that, "We don't require a DCO sign-off on contributions." became a hold.
      */
-    let tail = clause.slice(hit.index + hit[0].length);
-    for (let abut = new RegExp(String.raw`^[\s\-]{0,3}${T}`, "i").exec(tail); abut; ) {
-      tail = tail.slice(abut[0].length);
-      abut = new RegExp(String.raw`^[\s\-]{0,3}${T}`, "i").exec(tail);
+    const abuts = new RegExp(String.raw`^[\s\-]{0,3}${T}`, "i");
+    let residual = clause;
+    for (let removed = true; removed; ) {
+      removed = false;
+      for (const w of waivers) {
+        const span = new RegExp(w, "i").exec(residual);
+        if (!span) continue;
+        let tail = residual.slice(span.index + span[0].length);
+        for (let abut = abuts.exec(tail); abut; abut = abuts.exec(tail)) tail = tail.slice(abut[0].length);
+        residual = `${residual.slice(0, span.index)} ${tail}`;
+        removed = true;
+        break;
+      }
     }
-    if (new RegExp(T, "i").test(`${clause.slice(0, hit.index)} ${tail}`)) return "required";
+    if (new RegExp(T, "i").test(residual)) return "required";
     return "waived";
   }
   // Undecided reads as REQUIRED — the repo's asymmetry, not a shrug. A false hold costs one look; a
@@ -230,10 +262,22 @@ export function scanPolicyText(text: string): {
      * (P1 from review). The clause must START with the verb, which is what elision looks like:
      * "and tests are required" has its own subject and must not flip the CLA, and matching the
      * keywords alone would over-block it.
+     *
+     * English drops the copula too — "..., but required for code." — and a participle-initial clause
+     * was invisible, so the waiver read as blanket and the repo was allowed despite requiring a
+     * signature for code (a P1 from review, and this issue's fail-open class again). Without the
+     * copula there is no verb to anchor on, so the SCOPE does the anchoring: a bare participle counts
+     * only when what follows is a scope or the clause ends. That is what separates "required for
+     * code" from "required reading is the style guide", where the participle modifies a noun and
+     * asserts nothing about the instrument. One adverb is allowed in between, so "needed only for
+     * release" still counts.
      */
+    const PREDICATE = String.raw`(?:required|needed|necessary|mandatory|obligatory|compulsory)`;
+    const SCOPE_FOLLOWS = String.raw`(?=\s*(?:$|[.;,]|(?:\w+\s+)?(?:for|on|in|when|with|of|from)\b))`;
     const anaphoric = parts.some(
       ({ text: c }) =>
-        /^(?:is|are|it\s+is|they\s+are)\s+(?:still\s+)?(?:required|needed|necessary|mandatory|obligatory|compulsory)\b/i.test(c) &&
+        (new RegExp(String.raw`^(?:is|are|it\s+is|they\s+are)\s+(?:still\s+)?${PREDICATE}\b`, "i").test(c) ||
+          new RegExp(String.raw`^(?:still\s+)?${PREDICATE}\b${SCOPE_FOLLOWS}`, "i").test(c)) &&
         !SIGNATURE_FAMILIES.some(({ token }) => new RegExp(token, "i").test(c)),
     );
     for (const { text: clause, at: clauseAt } of parts) {

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -75,11 +75,17 @@ const ANY_INSTRUMENT = `(?:${SIGNATURE_FAMILIES.map(({ token }) => token).join("
  * written with an adjective instead of a noun, which is why they share this check rather than
  * getting a rule of their own.
  *
- * An adverb may stand between the copula and the hatch word — "No DCO is ever waived.", "No CLA is
+ * Words may stand between the copula and the hatch word — "No DCO is ever waived.", "No CLA is
  * simply optional." — which a P1 from review found falling through to the broad `no <instrument>`
  * matcher. The slot is any word rather than a roster, because it is only reachable when a hatch word
  * follows it: "No CLA is needed." puts `needed` where the hatch word would be, matches nothing here,
  * and stays a waiver. An open slot in front of a required anchor cannot over-match.
+ *
+ * UNBOUNDED, and deliberately. It was capped at four words and review immediately produced a
+ * five-word denial; any finite cap invites the next one, and the cap was arbitrary. It is safe to
+ * remove because `\w+\s+` crosses neither punctuation nor a clause boundary, so the slot cannot
+ * leave the statement it started in, and it still has to reach a hatch word to match at all. Fuzzed
+ * for backtracking rather than assumed safe — see the hang test in the suite.
  *
  * KNOWN LIMIT, found while fixing the above and not reported: an aside with commas — "No CLA is,
  * under our policy, optional." — still reads as a waiver, because the comma defeats the copula and
@@ -88,7 +94,7 @@ const ANY_INSTRUMENT = `(?:${SIGNATURE_FAMILIES.map(({ token }) => token).join("
  * needs punctuation tolerance inside the copula, which is one more widening in a pattern that has
  * produced a new gap for every widening so far. Recorded rather than fixed, and rather than hidden.
  */
-const ESCAPE_HATCH = String.raw`(?:is\s+|are\s+)?(?:\w+\s+){0,4}?(?:bypass|except|exempt|waive|opt[-\s]?out|workaround|ways?\s+around|optional|voluntary|discretionary|up\s+to\s+you|at\s+your\s+discretion)`;
+const ESCAPE_HATCH = String.raw`(?:is\s+|are\s+)?(?:\w+\s+)*?(?:bypass|except|exempt|waive|opt[-\s]?out|workaround|ways?\s+around|optional|voluntary|discretionary|up\s+to\s+you|at\s+your\s+discretion)`;
 
 /** Words that turn a waiver into a conditional requirement: it IS required, somewhere. */
 const SCOPE_LIMITER = /\b(?:except|unless|other\s+than|apart\s+from|save\s+for)\b/i;

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -168,11 +168,14 @@ function signaturePolarity(clause: string, clauseAt: number, sentence: string, t
      * fail-open class as everything else on this branch: a requirement hiding behind a waiver's
      * coordination.
      *
-     * The conjunction must be followed DIRECTLY by the predicate. "and tests are required" has its
-     * own subject and must not flip the instrument, and "and no CLA is required for code" is a second
-     * waiver rather than a requirement — both are excluded by that adjacency, not by a word list.
+     * Between the conjunction and the predicate only an elided subject's own copula may stand — "and
+     * is required for code", "and it is required for code". Nothing else: "and tests are required"
+     * has its OWN subject and must not flip the instrument, and "and no CLA is required for code" is
+     * a second waiver rather than a requirement. Both are excluded because a noun sits where the
+     * copula or predicate has to be, which is a rule about position rather than a word list.
      */
-    if (new RegExp(String.raw`\b(?:and|or|but|however)\s+(?:also\s+)?(?:still\s+)?${PREDICATE}\b${SCOPE_FOLLOWS}`, "i").test(clause)) {
+    const COORDINATED = String.raw`\b(?:and|or|but|however)\s+(?:(?:it|they)\s+)?(?:is|are)?\s*(?:also\s+)?(?:still\s+)?${PREDICATE}\b${SCOPE_FOLLOWS}`;
+    if (new RegExp(COORDINATED, "i").test(clause)) {
       return "required";
     }
     /**
@@ -296,10 +299,11 @@ export function scanPolicyText(text: string): {
      * signature for code: a P1 from review, and this issue's fail-open class again. `SCOPE_FOLLOWS`
      * is what keeps a bare participle from matching a noun modifier.
      */
+    const CONJUNCTION = String.raw`(?:(?:and|or|but|however)\s+)?`;
     const anaphoric = parts.some(
       ({ text: c }) =>
-        (new RegExp(String.raw`^(?:is|are|it\s+is|they\s+are)\s+(?:still\s+)?${PREDICATE}\b`, "i").test(c) ||
-          new RegExp(String.raw`^(?:still\s+)?${PREDICATE}\b${SCOPE_FOLLOWS}`, "i").test(c)) &&
+        (new RegExp(String.raw`^${CONJUNCTION}(?:is|are|it\s+is|they\s+are)\s+(?:still\s+)?${PREDICATE}\b`, "i").test(c) ||
+          new RegExp(String.raw`^${CONJUNCTION}(?:also\s+)?(?:still\s+)?${PREDICATE}\b${SCOPE_FOLLOWS}`, "i").test(c)) &&
         !SIGNATURE_FAMILIES.some(({ token }) => new RegExp(token, "i").test(c)),
     );
     for (const { text: clause, at: clauseAt } of parts) {

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -27,17 +27,148 @@ const FORBIDDEN_STATEMENTS: RegExp[] = [
   /autonomous\s+agents?\s+(?:are\s+)?not\s+(?:allowed|welcome|permitted)/i,
 ];
 
-const HUMAN_STATEMENTS: RegExp[] = [
+/**
+ * A human gate that is NOT a signature: someone must look, but nobody signs anything.
+ * Kept separate from the signature families below so the verdict code comes from WHICH roster
+ * matched, rather than from substring-testing the matched text afterwards.
+ */
+const HUMAN_REVIEW_STATEMENTS: RegExp[] = [
   /human:/i,
   /\bhuman\s+(?:review\s+)?required\b/i,
   /must\s+be\s+reviewed\s+by\s+a\s+human/i,
   /\bhuman\s+attest\w*/i,
-  /\bdco\b/i,
-  /developer\s+certificate\s+of\s+origin/i,
-  /sign(?:ing)?\s+the\s+cla/i,
-  /\bcla\s+(?:is\s+)?required\b/i,
-  /contributor\s+license\s+agreement/i,
 ];
+
+/**
+ * The instruments a human must sign, by family. Presence is not a requirement — polarity is
+ * decided per occurrence by `signaturePolarity`.
+ *
+ * WHY A BARE `\bcla\b` IS HERE. It was not, and that was the fail-open at the centre of issue #52.
+ * The only CLA-acronym patterns were `sign(?:ing)?\s+the\s+cla` and `\bcla\s+(?:is\s+)?required\b`,
+ * both defeated by an interposed "not", so five realistic "waive the DCO, assert the CLA" documents
+ * held on `main` only by the ACCIDENT of an un-negated `\bdco\b` elsewhere in the sentence —
+ * measured, every one of them reporting `human=["DCO"]` and nothing about the CLA. Make the DCO
+ * negation-aware without adding this token and all five fail open.
+ *
+ * `contributor\s+agreement` is separate from `contributor\s+licen[cs]e\s+agreement` because the
+ * short form is common and was unmatched. Neither is a bare `/agreement/i`: "you signal your
+ * agreement with the Code of Conduct" must not read as a CLA, which is the over-block direction.
+ *
+ * `signed[-\s]?off[-\s]?by` and `sign[-\s]?off` sit in the DCO family because that is what they
+ * are. On `main` "All commits must carry a Signed-off-by line." reached ALLOW with EMPTY matched
+ * phrases — a real signature requirement the scanner could not see at all.
+ */
+const SIGNATURE_FAMILIES: { family: string; token: string }[] = [
+  { family: "CLA", token: String.raw`(?:\bcla\b|contributor\s+licen[cs]e\s+agreement|contributor\s+agreement)` },
+  {
+    family: "DCO",
+    token: String.raw`(?:\bdco\b|developer\s+certificate\s+of\s+origin|signed[-\s]?off[-\s]?by|sign[-\s]?offs?\b)`,
+  },
+];
+
+/**
+ * "There is no DCO bypass" says the DCO is mandatory, not that it is waived. Checked BEFORE the
+ * waivers, because it is literally a negation sitting next to the token and every waiver pattern
+ * below would otherwise claim it.
+ */
+const ESCAPE_HATCH = String.raw`(?:bypass|exception|exemption|waiver|opt[-\s]?out|workaround|way\s+around)`;
+
+/** Words that turn a waiver into a conditional requirement: it IS required, somewhere. */
+const SCOPE_LIMITER = /\b(?:except|unless|other\s+than|apart\s+from|save\s+for)\b/i;
+
+/**
+ * There is deliberately NO "asserts a requirement" list here, and its absence is a finding rather
+ * than an omission.
+ *
+ * One was written — the usual `required|mandatory|must|sign\w*|…` roster — and the injection pass on
+ * the differential harness showed the harness could not see it being deleted. The reason is that it
+ * could never decide anything: an occurrence that matches no waiver already returns `"required"` on
+ * the line below, so the list and the fallback had the same answer and the list was unreachable. An
+ * unreachable roster of authoritative-looking vocabulary is exactly what issue #75 is about — the
+ * thing someone wires up later without re-reading.
+ *
+ * So the rule is one sentence: a signature instrument is WAIVED only if a waiver pattern governs it,
+ * and REQUIRED otherwise. Two corpus rows pin that the fallback is `required` and not `waived`
+ * ("See our CLA for details.", "We dropped the CLA requirement."), verified by flipping it.
+ */
+
+/**
+ * Decide whether one occurrence of a signature token is REQUIRED or WAIVED.
+ *
+ * Two different spans on purpose, and getting this wrong was a fail-open in the first draft of this
+ * function:
+ *
+ * - The WAIVER and the requirement verb are read from the CLAUSE, so two instruments in one
+ *   sentence cannot borrow each other's verb. "No DCO, contributor agreement required." needs this.
+ * - The SCOPE LIMITER is read from the whole SENTENCE, because "except" routinely sits in the next
+ *   clause. "A CLA is not required, except for new dependencies." read the waiver and never saw the
+ *   exception, so a scoped requirement came out as a blanket waiver — the exact fail-open class this
+ *   issue is about, reproduced inside its own fix. Caught by probing before it shipped.
+ *
+ * The ORDER is the rest of the design. Every waiver pattern that can swallow a requirement word
+ * does so explicitly — `no DCO is required` is one pattern, not "a negation" and "a requirement"
+ * fighting over one clause. The previous attempt made the DCO negation-aware and left the CLA
+ * invisible, and 8 of 10 realistic documents regressed to ALLOW.
+ */
+function signaturePolarity(clause: string, sentence: string, token: string): "required" | "waived" {
+  const T = token;
+  if (new RegExp(String.raw`\bno\s+${T}\s+${ESCAPE_HATCH}`, "i").test(clause)) return "required";
+  const waivers = [
+    String.raw`\bno\s+${T}\s+(?:is\s+|are\s+)?(?:required|needed|necessary|expected)\b`,
+    String.raw`${T}\s*:?\s*(?:is\s+|are\s+)?not\s+(?:required|needed|necessary|expected)\b`,
+    // The filler is bounded and stops at any clause break, so it cannot reach across a comma or a
+    // full stop to borrow a waiver from a neighbouring clause. It exists because "do not need TO
+    // SIGN a contributor license agreement" puts an infinitive between the verb and the token — a
+    // shape the corpus caught and the first draft of this list missed.
+    String.raw`\b(?:do(?:es)?\s+not|don['’]t|doesn['’]t|will\s+not|won['’]t)\s+(?:require|need|ask\s+for|expect)\b[^.;,\n]{0,25}?${T}`,
+    String.raw`\bthere\s+(?:is|are)\s+no\s+${T}`,
+    String.raw`\bno\s+${T}\b`,
+  ];
+  for (const w of waivers) {
+    if (!new RegExp(w, "i").test(clause)) continue;
+    // A scoped waiver is a requirement wearing a waiver's clothes: "not required EXCEPT for new
+    // dependencies" means a packet touching one needs it. Read from the sentence, not the clause.
+    return SCOPE_LIMITER.test(sentence) ? "required" : "waived";
+  }
+  /**
+   * Undecided reads as REQUIRED, which is the repo's stated asymmetry rather than a shrug: a false
+   * hold costs the operator one look, a false allow opens a draft into a repository that demands a
+   * signature, and `docs/PRODUCT.md` §3 constraint 4 is "Never forge CLA/DCO". A bare "see our CLA"
+   * with no verb is exactly the case where the tool should make a human decide.
+   */
+  return "required";
+}
+
+/**
+ * A sentence boundary is a terminator followed by whitespace and something that starts a sentence.
+ *
+ * Requiring the capital (or an opening quote/bracket) is what keeps `e.g.` and `i.e.` from ending a
+ * sentence mid-clause — the same hazard the `W` window above spells out abbreviation by
+ * abbreviation. A newline also ends one, because policy documents are markdown and a list item is a
+ * sentence whether or not it carries a full stop.
+ */
+function sentencesOf(text: string): string[] {
+  return text
+    .split(/(?<=[.!?])\s+(?=["'(\[]?[A-Z])|\n+/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Clause-sized spans, so two instruments in one sentence are judged separately.
+ *
+ * "No DCO, contributor agreement required." is the case that makes this necessary: one sentence
+ * holding a waiver and a requirement. Splitting on the comma is what lets the DCO read as waived and
+ * the contributor agreement as required, instead of one borrowing the other's verb. A code comment
+ * in the previous attempt claimed a `NEG_FILLER` regex handled the comma and nothing tested it;
+ * this is the same guarantee made structural.
+ */
+function clausesOf(sentence: string): string[] {
+  return sentence
+    .split(/[,;]|\bbut\b|\bhowever\b/i)
+    .map((c) => c.trim())
+    .filter(Boolean);
+}
 
 function quoteOf(match: RegExpExecArray): string {
   return match[0].replace(/\s+/g, " ").trim().slice(0, 160);
@@ -46,18 +177,41 @@ function quoteOf(match: RegExpExecArray): string {
 export function scanPolicyText(text: string): {
   forbidden: string[];
   human: string[];
+  /** Signature phrases the document ASSERTS. Non-empty is what makes a verdict HOLD_CLA. */
+  signatureRequired: string[];
+  /** Signature phrases the document WAIVES, kept so a freeze can show what was read and dismissed. */
+  signatureWaived: string[];
 } {
   const forbidden: string[] = [];
-  const human: string[] = [];
+  const humanReview: string[] = [];
+  const signatureRequired: string[] = [];
+  const signatureWaived: string[] = [];
   for (const re of FORBIDDEN_STATEMENTS) {
     const m = re.exec(text);
     if (m) forbidden.push(quoteOf(m));
   }
-  for (const re of HUMAN_STATEMENTS) {
+  for (const re of HUMAN_REVIEW_STATEMENTS) {
     const m = re.exec(text);
-    if (m) human.push(quoteOf(m));
+    if (m) humanReview.push(quoteOf(m));
   }
-  return { forbidden: [...new Set(forbidden)], human: [...new Set(human)] };
+  for (const sentence of sentencesOf(text)) {
+    for (const clause of clausesOf(sentence)) {
+      for (const { family, token } of SIGNATURE_FAMILIES) {
+        if (!new RegExp(token, "i").test(clause)) continue;
+        const quote = `${family}: ${clause.replace(/\s+/g, " ").trim().slice(0, 140)}`;
+        if (signaturePolarity(clause, sentence, token) === "required") signatureRequired.push(quote);
+        else signatureWaived.push(quote);
+      }
+    }
+  }
+  return {
+    forbidden: [...new Set(forbidden)],
+    // A WAIVED signature is deliberately absent: a document that says "No CLA. No DCO." must not
+    // park the packet, which is the over-block half of issue #52 and the live Wave-1 seed text.
+    human: [...new Set([...humanReview, ...signatureRequired])],
+    signatureRequired: [...new Set(signatureRequired)],
+    signatureWaived: [...new Set(signatureWaived)],
+  };
 }
 
 function holdFromConditions(record: PolicyRecord): PolicyVerdict | undefined {
@@ -142,11 +296,11 @@ export function evaluatePolicy(
   }
 
   if (record?.stance === "conditional") {
-    const scannedCla = scanned.human.some((p) => {
-      const lower = p.toLowerCase();
-      return lower.includes("cla") || lower.includes("dco") || lower.includes("certificate");
-    });
-    if (scannedCla) {
+    // The code comes from WHICH roster matched, not from substring-testing the matched text. The
+    // old test asked whether the phrase contained "cla", "dco" or "certificate", which is why
+    // "Contributor License Agreement" — the phrasing most likely to appear in a real
+    // CONTRIBUTING.md — landed in HOLD_HUMAN: the letters c, l, a never appear consecutively in it.
+    if (scanned.signatureRequired.length > 0) {
       return {
         allow: false,
         code: "HOLD_CLA",
@@ -181,10 +335,9 @@ export function evaluatePolicy(
   const matched = [...scanned.human];
 
   if (repo.aiPolicy === "human-required" || scanned.human.length > 0) {
-    const cla = scanned.human.some((p) => {
-      const lower = p.toLowerCase();
-      return lower.includes("cla") || lower.includes("dco") || lower.includes("certificate");
-    });
+    // Second of the two call sites that re-derived this. One source now, for the reason
+    // fixture-counts.ts gives about two copies of one rule.
+    const cla = scanned.signatureRequired.length > 0;
     return {
       allow: false,
       code: cla ? "HOLD_CLA" : "HOLD_HUMAN",

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -246,7 +246,12 @@ function signaturePolarity(clause: string, sentence: string, token: string): "re
      * words are DCO-family tokens, so a mention abutting a removed span is absorbed with it.
      * Without that, "We don't require a DCO sign-off on contributions." became a hold.
      */
-    const abuts = new RegExp(String.raw`^[\s\-]{0,3}${T}`, "i");
+    // At most one space, or a hyphen with nothing around it: "a DCO sign-off" and "sign-off" are one
+    // instrument, so the second token is absorbed with the first. A DASH THAT SEPARATES STATEMENTS is
+    // not that — "No DCO is required - DCO is required for code." had its requirement eaten by an
+    // absorption window three characters wide, a fail-open P1 from review. The exception is for a
+    // compound noun and is now shaped like one.
+    const abuts = new RegExp(String.raw`^(?:[ \t]|-)?${T}`, "i");
     let residual = clause;
     for (let removed = true; removed; ) {
       removed = false;
@@ -255,7 +260,16 @@ function signaturePolarity(clause: string, sentence: string, token: string): "re
         if (!span) continue;
         let tail = residual.slice(span.index + span[0].length);
         for (let abut = abuts.exec(tail); abut; abut = abuts.exec(tail)) tail = tail.slice(abut[0].length);
-        residual = `${residual.slice(0, span.index)} ${tail}`;
+        const next = `${residual.slice(0, span.index)} ${tail}`;
+        // Progress is required, not assumed. Termination here rests on the residual getting shorter,
+        // and nothing structural guaranteed it: a pattern whose removal leaves the length unchanged
+        // spins forever. Every pattern above does shrink, so NO TEST DEFENDS THIS LINE and a mutant
+        // deleting it survives — said plainly rather than implied. It is here because the gate reads
+        // a stranger's document, a non-terminating loop is a denial of service, and the next pattern
+        // added to that list should not be able to cause one. The hang is not hypothetical: this
+        // file's own mutation harness produced one while the invariant was only conventional.
+        if (next.length >= residual.length) continue;
+        residual = next;
         removed = true;
         break;
       }
@@ -302,7 +316,7 @@ function signaturePolarity(clause: string, sentence: string, token: string): "re
  * a reader comparing them should find them saying the same thing.
  */
 const CONTINUATION = new RegExp(
-  String.raw`^(?:[-*+>]|\d+[.)])?[\s"'(\[]*(?:(?:${SCOPE_LIMITER.source.replace(/^\\b|\\b$/g, "")}|${CONJUNCTION_WORDS})\b|(?:is|are|it\s+is|they\s+are)\s+(?:still\s+)?${PREDICATE}\b${SCOPE_FOLLOWS}|${PREDICATE}\b${SCOPE_FOLLOWS}|(?:it|this|that|they|these|those)\s+\w+)`,
+  String.raw`^(?:[-*+>]|\d+[.)])?[\s"'(\[]*(?:(?:${SCOPE_LIMITER.source.replace(/^\\b|\\b$/g, "")}|${CONJUNCTION_WORDS})\b|(?:is|are|it\s+is|they\s+are)\s+(?:still\s+)?${PREDICATE}\b${SCOPE_FOLLOWS}|${PREDICATE}\b${SCOPE_FOLLOWS}|(?:it|this|that|they|these|those)[\s,;]+\w+)`,
   "i",
 );
 

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -117,9 +117,27 @@ function signaturePolarity(clause: string, sentence: string, token: string): "re
   for (const w of waivers) {
     const hit = new RegExp(w, "i").exec(clause);
     if (!hit) continue;
-    // A scoped waiver is a requirement wearing a waiver's clothes: "not required EXCEPT for new
-    // dependencies" means a packet touching one needs it. Read from the sentence, not the clause.
-    if (SCOPE_LIMITER.test(sentence)) return "required";
+    /**
+     * A scoped waiver is a requirement in a waiver's clothes: "not required EXCEPT for new
+     * dependencies" means a packet touching one needs it. But the limiter has to belong to THIS
+     * waiver, and both ways of getting that wrong are fail-modes this branch actually shipped:
+     *
+     * - Reading it from the CLAUSE missed "A CLA is not required, except for new dependencies.",
+     *   because the limiter sits in the next clause. Fail-open.
+     * - Reading it from the whole SENTENCE over-blocked "No CLA is required, and all patches are
+     *   welcome except spam", where the "except" is about spam. Fail-closed, and it parks a packet
+     *   whose policy waives the CLA in as many words. Raised as P1 by review.
+     *
+     * So the span is the waiver's own statement: its clause, plus what follows the waiver up to the
+     * first coordinating conjunction — a limiter past an "and" belongs to a different statement —
+     * plus a leading "Except for X, ..." that the waiver is the main clause of.
+     */
+    const at = sentence.toLowerCase().indexOf(hit[0].toLowerCase());
+    const after = at === -1 ? "" : sentence.slice(at + hit[0].length);
+    const conjunction = after.search(/\b(?:and|or|but|however)\b/i);
+    const forward = conjunction === -1 ? after : after.slice(0, conjunction);
+    const leading = at > 0 && SCOPE_LIMITER.test(sentence.slice(0, at).replace(/^[\s"'(\[]*/, "").split(/[,;]/)[0] ?? "");
+    if (SCOPE_LIMITER.test(clause) || SCOPE_LIMITER.test(forward) || leading) return "required";
     /**
      * A WAIVER GOVERNS ONLY THE OCCURRENCE IT NAMES — a P1 from review. Polarity was decided once
      * per clause from the first match, so "No CLA is required for documentation and a CLA is

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -202,6 +202,9 @@ function signaturePolarity(clause: string, sentence: string, token: string): "re
      * phrasing, because the question is never asked.
      */
     if (SCOPE_LIMITER.test(sentence)) return "required";
+    // ...and a back-referring pronoun clause, for the same reason: what `it` points at is coreference,
+    // and the sentence cannot be read without knowing. See `PRONOUN_CLAUSE`.
+    if (PRONOUN_CLAUSE.test(sentence)) return "required";
     /**
      * A COORDINATED requirement on the same elided subject: "no CLA is required for docs and
      * required for code." `and` is not a clause delimiter, so this requirement lives inside the
@@ -299,7 +302,7 @@ function signaturePolarity(clause: string, sentence: string, token: string): "re
  * a reader comparing them should find them saying the same thing.
  */
 const CONTINUATION = new RegExp(
-  String.raw`^(?:[-*+>]|\d+[.)])?[\s"'(\[]*(?:(?:${SCOPE_LIMITER.source.replace(/^\\b|\\b$/g, "")}|${CONJUNCTION_WORDS})\b|(?:is|are|it\s+is|they\s+are)\s+(?:still\s+)?${PREDICATE}\b${SCOPE_FOLLOWS}|${PREDICATE}\b${SCOPE_FOLLOWS})`,
+  String.raw`^(?:[-*+>]|\d+[.)])?[\s"'(\[]*(?:(?:${SCOPE_LIMITER.source.replace(/^\\b|\\b$/g, "")}|${CONJUNCTION_WORDS})\b|(?:is|are|it\s+is|they\s+are)\s+(?:still\s+)?${PREDICATE}\b${SCOPE_FOLLOWS}|${PREDICATE}\b${SCOPE_FOLLOWS}|(?:it|this|that|they|these|those)\s+\w+)`,
   "i",
 );
 
@@ -310,6 +313,21 @@ const CONTINUATION = new RegExp(
  * the marker back first puts them in one sentence again.
  */
 const MARKER_ONLY = /^(?:[-*+>]|\d+[.)])\s*$/;
+
+/**
+ * A clause whose subject is a pronoun pointing at something already named.
+ *
+ * "No CLA is required for docs. It applies to code, except for vendored trees." — `It` is the CLA,
+ * and the sentence that qualifies the waiver was dropped because it names no instrument. A P1 from
+ * review, and the seventh continuation shape to arrive.
+ *
+ * It is the last one that gets a shape-specific fix, because the next one would need a vocabulary of
+ * applicability verbs (`applies`, `covers`, `extends to`) on top of the requirement vocabulary, and
+ * that is the road this branch already came down. A pronoun clause sharing a sentence with a waiver
+ * simply HOLDS: resolving what `it` refers to is coreference, which is further outside a regex than
+ * limiter attachment ever was.
+ */
+const PRONOUN_CLAUSE = /\b(?:it|this|that|they|these|those)\s+\w+/i;
 
 function sentencesOf(text: string): string[] {
   const out: string[] = [];

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -40,37 +40,23 @@ const HUMAN_REVIEW_STATEMENTS: RegExp[] = [
 ];
 
 /**
- * The instruments a human must sign, by family. Presence is not a requirement — polarity is
- * decided per occurrence by `signaturePolarity`.
+ * The instruments a human must sign. Presence is not a requirement — `signaturePolarity` decides.
  *
- * WHY A BARE `\bcla\b` IS HERE. It was not, and that was the fail-open at the centre of issue #52.
- * The only CLA-acronym patterns were `sign(?:ing)?\s+the\s+cla` and `\bcla\s+(?:is\s+)?required\b`,
- * both defeated by an interposed "not", so five realistic "waive the DCO, assert the CLA" documents
- * held on `main` only by the ACCIDENT of an un-negated `\bdco\b` elsewhere in the sentence —
- * measured, every one of them reporting `human=["DCO"]` and nothing about the CLA. Make the DCO
- * negation-aware without adding this token and all five fail open.
+ * The bare CLA acronym is the fix for issue #52. Without it the only CLA patterns were
+ * `sign(?:ing)?\s+the\s+cla` and `\bcla\s+(?:is\s+)?required\b`, both defeated by an interposed
+ * "not", so five realistic "waive the DCO, assert the CLA" documents held on `main` only by the
+ * ACCIDENT of an un-negated `\bdco\b` in the same sentence — each reporting `human=["DCO"]` and
+ * nothing about the CLA. Negate the DCO without adding this and all five fail open.
  *
- * `contributor\s+agreement` is separate from `contributor\s+licen[cs]e\s+agreement` because the
- * short form is common and was unmatched. Neither is a bare `/agreement/i`: "you signal your
- * agreement with the Code of Conduct" must not read as a CLA, which is the over-block direction.
+ * Plurals are a P1 from review: `\bcla\b` misses `CLAs`, so "No DCO. CLAs are mandatory." waived
+ * the DCO and saw nothing — this issue's defect in a new spelling. `\bclas?\b` cannot match
+ * "class" (the optional `s` still needs a boundary after it), and a corpus row asserts that.
  *
- * `signed[-\s]?off[-\s]?by` and `sign[-\s]?off` sit in the DCO family because that is what they
- * are. On `main` "All commits must carry a Signed-off-by line." reached ALLOW with EMPTY matched
- * phrases — a real signature requirement the scanner could not see at all.
+ * Not a bare `/agreement/i`: "your agreement with the Code of Conduct" is not a CLA. Sign-off
+ * vocabulary is DCO family because it is one — on `main` "All commits must carry a Signed-off-by
+ * line." reached ALLOW matching nothing at all.
  */
 const SIGNATURE_FAMILIES: { family: string; token: string }[] = [
-  /**
-   * The acronyms are PLURAL-TOLERANT, and that was a P1 fail-open in the first version of this
-   * change: `\bcla\b` does not match `CLAs`, so "No DCO. CLAs are mandatory." waived the DCO, saw
-   * nothing about the CLA, and reached ALLOW for a repository that demands a signature — the exact
-   * defect this issue exists to close, reintroduced in its own fix in a new spelling. Measured:
-   * "CLAs are required for all contributors." and "We require DCOs on every commit." were both
-   * SILENT, matching nothing at all.
-   *
-   * `\bclas?\b` cannot match "class": the optional `s` still needs a word boundary after it, and
-   * "class" has another letter there. The spelled-out forms already matched inside their own plurals
-   * by substring; the explicit `s?` says so rather than leaving it to be rediscovered.
-   */
   {
     family: "CLA",
     token: String.raw`(?:\bclas?\b|contributor\s+licen[cs]e\s+agreements?|contributor\s+agreements?)`,
@@ -92,19 +78,10 @@ const ESCAPE_HATCH = String.raw`(?:bypass|exception|exemption|waiver|opt[-\s]?ou
 const SCOPE_LIMITER = /\b(?:except|unless|other\s+than|apart\s+from|save\s+for)\b/i;
 
 /**
- * There is deliberately NO "asserts a requirement" list here, and its absence is a finding rather
- * than an omission.
- *
- * One was written — the usual `required|mandatory|must|sign\w*|…` roster — and the injection pass on
- * the differential harness showed the harness could not see it being deleted. The reason is that it
- * could never decide anything: an occurrence that matches no waiver already returns `"required"` on
- * the line below, so the list and the fallback had the same answer and the list was unreachable. An
- * unreachable roster of authoritative-looking vocabulary is exactly what issue #75 is about — the
- * thing someone wires up later without re-reading.
- *
- * So the rule is one sentence: a signature instrument is WAIVED only if a waiver pattern governs it,
- * and REQUIRED otherwise. Two corpus rows pin that the fallback is `required` and not `waived`
- * ("See our CLA for details.", "We dropped the CLA requirement."), verified by flipping it.
+ * There is deliberately NO "asserts a requirement" roster. One was written, and the injection pass
+ * showed the harness could not see it deleted: an occurrence matching no waiver already returns
+ * `"required"`, so the list and the fallback gave the same answer and it was unreachable — the #75
+ * orphan shape. The rule is one sentence: WAIVED only if a waiver governs it, REQUIRED otherwise.
  */
 
 /**
@@ -113,17 +90,16 @@ const SCOPE_LIMITER = /\b(?:except|unless|other\s+than|apart\s+from|save\s+for)\
  * Two different spans on purpose, and getting this wrong was a fail-open in the first draft of this
  * function:
  *
- * - The WAIVER and the requirement verb are read from the CLAUSE, so two instruments in one
- *   sentence cannot borrow each other's verb. "No DCO, contributor agreement required." needs this.
- * - The SCOPE LIMITER is read from the whole SENTENCE, because "except" routinely sits in the next
- *   clause. "A CLA is not required, except for new dependencies." read the waiver and never saw the
- *   exception, so a scoped requirement came out as a blanket waiver — the exact fail-open class this
- *   issue is about, reproduced inside its own fix. Caught by probing before it shipped.
+ * - The WAIVER is read from the CLAUSE, so two instruments in one sentence cannot borrow each
+ *   other's verb ("No DCO, contributor agreement required.").
+ * - The SCOPE LIMITER is read from the SENTENCE, because "except" sits in the next clause. Reading
+ *   it from the clause made "A CLA is not required, except for new dependencies." a blanket waiver
+ *   — this issue's fail-open class inside its own fix, caught by probing before it shipped.
  *
- * The ORDER is the rest of the design. Every waiver pattern that can swallow a requirement word
- * does so explicitly — `no DCO is required` is one pattern, not "a negation" and "a requirement"
- * fighting over one clause. The previous attempt made the DCO negation-aware and left the CLA
- * invisible, and 8 of 10 realistic documents regressed to ALLOW.
+ * The ORDER is the rest: every waiver that can swallow a requirement word does so explicitly, so
+ * `no DCO is required` is one pattern rather than a negation and a requirement fighting over a
+ * clause. The previous attempt negated the DCO and left the CLA invisible — 8 of 10 documents
+ * regressed to ALLOW.
  */
 function signaturePolarity(clause: string, sentence: string, token: string): "required" | "waived" {
   const T = token;
@@ -131,10 +107,9 @@ function signaturePolarity(clause: string, sentence: string, token: string): "re
   const waivers = [
     String.raw`\bno\s+${T}\s+(?:is\s+|are\s+)?(?:required|needed|necessary|expected)\b`,
     String.raw`${T}\s*:?\s*(?:is\s+|are\s+)?not\s+(?:required|needed|necessary|expected)\b`,
-    // The filler is bounded and stops at any clause break, so it cannot reach across a comma or a
-    // full stop to borrow a waiver from a neighbouring clause. It exists because "do not need TO
-    // SIGN a contributor license agreement" puts an infinitive between the verb and the token — a
-    // shape the corpus caught and the first draft of this list missed.
+    // Bounded filler, stopping at any clause break so it cannot borrow a neighbour's waiver. It
+    // exists because "do not need TO SIGN a contributor license agreement" puts an infinitive
+    // between verb and token — a shape the corpus caught and the first draft of this list missed.
     String.raw`\b(?:do(?:es)?\s+not|don['’]t|doesn['’]t|will\s+not|won['’]t)\s+(?:require|need|ask\s+for|expect)\b[^.;,\n]{0,25}?${T}`,
     String.raw`\bthere\s+(?:is|are)\s+no\s+${T}`,
     String.raw`\bno\s+${T}\b`,
@@ -146,23 +121,15 @@ function signaturePolarity(clause: string, sentence: string, token: string): "re
     // dependencies" means a packet touching one needs it. Read from the sentence, not the clause.
     if (SCOPE_LIMITER.test(sentence)) return "required";
     /**
-     * A WAIVER GOVERNS ONLY THE OCCURRENCE IT NAMES. Raised as P1 by review: polarity was decided
-     * once for the whole clause from the FIRST match, so
+     * A WAIVER GOVERNS ONLY THE OCCURRENCE IT NAMES — a P1 from review. Polarity was decided once
+     * per clause from the first match, so "No CLA is required for documentation and a CLA is
+     * required for code." matched the waiver, never saw the second occurrence, and reached ALLOW.
+     * Removing the waived span and asking whether the instrument is still mentioned settles it
+     * without guessing at conjunctions; any surviving mention is ungoverned, so it reads as required.
      *
-     *   "No CLA is required for documentation and a CLA is required for code contributions."
-     *
-     * matched the waiver, never looked at the second occurrence, and reached ALLOW for a repository
-     * that requires a signature. "and" is not a clause delimiter and should not have to be: taking
-     * the waived text out and asking whether the instrument is still mentioned answers it without
-     * guessing at English conjunctions. Any surviving mention is an occurrence no waiver spoke for,
-     * and under this repo's asymmetry that reads as required.
-     */
-    /**
-     * One instrument can be NAMED TWICE in a row — "a DCO sign-off" is a single thing, and both
-     * "DCO" and "sign-off" are DCO-family tokens. So a mention abutting the waiver's own span is
-     * absorbed into it before the leftovers are inspected; without that,
-     * "We don't require a DCO sign-off on contributions." saw "sign-off" as an ungoverned second
-     * occurrence and flipped a plain waiver into a hold.
+     * One instrument can be named twice in a row, though: "a DCO sign-off" is a single thing and
+     * both words are DCO-family tokens, so a mention abutting the waiver's span is absorbed first.
+     * Without that, "We don't require a DCO sign-off on contributions." became a hold.
      */
     let tail = clause.slice(hit.index + hit[0].length);
     for (let abut = new RegExp(String.raw`^[\s\-]{0,3}${T}`, "i").exec(tail); abut; ) {
@@ -172,22 +139,17 @@ function signaturePolarity(clause: string, sentence: string, token: string): "re
     if (new RegExp(T, "i").test(`${clause.slice(0, hit.index)} ${tail}`)) return "required";
     return "waived";
   }
-  /**
-   * Undecided reads as REQUIRED, which is the repo's stated asymmetry rather than a shrug: a false
-   * hold costs the operator one look, a false allow opens a draft into a repository that demands a
-   * signature, and `docs/PRODUCT.md` §3 constraint 4 is "Never forge CLA/DCO". A bare "see our CLA"
-   * with no verb is exactly the case where the tool should make a human decide.
-   */
+  // Undecided reads as REQUIRED — the repo's asymmetry, not a shrug. A false hold costs one look; a
+  // false allow opens a draft into a repo demanding a signature, and PRODUCT.md §3 says never forge.
   return "required";
 }
 
 /**
  * A sentence boundary is a terminator followed by whitespace and something that starts a sentence.
  *
- * Requiring the capital (or an opening quote/bracket) is what keeps `e.g.` and `i.e.` from ending a
- * sentence mid-clause — the same hazard the `W` window above spells out abbreviation by
- * abbreviation. A newline also ends one, because policy documents are markdown and a list item is a
- * sentence whether or not it carries a full stop.
+ * Requiring the capital keeps `e.g.` and `i.e.` from ending a sentence mid-clause — the hazard the
+ * `W` window above spells out abbreviation by abbreviation. A newline ends one too: these are
+ * markdown, and a list item is a sentence whether or not it carries a full stop.
  */
 function sentencesOf(text: string): string[] {
   return text

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -231,23 +231,43 @@ function signaturePolarity(clause: string, clauseAt: number, sentence: string, t
  * `W` window above spells out abbreviation by abbreviation. A newline ends one too: these are
  * markdown, and a list item is a sentence whether or not it carries a full stop.
  *
- * A sentence STARTING with a scope limiter is not a new statement, it is the previous one's scope:
- * "No CLA is required. Except for code." Splitting them left a blanket waiver and a token-less
- * fragment nothing looked at, and the repo reached ALLOW while requiring a CLA for code — a P1 from
- * review. Joining it back is what lets every existing scope rule see it, rather than adding a second
- * way to decide scope.
+ * A CONTINUATION is not a new statement, it is more of the previous one, so it is joined back —
+ * which lets every existing clause and scope rule see it instead of adding a second way to decide
+ * scope. Three P1s from review, all the same defect at different punctuation:
  *
- * Sentence-INITIAL is the whole test, and it is what separates this from "No CLA. Reviews are quick,
- * except during release weeks.", where the limiter sits mid-sentence with its own subject and must
- * not reach the waiver. Where a fragment is genuinely ambiguous, joining over-blocks rather than
- * over-allows, which is the asymmetry `signaturePolarity` closes with.
+ * - "No CLA is required. Except for code." — the scope, split off as a token-less fragment.
+ * - "A CLA is not required for docs. But is required for code." — the requirement, same shape.
+ * - "No CLA is required.\n- Except for code." — the same again behind a markdown list marker, which
+ *   the first version of this rule did not allow for.
+ *
+ * Each left a blanket waiver and a fragment nothing looked at, and the repo reached ALLOW while
+ * requiring a signature. What makes a continuation is its FIRST word: a scope limiter or a
+ * coordinating conjunction, after any list marker or opening quote. That is what separates them from
+ * "No CLA. Reviews are quick, except during release weeks.", where the limiter sits mid-sentence
+ * with its own subject and must not reach the waiver.
+ *
+ * A fragment that is genuinely ambiguous joins, and joining over-blocks rather than over-allows —
+ * the asymmetry `signaturePolarity` closes with, applied to punctuation.
  */
+const CONTINUATION = new RegExp(
+  String.raw`^(?:[-*+>]|\d+[.)])?[\s"'(\[]*(?:${SCOPE_LIMITER.source.replace(/^\\b|\\b$/g, "")}|and|or|but|however)\b`,
+  "i",
+);
+
+/**
+ * A fragment that is nothing but a list marker. `1.` ends in a terminator followed by a capital, so
+ * the boundary rule above splits an ordered item into a marker and a body — and the marker then stood
+ * between a waiver and its scope, so the scope joined to the marker instead of the waiver. Joining
+ * the marker back first puts them in one sentence again.
+ */
+const MARKER_ONLY = /^(?:[-*+>]|\d+[.)])\s*$/;
+
 function sentencesOf(text: string): string[] {
   const out: string[] = [];
   for (const sentence of text.split(/(?<=[.!?])\s+(?=["'(\[]?[A-Z])|\n+/).map((s) => s.trim()).filter(Boolean)) {
-    const anaphoricScope = new RegExp(String.raw`^["'(\[]*${SCOPE_LIMITER.source.replace(/^\\b|\\b$/g, "")}\b`, "i").test(sentence);
     const previous = out.at(-1);
-    if (anaphoricScope && previous !== undefined) out[out.length - 1] = `${previous} ${sentence}`;
+    const continues = CONTINUATION.test(sentence) || MARKER_ONLY.test(sentence);
+    if (previous !== undefined && continues) out[out.length - 1] = `${previous} ${sentence}`;
     else out.push(sentence);
   }
   return out;

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -64,6 +64,16 @@ const SIGNATURE_FAMILIES: { family: string; token: string }[] = [
 const ANY_INSTRUMENT = `(?:${SIGNATURE_FAMILIES.map(({ token }) => token).join("|")})`;
 
 /**
+ * The words a requirement is asserted WITH, when its subject has been elided.
+ *
+ * ONE roster, because there were two and they drifted: the waiver patterns knew `expected` and this
+ * did not, so "No CLA is expected for docs and expected for code." waived the whole sentence and
+ * reached ALLOW — a P1 from review. A waiver and a requirement are the same vocabulary under
+ * opposite polarity, so a word this factory can waive is a word it must be able to require.
+ */
+const PREDICATE = String.raw`(?:required|needed|necessary|expected|mandatory|obligatory|compulsory)`;
+
+/**
  * "There is no DCO bypass" says the DCO is mandatory, not that it is waived. Checked BEFORE the
  * waivers, because it is literally a negation sitting next to the token and every waiver pattern
  * below would otherwise claim it.
@@ -81,6 +91,11 @@ const ANY_INSTRUMENT = `(?:${SIGNATURE_FAMILIES.map(({ token }) => token).join("
  * follows it: "No CLA is needed." puts `needed` where the hatch word would be, matches nothing here,
  * and stays a waiver. An open slot in front of a required anchor cannot over-match.
  *
+ * The slot cannot cross a requirement word. Unbounding it let "No CLA is required for optional
+ * contributions." reach `optional` across "is required for" and reverse a plain waiver — a
+ * fail-CLOSED P1 from review, caused by the previous commit. Past a `PREDICATE` this is no longer a
+ * "no X is <permission>" construction at all, so the temper says exactly that.
+ *
  * UNBOUNDED, and deliberately. It was capped at four words and review immediately produced a
  * five-word denial; any finite cap invites the next one, and the cap was arbitrary. It is safe to
  * remove because `\w+\s+` crosses neither punctuation nor a clause boundary, so the slot cannot
@@ -94,7 +109,7 @@ const ANY_INSTRUMENT = `(?:${SIGNATURE_FAMILIES.map(({ token }) => token).join("
  * needs punctuation tolerance inside the copula, which is one more widening in a pattern that has
  * produced a new gap for every widening so far. Recorded rather than fixed, and rather than hidden.
  */
-const ESCAPE_HATCH = String.raw`(?:is\s+|are\s+)?(?:\w+\s+)*?(?:bypass|except|exempt|waive|opt[-\s]?out|workaround|ways?\s+around|optional|voluntary|discretionary|up\s+to\s+you|at\s+your\s+discretion)`;
+const ESCAPE_HATCH = String.raw`(?:is\s+|are\s+)?(?:(?!${PREDICATE})\w+\s+)*?(?:bypass|except|exempt|waive|opt[-\s]?out|workaround|ways?\s+around|optional|voluntary|discretionary|up\s+to\s+you|at\s+your\s+discretion)`;
 
 /** Words that turn a waiver into a conditional requirement: it IS required, somewhere. */
 const SCOPE_LIMITER = /\b(?:except|unless|other\s+than|apart\s+from|save\s+for)\b/i;
@@ -109,16 +124,6 @@ const SCOPE_LIMITER = /\b(?:except|unless|other\s+than|apart\s+from|save\s+for)\
  * and `COORDINATED` already reads the ones that do not. An unfalsifiable rule is worse than none.
  */
 const CONJUNCTION_WORDS = String.raw`(?:and|or|plus|but|however|yet|though|although|whereas|while|nevertheless|nonetheless)`;
-
-/**
- * The words a requirement is asserted WITH, when its subject has been elided.
- *
- * ONE roster, because there were two and they drifted: the waiver patterns knew `expected` and this
- * did not, so "No CLA is expected for docs and expected for code." waived the whole sentence and
- * reached ALLOW — a P1 from review. A waiver and a requirement are the same vocabulary under
- * opposite polarity, so a word this factory can waive is a word it must be able to require.
- */
-const PREDICATE = String.raw`(?:required|needed|necessary|expected|mandatory|obligatory|compulsory)`;
 
 /**
  * What must follow a bare `PREDICATE` for it to be a requirement rather than a noun modifier.
@@ -282,7 +287,15 @@ function signaturePolarity(clause: string, sentence: string, token: string): "re
         const span = new RegExp(w, "i").exec(residual);
         if (!span) continue;
         let tail = residual.slice(span.index + span[0].length);
-        for (let abut = abuts.exec(tail); abut; abut = abuts.exec(tail)) tail = tail.slice(abut[0].length);
+        // Absorption only from a span that ENDS with an instrument. "We don't require a DCO sign-off"
+        // removes "...a DCO" and the next token continues that same noun phrase; "No DCO is required
+        // DCO is required for code." removes "...is required" and the next token starts a new
+        // statement. A one-space window cannot tell those apart, and eating the second one was a
+        // fail-open P1 from review. What the span ends with can tell them apart exactly.
+        const compound = new RegExp(String.raw`${T}\s*$`, "i").test(span[0]);
+        if (compound) {
+          for (let abut = abuts.exec(tail); abut; abut = abuts.exec(tail)) tail = tail.slice(abut[0].length);
+        }
         const next = `${residual.slice(0, span.index)} ${tail}`;
         // Progress is required, not assumed. Termination here rests on the residual getting shorter,
         // and nothing structural guaranteed it: a pattern whose removal leaves the length unchanged

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -422,18 +422,33 @@ export function scanPolicyText(text: string): {
      * is what keeps a bare participle from matching a noun modifier.
      */
     const CONJUNCTION = String.raw`(?:${CONJUNCTION_WORDS}\s+)?`;
-    const anaphoric = parts.some(
-      ({ text: c }) =>
-        (new RegExp(String.raw`^${CONJUNCTION}(?:is|are|it\s+is|they\s+are)\s+(?:still\s+)?${PREDICATE}\b`, "i").test(c) ||
-          new RegExp(String.raw`^${CONJUNCTION}(?:also\s+)?(?:still\s+)?${PREDICATE}\b${SCOPE_FOLLOWS}`, "i").test(c)) &&
-        !SIGNATURE_FAMILIES.some(({ token }) => new RegExp(token, "i").test(c)),
-    );
+    // No "and this clause names no instrument" test: the walk below only asks this of clauses where
+    // no family token matched, so the guard that used to live here was unreachable — a mutant
+    // deleting it changed nothing, which is how it was found.
+    const isAnaphoric = (c: string) =>
+      new RegExp(String.raw`^${CONJUNCTION}(?:is|are|it\s+is|they\s+are)\s+(?:still\s+)?${PREDICATE}\b`, "i").test(c) ||
+      new RegExp(String.raw`^${CONJUNCTION}(?:also\s+)?(?:still\s+)?${PREDICATE}\b${SCOPE_FOLLOWS}`, "i").test(c);
+    /**
+     * An elided subject refers to the instrument most recently NAMED, so the requirement lands on
+     * that family and no other. A sentence-wide flag put it on both: "No CLA is required for docs,
+     * but is required for code, and no DCO is needed." reported the DCO as required when the sentence
+     * waives it outright — a P1 from review, and a fail-CLOSED one. The verdict happened to be the
+     * same, because the CLA genuinely is required, but the freeze evidence named the wrong instrument
+     * and that record is what a human reads before signing.
+     */
+    const anaphoricFamilies = new Set<string>();
+    let named: string | undefined;
+    for (const { text: c } of parts) {
+      const here = SIGNATURE_FAMILIES.find(({ token }) => new RegExp(token, "i").test(c));
+      if (here) named = here.family;
+      else if (isAnaphoric(c) && named !== undefined) anaphoricFamilies.add(named);
+    }
     for (const { text: clause, at: clauseAt } of parts) {
       for (const { family, token } of SIGNATURE_FAMILIES) {
         if (!new RegExp(token, "i").test(clause)) continue;
         const quote = `${family}: ${clause.replace(/\s+/g, " ").trim().slice(0, 140)}`;
         const polarity = signaturePolarity(clause, clauseAt, sentence, token);
-        if (polarity === "required" || anaphoric) signatureRequired.push(quote);
+        if (polarity === "required" || anaphoricFamilies.has(family)) signatureRequired.push(quote);
         else signatureWaived.push(quote);
       }
     }

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -80,21 +80,20 @@ const SCOPE_LIMITER = /\b(?:except|unless|other\s+than|apart\s+from|save\s+for)\
 /**
  * Decide whether one occurrence of a signature token is REQUIRED or WAIVED.
  *
- * Two different spans on purpose, and getting this wrong was a fail-open in the first draft of this
- * function:
+ * Two different spans on purpose, and getting this wrong was a fail-open in the first draft:
  *
  * - The WAIVER is read from the CLAUSE, so two instruments in one sentence cannot borrow each
  *   other's verb ("No DCO, contributor agreement required.").
- * - The SCOPE LIMITER is read from the SENTENCE, because "except" sits in the next clause. Reading
- *   it from the clause made "A CLA is not required, except for new dependencies." a blanket waiver
- *   — this issue's fail-open class inside its own fix, caught by probing before it shipped.
+ * - The SCOPE LIMITER is read from the waiver's own STATEMENT, which crosses the clause boundary but
+ *   stops short of the whole sentence. Three wrong spans shipped for this one decision; the block at
+ *   the limiter check names each and why the current one is neither too narrow nor too wide.
  *
  * The ORDER is the rest: every waiver that can swallow a requirement word does so explicitly, so
  * `no DCO is required` is one pattern rather than a negation and a requirement fighting over a
  * clause. The previous attempt negated the DCO and left the CLA invisible — 8 of 10 documents
  * regressed to ALLOW.
  */
-function signaturePolarity(clause: string, sentence: string, token: string): "required" | "waived" {
+function signaturePolarity(clause: string, clauseAt: number, sentence: string, token: string): "required" | "waived" {
   const T = token;
   if (new RegExp(String.raw`\bno\s+${T}\s+${ESCAPE_HATCH}`, "i").test(clause)) return "required";
   const waivers = [
@@ -118,9 +117,15 @@ function signaturePolarity(clause: string, sentence: string, token: string): "re
      * packet that waives the CLA outright — P1 from review). So the span is the waiver's own
      * statement: its clause, what follows up to the first coordinating conjunction, and a leading
      * "Except for X, ..." it is the main clause of.
+     *
+     * The position is the clause's offset plus the match's offset inside it. Asking the SENTENCE
+     * where `hit[0]` is answers with the first copy, so a repeated waiver measured the later one from
+     * the earlier one's position: the forward span stopped at the intervening conjunction, the
+     * limiter behind it was never in view, and a scoped requirement reached ALLOW. Third P1 from
+     * review, and the third wrong span for this one decision.
      */
-    const at = sentence.toLowerCase().indexOf(hit[0].toLowerCase());
-    const after = at === -1 ? "" : sentence.slice(at + hit[0].length);
+    const at = clauseAt + hit.index;
+    const after = sentence.slice(at + hit[0].length);
     const conjunction = after.search(/\b(?:and|or|but|however)\b/i);
     const forward = conjunction === -1 ? after : after.slice(0, conjunction);
     const leading = at > 0 && SCOPE_LIMITER.test(sentence.slice(0, at).replace(/^[\s"'(\[]*/, "").split(/[,;]/)[0] ?? "");
@@ -164,19 +169,32 @@ function sentencesOf(text: string): string[] {
 }
 
 /**
- * Clause-sized spans, so two instruments in one sentence are judged separately.
+ * Clause-sized spans, so two instruments in one sentence are judged separately, each with its own
+ * offset into the sentence.
  *
  * "No DCO, contributor agreement required." is the case that makes this necessary: one sentence
  * holding a waiver and a requirement. Splitting on the comma is what lets the DCO read as waived and
  * the contributor agreement as required, instead of one borrowing the other's verb. A code comment
  * in the previous attempt claimed a `NEG_FILLER` regex handled the comma and nothing tested it;
  * this is the same guarantee made structural.
+ *
+ * The offset is carried, not recovered later: a sentence can repeat a clause verbatim, and searching
+ * for its text answers with the first copy. The cursor only moves forward, so identical clauses still
+ * get their own positions.
  */
-function clausesOf(sentence: string): string[] {
-  return sentence
-    .split(/[,;]|\bbut\b|\bhowever\b/i)
-    .map((c) => c.trim())
-    .filter(Boolean);
+function clausesOf(sentence: string): { text: string; at: number }[] {
+  const out: { text: string; at: number }[] = [];
+  let cursor = 0;
+  for (const part of sentence.split(/[,;]|\bbut\b|\bhowever\b/i)) {
+    const text = part.trim();
+    if (!text) continue;
+    // Only the splitting delimiter lies between `cursor` and this clause, so the first match from
+    // `cursor` is this clause rather than a later repeat of it.
+    const at = sentence.indexOf(text, cursor);
+    out.push({ text, at });
+    cursor = at + text.length;
+  }
+  return out;
 }
 
 function quoteOf(match: RegExpExecArray): string {
@@ -214,15 +232,15 @@ export function scanPolicyText(text: string): {
      * keywords alone would over-block it.
      */
     const anaphoric = parts.some(
-      (c) =>
+      ({ text: c }) =>
         /^(?:is|are|it\s+is|they\s+are)\s+(?:still\s+)?(?:required|needed|necessary|mandatory|obligatory|compulsory)\b/i.test(c) &&
         !SIGNATURE_FAMILIES.some(({ token }) => new RegExp(token, "i").test(c)),
     );
-    for (const clause of parts) {
+    for (const { text: clause, at: clauseAt } of parts) {
       for (const { family, token } of SIGNATURE_FAMILIES) {
         if (!new RegExp(token, "i").test(clause)) continue;
         const quote = `${family}: ${clause.replace(/\s+/g, " ").trim().slice(0, 140)}`;
-        const polarity = signaturePolarity(clause, sentence, token);
+        const polarity = signaturePolarity(clause, clauseAt, sentence, token);
         if (polarity === "required" || anaphoric) signatureRequired.push(quote);
         else signatureWaived.push(quote);
       }

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -70,6 +70,18 @@ const ESCAPE_HATCH = String.raw`(?:bypass|exception|exemption|waiver|opt[-\s]?ou
 /** Words that turn a waiver into a conditional requirement: it IS required, somewhere. */
 const SCOPE_LIMITER = /\b(?:except|unless|other\s+than|apart\s+from|save\s+for)\b/i;
 
+/** The words a requirement is asserted WITH, when its subject has been elided. */
+const PREDICATE = String.raw`(?:required|needed|necessary|mandatory|obligatory|compulsory)`;
+
+/**
+ * What must follow a bare `PREDICATE` for it to be a requirement rather than a noun modifier.
+ *
+ * Without a copula there is no verb to anchor on, so the SCOPE anchors instead: "required for code"
+ * asserts something about the instrument, "required reading is the style guide" does not. One adverb
+ * may intervene, so "needed only for release" still counts.
+ */
+const SCOPE_FOLLOWS = String.raw`(?=\s*(?:$|[.;,]|(?:\w+\s+)?(?:for|on|in|when|with|of|from)\b))`;
+
 /**
  * There is deliberately NO "asserts a requirement" roster. One was written, and the injection pass
  * showed the harness could not see it deleted: an occurrence matching no waiver already returns
@@ -146,6 +158,22 @@ function signaturePolarity(clause: string, clauseAt: number, sentence: string, t
       const forward = conjunction === -1 ? after : after.slice(0, conjunction);
       const leading = at > 0 && SCOPE_LIMITER.test(sentence.slice(0, at).replace(/^[\s"'(\[]*/, "").split(/[,;]/)[0] ?? "");
       if (SCOPE_LIMITER.test(forward) || leading) return "required";
+    }
+    /**
+     * A COORDINATED requirement on the same elided subject: "no CLA is required for docs and
+     * required for code." `and` is not a clause delimiter, so this requirement lives inside the
+     * waiver's own clause, where the limiter check finds no limiter and the anaphora pass — which
+     * needs a clause-INITIAL predicate — cannot see it either. The waiver read as blanket and the
+     * repo was ALLOWED while demanding a signature for code. A P1 from review, and the same
+     * fail-open class as everything else on this branch: a requirement hiding behind a waiver's
+     * coordination.
+     *
+     * The conjunction must be followed DIRECTLY by the predicate. "and tests are required" has its
+     * own subject and must not flip the instrument, and "and no CLA is required for code" is a second
+     * waiver rather than a requirement — both are excluded by that adjacency, not by a word list.
+     */
+    if (new RegExp(String.raw`\b(?:and|or|but|however)\s+(?:also\s+)?(?:still\s+)?${PREDICATE}\b${SCOPE_FOLLOWS}`, "i").test(clause)) {
+      return "required";
     }
     /**
      * A WAIVER GOVERNS ONLY THE OCCURRENCE IT NAMES — a P1 from review. Polarity was decided once
@@ -264,16 +292,10 @@ export function scanPolicyText(text: string): {
      * keywords alone would over-block it.
      *
      * English drops the copula too — "..., but required for code." — and a participle-initial clause
-     * was invisible, so the waiver read as blanket and the repo was allowed despite requiring a
-     * signature for code (a P1 from review, and this issue's fail-open class again). Without the
-     * copula there is no verb to anchor on, so the SCOPE does the anchoring: a bare participle counts
-     * only when what follows is a scope or the clause ends. That is what separates "required for
-     * code" from "required reading is the style guide", where the participle modifies a noun and
-     * asserts nothing about the instrument. One adverb is allowed in between, so "needed only for
-     * release" still counts.
+     * was invisible, so the waiver read as blanket and the repo was ALLOWED despite requiring a
+     * signature for code: a P1 from review, and this issue's fail-open class again. `SCOPE_FOLLOWS`
+     * is what keeps a bare participle from matching a noun modifier.
      */
-    const PREDICATE = String.raw`(?:required|needed|necessary|mandatory|obligatory|compulsory)`;
-    const SCOPE_FOLLOWS = String.raw`(?=\s*(?:$|[.;,]|(?:\w+\s+)?(?:for|on|in|when|with|of|from)\b))`;
     const anaphoric = parts.some(
       ({ text: c }) =>
         (new RegExp(String.raw`^(?:is|are|it\s+is|they\s+are)\s+(?:still\s+)?${PREDICATE}\b`, "i").test(c) ||

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -27,11 +27,8 @@ const FORBIDDEN_STATEMENTS: RegExp[] = [
   /autonomous\s+agents?\s+(?:are\s+)?not\s+(?:allowed|welcome|permitted)/i,
 ];
 
-/**
- * A human gate that is NOT a signature: someone must look, but nobody signs anything.
- * Kept separate from the signature families below so the verdict code comes from WHICH roster
- * matched, rather than from substring-testing the matched text afterwards.
- */
+/** A human gate that is NOT a signature: someone looks, nobody signs. Separate roster so the
+ * verdict code comes from WHICH roster matched, not from substring-testing the matched text. */
 const HUMAN_REVIEW_STATEMENTS: RegExp[] = [
   /human:/i,
   /\bhuman\s+(?:review\s+)?required\b/i,
@@ -42,19 +39,15 @@ const HUMAN_REVIEW_STATEMENTS: RegExp[] = [
 /**
  * The instruments a human must sign. Presence is not a requirement — `signaturePolarity` decides.
  *
- * The bare CLA acronym is the fix for issue #52. Without it the only CLA patterns were
+ * The bare CLA acronym is the fix for #52: without it the only CLA patterns were
  * `sign(?:ing)?\s+the\s+cla` and `\bcla\s+(?:is\s+)?required\b`, both defeated by an interposed
- * "not", so five realistic "waive the DCO, assert the CLA" documents held on `main` only by the
- * ACCIDENT of an un-negated `\bdco\b` in the same sentence — each reporting `human=["DCO"]` and
- * nothing about the CLA. Negate the DCO without adding this and all five fail open.
+ * "not", so five "waive the DCO, assert the CLA" documents held on `main` only by the ACCIDENT of an
+ * un-negated `\bdco\b` in the same sentence — each reporting `human=["DCO"]`, nothing about the CLA.
  *
- * Plurals are a P1 from review: `\bcla\b` misses `CLAs`, so "No DCO. CLAs are mandatory." waived
- * the DCO and saw nothing — this issue's defect in a new spelling. `\bclas?\b` cannot match
- * "class" (the optional `s` still needs a boundary after it), and a corpus row asserts that.
- *
+ * Plurals are a P1 from review: `\bcla\b` misses `CLAs`, so "No DCO. CLAs are mandatory." saw
+ * nothing. `\bclas?\b` cannot match "class" (the optional `s` needs a boundary), asserted by a row.
  * Not a bare `/agreement/i`: "your agreement with the Code of Conduct" is not a CLA. Sign-off
- * vocabulary is DCO family because it is one — on `main` "All commits must carry a Signed-off-by
- * line." reached ALLOW matching nothing at all.
+ * vocabulary is DCO family — "All commits must carry a Signed-off-by line." matched nothing at all.
  */
 const SIGNATURE_FAMILIES: { family: string; token: string }[] = [
   {
@@ -213,17 +206,12 @@ export function scanPolicyText(text: string): {
   for (const sentence of sentencesOf(text)) {
     const parts = clausesOf(sentence);
     /**
-     * An ANAPHORIC requirement: a clause that asserts one while naming no instrument, because its
-     * subject was elided and is the instrument named earlier —
-     *
-     *   "A CLA is not required for documentation, but is required for code contributions."
-     *
-     * The requirement lands in a clause with no token, so the per-clause pass skipped it and only
-     * the waiver was recorded. P1 from review.
-     *
-     * The clause must START with the verb, which is what elision looks like. "and tests are
-     * required" has its own subject and must NOT flip the CLA — testing for the keywords alone
-     * would over-block that, and over-blocking parks a legitimate packet.
+     * An ANAPHORIC requirement — a clause asserting one while naming no instrument, its subject
+     * elided: "A CLA is not required for documentation, but is required for code." The requirement
+     * lands in a token-less clause, so the per-clause pass skipped it and recorded only the waiver
+     * (P1 from review). The clause must START with the verb, which is what elision looks like:
+     * "and tests are required" has its own subject and must not flip the CLA, and matching the
+     * keywords alone would over-block it.
      */
     const anaphoric = parts.some(
       (c) =>

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -75,7 +75,7 @@ const ANY_INSTRUMENT = `(?:${SIGNATURE_FAMILIES.map(({ token }) => token).join("
  * written with an adjective instead of a noun, which is why they share this check rather than
  * getting a rule of their own.
  */
-const ESCAPE_HATCH = String.raw`(?:is\s+|are\s+)?(?:bypass|exception|exemption|waiver|opt[-\s]?out|workaround|way\s+around|optional|voluntary|discretionary|up\s+to\s+you|at\s+your\s+discretion)`;
+const ESCAPE_HATCH = String.raw`(?:is\s+|are\s+)?(?:bypass|except|exempt|waive|opt[-\s]?out|workaround|ways?\s+around|optional|voluntary|discretionary|up\s+to\s+you|at\s+your\s+discretion)`;
 
 /** Words that turn a waiver into a conditional requirement: it IS required, somewhere. */
 const SCOPE_LIMITER = /\b(?:except|unless|other\s+than|apart\s+from|save\s+for)\b/i;
@@ -246,12 +246,16 @@ function signaturePolarity(clause: string, sentence: string, token: string): "re
      * words are DCO-family tokens, so a mention abutting a removed span is absorbed with it.
      * Without that, "We don't require a DCO sign-off on contributions." became a hold.
      */
-    // At most one space, or a hyphen with nothing around it: "a DCO sign-off" and "sign-off" are one
-    // instrument, so the second token is absorbed with the first. A DASH THAT SEPARATES STATEMENTS is
-    // not that — "No DCO is required - DCO is required for code." had its requirement eaten by an
-    // absorption window three characters wide, a fail-open P1 from review. The exception is for a
-    // compound noun and is now shaped like one.
-    const abuts = new RegExp(String.raw`^(?:[ \t]|-)?${T}`, "i");
+    // ONE SPACE, and nothing else. "a DCO sign-off" is one instrument reached across a space, so the
+    // second token is absorbed with the first; a hyphen inside a token is already part of the token
+    // itself (`signed[-\s]?off`), so this window never needed one.
+    //
+    // Two fail-open P1s from review taught that, one per width. A three-character space-or-hyphen
+    // window ate the requirement in "No DCO is required - DCO is required for code."; narrowing it to
+    // one space OR one hyphen still ate "No DCO is required-DCO is required for code.", because an
+    // unspaced dash joins statements at least as often as it joins words. A window this narrow cannot
+    // reach across either.
+    const abuts = new RegExp(String.raw`^[ \t]?${T}`, "i");
     let residual = clause;
     for (let removed = true; removed; ) {
       removed = false;

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -64,8 +64,15 @@ const SIGNATURE_FAMILIES: { family: string; token: string }[] = [
  * "There is no DCO bypass" says the DCO is mandatory, not that it is waived. Checked BEFORE the
  * waivers, because it is literally a negation sitting next to the token and every waiver pattern
  * below would otherwise claim it.
+ *
+ * `optional` and its synonyms belong here for the same reason, and a P1 from review found them
+ * missing: "No CLA is optional." asserts the CLA. They matched no waiver predicate and no hatch
+ * word, so the broad `no <token>` fallback consumed the mention and the repo reached ALLOW. Negating
+ * a PERMISSION is asserting the requirement — the same sentence as "no CLA waiver is available",
+ * written with an adjective instead of a noun, which is why they share this check rather than
+ * getting a rule of their own.
  */
-const ESCAPE_HATCH = String.raw`(?:bypass|exception|exemption|waiver|opt[-\s]?out|workaround|way\s+around)`;
+const ESCAPE_HATCH = String.raw`(?:is\s+|are\s+)?(?:bypass|exception|exemption|waiver|opt[-\s]?out|workaround|way\s+around|optional|voluntary|discretionary|up\s+to\s+you|at\s+your\s+discretion)`;
 
 /** Words that turn a waiver into a conditional requirement: it IS required, somewhere. */
 const SCOPE_LIMITER = /\b(?:except|unless|other\s+than|apart\s+from|save\s+for)\b/i;
@@ -181,7 +188,12 @@ function signaturePolarity(clause: string, clauseAt: number, sentence: string, t
      * a second waiver rather than a requirement. Both are excluded because a noun sits where the
      * copula or predicate has to be, which is a rule about position rather than a word list.
      */
-    const COORDINATED = String.raw`\b(?:and|or|but|however)\s+(?:(?:it|they)\s+)?(?:is|are)?\s*(?:also\s+)?(?:still\s+)?${PREDICATE}\b${SCOPE_FOLLOWS}`;
+    // The separator is a conjunction OR a sentence terminator, because `sentencesOf` joins a
+    // continuation back into this sentence and a joined fragment brings its full stop with it:
+    // "No CLA is required for docs. Required for code." has no conjunction to find. A P1 from review
+    // reached ALLOW on exactly that, the fix for the fragment having stopped one step short.
+    // A list marker may stand after the separator too, since the joined fragment keeps its bullet.
+    const COORDINATED = String.raw`(?:\b(?:and|or|but|however)\s+|[.;:]\s+)(?:(?:[-*+>]|\d+[.)])\s*)?(?:(?:it|they)\s+)?(?:is|are)?\s*(?:also\s+)?(?:still\s+)?${PREDICATE}\b${SCOPE_FOLLOWS}`;
     if (new RegExp(COORDINATED, "i").test(clause)) {
       return "required";
     }
@@ -249,8 +261,14 @@ function signaturePolarity(clause: string, clauseAt: number, sentence: string, t
  * A fragment that is genuinely ambiguous joins, and joining over-blocks rather than over-allows —
  * the asymmetry `signaturePolarity` closes with, applied to punctuation.
  */
+/**
+ * A continuation may also lead with the PREDICATE itself — "No CLA is required for docs.\nRequired
+ * for code." — which a P1 from review found detached, leaving a blanket waiver and a token-less
+ * fragment. `SCOPE_FOLLOWS` is what keeps that from swallowing "Required reading is the style
+ * guide.", where the participle modifies a noun and the sentence genuinely is a new statement.
+ */
 const CONTINUATION = new RegExp(
-  String.raw`^(?:[-*+>]|\d+[.)])?[\s"'(\[]*(?:${SCOPE_LIMITER.source.replace(/^\\b|\\b$/g, "")}|and|or|but|however)\b`,
+  String.raw`^(?:[-*+>]|\d+[.)])?[\s"'(\[]*(?:(?:${SCOPE_LIMITER.source.replace(/^\\b|\\b$/g, "")}|and|or|but|however)\b|${PREDICATE}\b${SCOPE_FOLLOWS})`,
   "i",
 );
 

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -108,6 +108,33 @@ const PREDICATE = String.raw`(?:required|needed|necessary|expected|mandatory|obl
 const SCOPE_FOLLOWS = String.raw`(?=\s*(?:$|[.;,]|(?:\w+\s+)?(?:for|on|in|when|with|of|from)\b))`;
 
 /**
+ * A waiver's own statement ends where the NEXT statement begins, and the text between them is scope.
+ *
+ * The boundary is a conjunction behind a comma or semicolon — necessary, not sufficient. "for
+ * documentation, or code, except for third-party contributions" puts a comma before the `or`, and
+ * "code" is still scope: a bare noun phrase closed by the next comma. A new statement is longer than
+ * that and carries a verb. So each candidate boundary is examined, scope items are skipped, and the
+ * span ends at the first candidate that reads as a statement.
+ *
+ * Both directions cost a P1 on this branch: truncating at every conjunction lost the exception,
+ * truncating at none of them reclassified "and all patches are welcome except spam" as a scoped
+ * requirement.
+ */
+const FINITE_VERB = /\b(?:is|are|was|were|be|been|being|has|have|had|do|does|did|will|would|can|could|may|might|must|should|shall|need|needs|require|requires|review|reviews|accept|accepts|welcome|apply|applies|ask|asks|expect|expects)\b/i;
+
+function truncateAtStatement(after: string): string {
+  const boundary = new RegExp(String.raw`[,;]\s*${CONJUNCTION_WORDS}\b`, "gi");
+  for (let hit = boundary.exec(after); hit; hit = boundary.exec(after)) {
+    const segment = after.slice(hit.index + hit[0].length).split(/[,;.]/)[0] ?? "";
+    const words = segment.trim().split(/\s+/).filter(Boolean);
+    // A scope item: short, and asserting nothing. Keep looking for a real statement boundary.
+    if (words.length <= 3 && !FINITE_VERB.test(segment)) continue;
+    return after.slice(0, hit.index);
+  }
+  return after;
+}
+
+/**
  * There is deliberately NO "asserts a requirement" roster. One was written, and the injection pass
  * showed the harness could not see it deleted: an occurrence matching no waiver already returns
  * `"required"`, so the list and the fallback gave the same answer and it was unreachable — the #75
@@ -189,13 +216,16 @@ function signaturePolarity(clause: string, clauseAt: number, sentence: string, t
       const span = spans[0]!;
       const at = clauseAt + span.at;
       const after = sentence.slice(at + span.length);
-      // A conjunction ends this statement only where it BEGINS a clause, which is where a comma
-      // or semicolon puts it. Truncating at any conjunction cut "for documentation or code except
-      // for third-party contributions" at the `or` — a scope coordination, not a new statement —
-      // and lost the exception behind it: a P1 from review, and the fail-open mirror of the
-      // over-block that put truncation here in the first place.
-      const conjunction = after.search(new RegExp(String.raw`[,;]\s*${CONJUNCTION_WORDS}\b`, "i"));
-      const forward = conjunction === -1 ? after : after.slice(0, conjunction);
+      // A conjunction ends this statement only where it BEGINS a new one. A comma is necessary for
+      // that and not sufficient: "for documentation, or code, except for third-party contributions"
+      // has a comma before the `or`, yet "code" is another SCOPE, not another statement — truncating
+      // there lost the exception behind it. Two P1s from review, one for each half.
+      //
+      // A new statement carries a subject and a verb, so it is longer than a list item and it says
+      // something. A continued scope is a short noun phrase closed by the next comma. That is the
+      // test: skip a candidate whose following segment is a bare scope item, keep looking, and
+      // truncate at the first one that reads as a statement.
+      const forward = truncateAtStatement(after);
       const leading = at > 0 && SCOPE_LIMITER.test(sentence.slice(0, at).replace(/^[\s"'(\[]*/, "").split(/[,;]/)[0] ?? "");
       if (SCOPE_LIMITER.test(forward) || leading) return "required";
     }
@@ -294,7 +324,7 @@ function signaturePolarity(clause: string, clauseAt: number, sentence: string, t
  * guide.", where the participle modifies a noun and the sentence genuinely is a new statement.
  */
 const CONTINUATION = new RegExp(
-  String.raw`^(?:[-*+>]|\d+[.)])?[\s"'(\[]*(?:(?:${SCOPE_LIMITER.source.replace(/^\\b|\\b$/g, "")}|${CONJUNCTION_WORDS})\b|${PREDICATE}\b${SCOPE_FOLLOWS})`,
+  String.raw`^(?:[-*+>]|\d+[.)])?[\s"'(\[]*(?:(?:${SCOPE_LIMITER.source.replace(/^\\b|\\b$/g, "")}|${CONJUNCTION_WORDS})\b|(?:is|are|it\s+is|they\s+are)\s+(?:still\s+)?${PREDICATE}\b|${PREDICATE}\b${SCOPE_FOLLOWS})`,
   "i",
 );
 
@@ -339,6 +369,12 @@ function clausesOf(sentence: string): { text: string; at: number }[] {
     if (!text) continue;
     // Only the splitting delimiter lies between `cursor` and this clause, so the first match from
     // `cursor` is this clause rather than a later repeat of it.
+    //
+    // Behaviourally inert as the code stands, and said plainly rather than implied by a test that
+    // does not exist: a mutant searching from 0 changes no verdict here. It can only widen a later
+    // clause's span to an earlier clause's, and a wider span only ever ADDS a hold, so it cannot
+    // open the gate. Kept because measuring one clause at another clause's offset is wrong however
+    // the limiter rules are drawn, and `truncateAtStatement` above has already been redrawn twice.
     const at = sentence.indexOf(text, cursor);
     out.push({ text, at });
     cursor = at + text.length;

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -60,6 +60,9 @@ const SIGNATURE_FAMILIES: { family: string; token: string }[] = [
   },
 ];
 
+/** Every signature instrument, as one alternation, so a filler can be told to stop at any of them. */
+const ANY_INSTRUMENT = `(?:${SIGNATURE_FAMILIES.map(({ token }) => token).join("|")})`;
+
 /**
  * "There is no DCO bypass" says the DCO is mandatory, not that it is waived. Checked BEFORE the
  * waivers, because it is literally a negation sitting next to the token and every waiver pattern
@@ -142,10 +145,25 @@ function signaturePolarity(clause: string, sentence: string, token: string): "re
   const waivers = [
     String.raw`\bno\s+${T}\s+(?:is\s+|are\s+)?${PREDICATE}\b`,
     String.raw`${T}\s*:?\s*(?:is\s+|are\s+)?not\s+${PREDICATE}\b`,
-    // Bounded filler, stopping at any clause break so it cannot borrow a neighbour's waiver. It
-    // exists because "do not need TO SIGN a contributor license agreement" puts an infinitive
-    // between verb and token — a shape the corpus caught and the first draft of this list missed.
-    String.raw`\b(?:do(?:es)?\s+not|don['’]t|doesn['’]t|will\s+not|won['’]t)\s+(?:require|need|ask\s+for|expect)\b[^.;,\n]{0,25}?${T}`,
+    // Bounded filler, because "do not need TO SIGN a contributor license agreement" puts an
+    // infinitive between verb and token — a shape the corpus caught and the first draft missed.
+    //
+    // The filler is TEMPERED, not merely bounded, and the difference was a fail-open: the character
+    // class stopped at punctuation but `and` is not punctuation, so "We do not require a CLA and a
+    // DCO is required." let the filler run past the CLA and waive a DCO the sentence demands. The
+    // comment here used to claim it "stops at any clause break"; it did not, and no test disagreed.
+    //
+    // The temper is ANOTHER INSTRUMENT, not a conjunction. Both were written and a mutant showed the
+    // conjunction half redundant — a filler only matters when it reaches an instrument, so being
+    // unable to pass one is the whole guarantee. It also states the invariant directly: a verb waives
+    // the instrument it reaches and never one behind another. The cost is that two family tokens
+    // sitting adjacent — "a contributor agreement sign-off" — hold rather than waive together, which
+    // is the same call taken for limiters: adjacent-or-coordinated is not something to guess at.
+    //
+    // The length bound stays for a non-behavioural reason, said plainly because no test defends it:
+    // a lazy quantifier inside a tempered class over adversarial input is a backtracking hazard, and
+    // this scanner reads a stranger's document.
+    String.raw`\b(?:do(?:es)?\s+not|don['’]t|doesn['’]t|will\s+not|won['’]t)\s+(?:require|need|ask\s+for|expect)\b(?:(?!${ANY_INSTRUMENT})[^.;,\n]){0,25}?${T}`,
     String.raw`\bthere\s+(?:is|are)\s+no\s+${T}`,
     String.raw`\bno\s+${T}\b`,
   ];


### PR DESCRIPTION
Closes #52

## What

The CLA/DCO scanner now decides polarity **per signature instrument occurrence** — waived or
required — instead of matching presence and hoping negation sorts itself out. The verdict code comes
from which roster matched, not from substring-testing the matched phrase.

## Why

The gate's correct answers were accidents. `HUMAN_STATEMENTS` had no bare `\bcla\b`; its only
CLA-acronym patterns were `sign(?:ing)?\s+the\s+cla` and `\bcla\s+(?:is\s+)?required\b`, both
defeated by an interposed "not". So all five realistic "waive the DCO, assert the CLA" documents
*did* hold on `main` — every one of them through an un-negated `\bdco\b` elsewhere in the sentence,
with nothing matched about the CLA. Measured, not inferred; each reported `human=["DCO"]`.

Making the DCO negation-aware is not optional — `"No CLA. No DCO. Conventional commits."` is the
live Wave-1 seed text and was parking the packet — and doing it removes the accident with nothing
behind it. That is exactly how the previous attempt regressed 8 of 10 documents to ALLOW.

**Two holes the same measurement found that the issue does not mention:**

- `"All commits must carry a Signed-off-by line."` reached **ALLOW with empty matched phrases** — a
  plain signature requirement the scanner could not see at all.
- The short form `contributor agreement` was unmatched, so `"No DCO, contributor agreement
  required."` also held only via the accident.

## How verified

- **tests**: 325 across 16 files, `suite ok`; `npm run validate` exit 0. Worktree baseline was
  320/16.
- **acceptance, item by item**:
  - the five named documents hold as `HOLD_CLA` — asserted through `evaluatePolicy`, not just the scanner
  - `"No CLA. No DCO. Conventional commits."` is `ALLOW`, and the waiver is still *reported* so a freeze shows what was read and dismissed
  - the comma boundary is asserted by name
  - `"Pull requests without a signed Contributor License Agreement will be closed."` → `HOLD_CLA` (it was `HOLD_HUMAN`; #50's root cause reached from here)
- **mutation audit: 16 mutants, 16 killed, 0 survivors.** Including all three the issue names, plus
  each guard I added: escape-hatch, scope limiter (and its span), waiver ordering, per-occurrence
  governance, the abutting-mention absorb, plural tolerance, the fail-closed fallback, both
  splitters, and both verdict call sites.
- **differential sweep vs `main`, 61 fresh phrasings**:

  | | |
  |---|---|
  | **fail-open regressions vs `main`** | **0** |
  | fail-opens fixed (main allowed, branch holds) | 15 |
  | over-blocks fixed (main held, branch allows) | 7 |
  | new over-blocks | 0 |

- **the harness is proven non-vacuous** — #37's park note is explicit that "a differential harness
  reporting 0 is worthless until you have shown it can report non-0", so six defects were injected:

  | injected defect | harness reports |
  |---|---|
  | bare CLA acronym removed | 11 regressions |
  | only the short `contributor agreement` removed | 2 |
  | plural tolerance dropped | 1 |
  | fail-closed fallback flipped to waived | 19 |
  | waiver governs the whole clause again | 2 |
  | sign-off vocabulary dropped from the DCO family | **0 — not detected** |
  | *control:* rename a local, no behavioural content | 0 (correctly silent) |

  It has single-row resolution and does not cry wolf. The one blind spot is **by design and worth
  naming**: dropping sign-off vocabulary loses an *improvement over `main`*, which is not a
  regression *against* `main`. That class is covered by the other ratchet — the committed corpus,
  whose expected values are absolute; the same mutation is killed there. Two ratchets, complementary,
  each demonstrated.

## Notes for review

**Corpus provenance was settled before any regex was touched**, because that is what #37's park note
says the next attempt must do first. No row is derived from a constant in `policy.ts`; they come from
the documents quoted in #52 and #50, ordinary CONTRIBUTING.md phrasing, and paraphrase into shapes
the implementation does not name. Floors are separate per direction (≥40 total, ≥15 required, ≥10
waived, ≥6 silent) and documents must be distinct, because #37's round 3 shipped `suite ok` with its
headline corpus **emptied**.

**Three defects were found in this change by attacking it, not by running it.**

1. A comma before "except" hid the scope limiter, so `"A CLA is not required, except for new
   dependencies."` came out a blanket waiver — this issue's own fail-open class inside its own fix.
   The limiter is now read from the sentence and the waiver from the clause.
2. An `ASSERTS_REQUIREMENT` roster was written and then **deleted**: the injection pass showed the
   harness could not see it go, because an occurrence matching no waiver already returned
   `"required"`, so the list and the fallback gave the same answer and it was unreachable. An
   unreachable roster of authoritative-looking vocabulary is what #75 is about.
3. `"There is no CLA to sign."` does **not** flip to a hold. The issue predicted it would, as the
   measured cost of adding a bare `\bcla\b`; waiver-first ordering means that cost never materialises.

**Two P1 fail-opens came from review, both real, both mine:**

1. *Plural acronyms.* `\bcla\b` misses `CLAs`, so `"No DCO. CLAs are mandatory."` waived the DCO and
   saw nothing. `"CLAs are required for all contributors."` and `"We require DCOs on every commit."`
   matched **nothing at all**. Same defect as the issue, new spelling — and reachable precisely
   because removing the `\bdco\b` accident exposed it. `\bclas?\b` cannot match "class" (the optional
   `s` still needs a boundary), asserted by a corpus row.
2. *Mixed polarity in one clause.* Polarity was decided once per clause from the first match, so
   `"No CLA is required for documentation and a CLA is required for code."` matched the waiver, never
   looked at the second occurrence, and reached ALLOW. A waiver now governs only the occurrence it
   names. Fixing that needed a second rule: `"a DCO sign-off"` is one instrument named twice, so an
   abutting mention is absorbed first — without it a plain waiver became a hold.

**Deliberate, and argue with them if you disagree:**

- **Undecided reads as REQUIRED.** `"See our CLA for details."` holds. That is the repo's stated
  asymmetry — a false hold costs one look, a false allow forges a signature — and two corpus rows pin
  it, verified by flipping the fallback (19 regressions).
- **`holdFromConditions` still substring-tests** `record.conditions` for "cla"/"dco". Left alone: its
  input is the operator's own curated array in `policy-records.json`, not adversarial prose, so a
  controlled vocabulary is a different problem from scanning a stranger's CONTRIBUTING.md. It is a
  candidate for #50.
- **`clausesOf` changes no verdict any more** — per-occurrence governance handles mixed polarity
  alone. Kept and pinned for what it does change: the quote the operator reads at the freeze points
  at the clause asserting the CLA rather than a sentence with the waiver still inside it.
- **Overlap with #50 is unavoidable and disclosed.** Getting the five documents to `HOLD_CLA`
  requires knowing which family matched, which is #50's "carry the pattern's identity through". #50
  is next in the sweep and I will assess honestly there what remains rather than claiming it here.
- **Two scoped-waiver shapes are still out of scope**: `"A CLA is not required for contributors from
  partner organizations."` stays waived. Distinguishing "not required for <group>" from a blanket
  waiver risks the over-block class that killed round 1 of #37, and #50's comment routes both to
  itself.

**On size**: this landed at 426 net against the 400 cap with 226 of 446 added lines being prose. The
commentary is cut rather than the work, and the mutation audit was re-run afterwards. 375 net now.




































<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR changes signature-policy scanning to classify each CLA/DCO occurrence by polarity and carry the matched instrument family into verdict selection.
- Separates required and waived signature evidence.
- Adds sentence, clause, continuation, anaphora, and scope handling.
- Adds a large bidirectional corpus and adversarial termination coverage.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because a scoped CLA/DCO requirement using the previously reported `just for code` wording can still be silently dropped.

The shared qualifier guard excludes `just`, so an elided requirement after a waiver is not recognized and policy evaluation can allow a repository that requires a signature for code contributions.

**Files Needing Attention:** factory/policy.ts
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| factory/policy.ts | Reworks signature detection and verdict attribution, but the closed qualifier roster still drops the previously reported `just for code` requirement. |
| factory/policy.test.ts | Adds extensive polarity, attribution, scope, continuation, and adversarial-input coverage, but does not cover the prior exact `just for code` qualifier. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Policy document] --> B[Split into sentences and clauses]
  B --> C[Find signature-family occurrences]
  C --> D[Determine required or waived polarity]
  D --> E{Any required signature?}
  E -->|Yes| F[HOLD_CLA]
  E -->|No| G[Continue policy evaluation]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20ravidsrk%2Foss-foundry%20PR%20%2391%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=ravidsrk%2Foss-foundry&pr=91&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Afactory%2Fpolicy.ts%3A140-141%0A**Qualifier%20still%20drops%20requirement**%0A%0AWhen%20a%20policy%20says%20%60No%20CLA%20is%20required%20for%20docs%2C%20and%20required%20just%20for%20code.%60%2C%20the%20closed%20%60QUALIFIER%60%20roster%20rejects%20%60just%60%2C%20so%20%60SCOPE_FOLLOWS%60%20does%20not%20recognize%20the%20elided%20requirement.%20Only%20the%20waiver%20is%20recorded%2C%20causing%20a%20repository%20that%20requires%20a%20CLA%20for%20code%20contributions%20to%20receive%20%60ALLOW%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ravidsrk%2Foss-foundry&pr=91&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
factory/policy.ts:140-141
**Qualifier still drops requirement**

When a policy says `No CLA is required for docs, and required just for code.`, the closed `QUALIFIER` roster rejects `just`, so `SCOPE_FOLLOWS` does not recognize the elided requirement. Only the waiver is recorded, causing a repository that requires a CLA for code contributions to receive `ALLOW`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (18): Last reviewed commit: ["docs(policy): the absorption gate subsum..."](https://github.com/ravidsrk/oss-foundry/commit/c78a5ff43293c70052dc12bcdc3cbc08d3cd1663) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58264973)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->