### PR TITLE
fix(github): paginate every list read, and act on a capped one (#69)

### DIFF
--- a/factory/cli.test.ts
+++ b/factory/cli.test.ts
@@ -178,11 +178,8 @@ interface LivePr {
    * reviewed it" — the distinction the two review KPIs are built on (issue #39).
    */
   reviewsUnreadable?: boolean;
-  /**
-   * The review endpoints answering with a cursor that never ends, so the paginated read stops at its
-   * page cap. Distinct from `reviewsUnreadable` because the operator's next move differs: an outage
-   * is worth retrying, a capped read will cap again (issue #69).
-   */
+  /** A never-ending review cursor, so the read stops at its cap. Distinct from `reviewsUnreadable`:
+   * an outage is worth retrying and a capped read is not (issue #69). */
   reviewsTruncated?: boolean;
 }
 
@@ -285,8 +282,7 @@ globalThis.fetch = async (url) => {
     if (pr.reviewsUnreadable) return json(500, { message: "review endpoints unavailable" });
     const reviewBody = actors(parts[5] === "reviews" ? pr.reviews : pr.reviewComments);
     if (pr.reviewsTruncated) {
-      // Same shape as the commit cursor above: points back at this path, so every page answers and
-      // only the page cap ever stops the read.
+      // Same shape as the commit cursor above: only the page cap ever stops this read.
       const rp = Number(new URL(u).searchParams.get("page") ?? "1") + 1;
       const rnext = "https://api.github.com/repos/" + parts[1] + "/" + parts[2] + "/pulls/" + parts[4] + "/" + parts[5] + "?page=" + rp;
       return json(200, reviewBody, { link: '<' + rnext + '>; rel="next"' });
@@ -2297,18 +2293,9 @@ test("the clock says so when the commit read fails, and when it merely stops sho
 });
 
 /**
- * Issue #69, the operator-visible half: a competing-work read that stops at the page cap must refuse,
- * not proceed.
- *
- * The gate exists to assert the ABSENCE of a competing pull request, and an absence is the one thing
- * a short read cannot establish. Before the fix these reads stopped silently at 100 items and a
- * truncated success was byte-identical to a complete one; now the cap is 1,000, so this is a loud
- * stop rather than a likely one — but it has to be a stop, because proceeding would publish "no
- * competing pull request" as a fact the run never checked.
- *
- * Driven through the real CLI rather than asserted on the reader's return value: the reader returning
- * `truncated` and the verb acting on it are two different claims, and only the second one protects
- * an operator.
+ * Issue #69's operator-visible half: a capped competing-work read must refuse, since proceeding
+ * publishes "no competing pull request" as a fact the run never checked. Driven through the real CLI,
+ * because the reader returning `truncated` and the verb acting on it are two claims.
  */
 test("a competing-work read that stops at the page cap refuses the tick", () => {
   const dir = tmp("foundry-cap-");
@@ -2336,15 +2323,8 @@ globalThis.fetch = async (url) => {
   assert.match(run.out, /no competing pull request/, run.out);
 });
 
-/**
- * The same refusal for the OTHER read that feeds the same verdict. Raised by review: the first
- * version checked the open-pulls read and left the cross-reference timeline unchecked, so a capped
- * timeline reached `classifyCompetition` and a competing PR past the cap was missed — the issue then
- * entered the live scouting set, which is the fail-open this unit is about, one read over.
- *
- * The open-pulls read answers cleanly here, so the timeline is the only thing capped and this test
- * is about the timeline rather than a second copy of the one above.
- */
+/** The same refusal for the OTHER read feeding that verdict: checking open-pulls alone let a capped
+ * timeline reach `classifyCompetition`. Open-pulls answers cleanly, so only the timeline caps. */
 test("a capped cross-reference timeline refuses the tick too", () => {
   const dir = tmp("foundry-cap2-");
   const preload = join(dir, "preload.mjs");
@@ -2354,8 +2334,7 @@ test("a capped cross-reference timeline refuses the tick too", () => {
   new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json", ...headers } });
 globalThis.fetch = async (url) => {
   const u = String(url);
-  // A clean, complete open-pulls read: no next page, and nothing matching by closing keyword, so
-  // the timeline read is reached.
+  // Clean, complete open-pulls read, so the timeline read is reached.
   if (u.includes("/pulls?state=open")) return json(200, []);
   // The timeline never runs out of pages.
   if (u.includes("/timeline")) return json(200, [], { link: "<" + u + "&page=2>; rel=" + String.fromCharCode(34) + "next" + String.fromCharCode(34) });
@@ -2382,17 +2361,15 @@ globalThis.fetch = async (url) => {
 });
 
 /**
- * Issue #69: a CAPPED review read is neither a failure nor an observation, and reconcile has to say
- * which.
- *
- * Round 1 of this fix stopped storing the partial count — correct, since a wrong KPI is worse than a
- * missing one — but left the field simply absent, which is what an OUTAGE also leaves. So the
- * operator got retry guidance for a condition that will reproduce on every re-run. Raised by review.
- *
- * The two conditions are driven side by side, because the claim is that they are distinguishable and
- * a single-condition test cannot see that.
+ * A CAPPED review read is neither a failure nor an observation. Not storing the partial count was
+ * right — a wrong KPI is worse than none — but leaving the field simply absent is what an OUTAGE
+ * leaves too, so the operator got retry advice for a condition that reproduces every run. Driven
+ * side by side, because "distinguishable" is a claim one condition cannot show.
  */
-test("reconcile tells a capped review read apart from an outage", () => {
+test("a capped review read is told apart from an outage, in BOTH verbs", () => {
+  // The cap advisory once lived in `reconcile` alone, beside `packetChecks`'s generic "re-run when
+  // GitHub answers" line — so one run said both re-run and do-not-re-run about one PR, and the clock
+  // said neither. The fact now rides `LivePrLite`, which both verbs already build.
   const BLIND = "pkt_ravidsrk_frontguard_195";
   const blind = reviewBlindState(BLIND);
   const stranded = blind.packets.find((p) => p.id === BLIND)!;
@@ -2403,21 +2380,55 @@ test("reconcile tells a capped review read apart from an outage", () => {
   assert.equal(capped.code, 0, capped.out);
   assert.match(
     capped.out,
-    new RegExp(`^ADVISORY ${BLIND}: the human-review read on .* stopped at the \\d+-page cap`, "m"),
+    new RegExp(`^ADVISORY ${BLIND}: the human-review read on .* stopped at its page cap`, "m"),
     `a capped review read must name the cap:\n${capped.out}`,
   );
-  // The advice has to be actionable and true: a re-run caps again, so it must not say "retry".
+  // Actionable and true: a re-run caps again.
   assert.match(capped.out, /re-run will cap again/, capped.out);
-  assert.match(capped.out, /NOT recorded/, capped.out);
+  assert.equal(
+    /Run `reconcile` on a pass where GitHub answers/.test(capped.out),
+    false,
+    `the cap advisory and the outage advice cannot both be printed for one PR:\n${capped.out}`,
+  );
 
-  // The outage, for contrast — same packet, same verb, different message.
+  // The outage, for contrast — same packet, same verb, the other message and no cap wording.
   const outage = runCli(["reconcile", "--state", writeState(blind)], tmpdir(), {
     preload: prFactsStub(livePrs({ [stranded.prUrl!]: { reviewsUnreadable: true } })),
   });
   assert.equal(outage.code, 0, outage.out);
+  assert.match(outage.out, new RegExp(`^ADVISORY ${BLIND}: the ledger records no human-review`, "m"), outage.out);
   assert.equal(
-    /stopped at the \d+-page cap/.test(outage.out),
+    /stopped at its page cap/.test(outage.out),
     false,
     `an outage must not report itself as a capped read:\n${outage.out}`,
   );
+});
+
+
+/**
+ * Both `packetChecks` call sites supply the same facts. This unit shipped the one-call-site defect
+ * three times — `revert`, `revertTruncated`, `reviewTruncated` — because an omitted optional field is
+ * a runtime `undefined` here, never a compile error. By source and not by a drive, deliberately: the
+ * clock reads the COMMITTED SEED, where every merged packet carries an observation, so the review
+ * advisory is UNREACHABLE from it — unavailable rather than inconvenient.
+ */
+test("reconcile and verify-ledger hand packetChecks the same fields", () => {
+  // Only the fields NOT carried by the shared `live` object: reconcile spreads `live`, the clock
+  // lists fields inline, and that difference in form is fine. The truncation flags are not in either.
+  const callSite = (rel: string) => {
+    const source = readFileSync(new URL(rel, import.meta.url), "utf8");
+    const at = source.indexOf("packetChecks(");
+    assert.notEqual(at, -1, `${rel}: packetChecks call site not found — this guard has drifted`);
+    return source.slice(at, source.indexOf("});", at));
+  };
+  for (const rel of ["./cli.ts", "./verify-ledger.ts"]) {
+    const call = callSite(rel);
+    for (const field of ["revert", "revertTruncated", "reviewTruncated"]) {
+      assert.match(
+        call,
+        new RegExp(`\\b${field}:`),
+        `${rel} stopped handing packetChecks \`${field}\`, so that check silently reports it did not run`,
+      );
+    }
+  }
 });

--- a/factory/cli.test.ts
+++ b/factory/cli.test.ts
@@ -2281,3 +2281,43 @@ test("the clock says so when the commit read fails, and when it merely stops sho
     `a complete read must stay quiet or the advisory means nothing:\n${clean.out}`,
   );
 });
+
+/**
+ * Issue #69, the operator-visible half: a competing-work read that stops at the page cap must refuse,
+ * not proceed.
+ *
+ * The gate exists to assert the ABSENCE of a competing pull request, and an absence is the one thing
+ * a short read cannot establish. Before the fix these reads stopped silently at 100 items and a
+ * truncated success was byte-identical to a complete one; now the cap is 1,000, so this is a loud
+ * stop rather than a likely one — but it has to be a stop, because proceeding would publish "no
+ * competing pull request" as a fact the run never checked.
+ *
+ * Driven through the real CLI rather than asserted on the reader's return value: the reader returning
+ * `truncated` and the verb acting on it are two different claims, and only the second one protects
+ * an operator.
+ */
+test("a competing-work read that stops at the page cap refuses the tick", () => {
+  const dir = tmp("foundry-cap-");
+  const preload = join(dir, "preload.mjs");
+  writeFileSync(
+    preload,
+    `const json = (status, body, headers = {}) =>
+  new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json", ...headers } });
+globalThis.fetch = async (url) => {
+  const u = String(url);
+  // Always another page: the cap is what ends this read, which is the condition under test.
+  if (/\\/pulls\\?state=open/.test(u)) return json(200, [], { link: "<" + u + "&page=2>; rel=\\"next\\"" });
+  return json(404, { message: "unstubbed " + u });
+};
+`,
+  );
+  const path = join(dir, "state.json");
+  writeFileSync(path, JSON.stringify(emptyLedger()));
+
+  const run = runCli(["tick", "--state", path], tmpdir(), { preload });
+  assert.equal(run.code, 1, run.out);
+  assert.match(run.out, /page cap/, run.out);
+  // The message must name the consequence, not just the mechanism: an operator reading "stopped at
+  // the cap" needs to be told what claim it invalidates.
+  assert.match(run.out, /no competing pull request/, run.out);
+});

--- a/factory/cli.test.ts
+++ b/factory/cli.test.ts
@@ -178,8 +178,8 @@ interface LivePr {
    * reviewed it" — the distinction the two review KPIs are built on (issue #39).
    */
   reviewsUnreadable?: boolean;
-  /** A never-ending review cursor, so the read stops at its cap. Distinct from `reviewsUnreadable`:
-   * an outage is worth retrying and a capped read is not (issue #69). */
+  /** A never-ending review cursor, so the read caps. Unlike `reviewsUnreadable`, retrying will not
+   * help (issue #69). */
   reviewsTruncated?: boolean;
 }
 
@@ -2361,15 +2361,14 @@ globalThis.fetch = async (url) => {
 });
 
 /**
- * A CAPPED review read is neither a failure nor an observation. Not storing the partial count was
- * right — a wrong KPI is worse than none — but leaving the field simply absent is what an OUTAGE
- * leaves too, so the operator got retry advice for a condition that reproduces every run. Driven
- * side by side, because "distinguishable" is a claim one condition cannot show.
+ * A CAPPED review read is neither a failure nor an observation. Not storing the partial count is
+ * right, but leaving the field simply absent is what an OUTAGE leaves too, so the operator got retry
+ * advice for a condition that reproduces every run. Driven side by side, because "distinguishable"
+ * is a claim one condition cannot show.
  */
 test("a capped review read is told apart from an outage, in BOTH verbs", () => {
-  // The cap advisory once lived in `reconcile` alone, beside `packetChecks`'s generic "re-run when
-  // GitHub answers" line — so one run said both re-run and do-not-re-run about one PR, and the clock
-  // said neither. The fact now rides `LivePrLite`, which both verbs already build.
+  // The cap advisory once lived in `reconcile` alone, beside the generic "re-run when GitHub
+  // answers" line, so one run said both re-run and do-not-re-run. It now rides `LivePrLite`.
   const BLIND = "pkt_ravidsrk_frontguard_195";
   const blind = reviewBlindState(BLIND);
   const stranded = blind.packets.find((p) => p.id === BLIND)!;

--- a/factory/cli.test.ts
+++ b/factory/cli.test.ts
@@ -178,6 +178,12 @@ interface LivePr {
    * reviewed it" — the distinction the two review KPIs are built on (issue #39).
    */
   reviewsUnreadable?: boolean;
+  /**
+   * The review endpoints answering with a cursor that never ends, so the paginated read stops at its
+   * page cap. Distinct from `reviewsUnreadable` because the operator's next move differs: an outage
+   * is worth retrying, a capped read will cap again (issue #69).
+   */
+  reviewsTruncated?: boolean;
 }
 
 /** What `GET /repos/{owner}/{repo}/commits?since=…` answers, keyed by repo id. */
@@ -277,7 +283,15 @@ globalThis.fetch = async (url) => {
   // pull, so they are matched before the pull itself.
   if (parts[5] === "reviews" || parts[5] === "comments") {
     if (pr.reviewsUnreadable) return json(500, { message: "review endpoints unavailable" });
-    return json(200, actors(parts[5] === "reviews" ? pr.reviews : pr.reviewComments));
+    const reviewBody = actors(parts[5] === "reviews" ? pr.reviews : pr.reviewComments);
+    if (pr.reviewsTruncated) {
+      // Same shape as the commit cursor above: points back at this path, so every page answers and
+      // only the page cap ever stops the read.
+      const rp = Number(new URL(u).searchParams.get("page") ?? "1") + 1;
+      const rnext = "https://api.github.com/repos/" + parts[1] + "/" + parts[2] + "/pulls/" + parts[4] + "/" + parts[5] + "?page=" + rp;
+      return json(200, reviewBody, { link: '<' + rnext + '>; rel="next"' });
+    }
+    return json(200, reviewBody);
   }
   return json(200, {
     html_url: "https://github.com/" + path,
@@ -2365,4 +2379,45 @@ globalThis.fetch = async (url) => {
   const run = runCli(["tick", "--state", path], tmpdir(), { preload });
   assert.equal(run.code, 1, run.out);
   assert.match(run.out, /page cap/, run.out);
+});
+
+/**
+ * Issue #69: a CAPPED review read is neither a failure nor an observation, and reconcile has to say
+ * which.
+ *
+ * Round 1 of this fix stopped storing the partial count — correct, since a wrong KPI is worse than a
+ * missing one — but left the field simply absent, which is what an OUTAGE also leaves. So the
+ * operator got retry guidance for a condition that will reproduce on every re-run. Raised by review.
+ *
+ * The two conditions are driven side by side, because the claim is that they are distinguishable and
+ * a single-condition test cannot see that.
+ */
+test("reconcile tells a capped review read apart from an outage", () => {
+  const BLIND = "pkt_ravidsrk_frontguard_195";
+  const blind = reviewBlindState(BLIND);
+  const stranded = blind.packets.find((p) => p.id === BLIND)!;
+
+  const capped = runCli(["reconcile", "--state", writeState(blind)], tmpdir(), {
+    preload: prFactsStub(livePrs({ [stranded.prUrl!]: { reviewsTruncated: true } })),
+  });
+  assert.equal(capped.code, 0, capped.out);
+  assert.match(
+    capped.out,
+    new RegExp(`^ADVISORY ${BLIND}: the human-review read on .* stopped at the \\d+-page cap`, "m"),
+    `a capped review read must name the cap:\n${capped.out}`,
+  );
+  // The advice has to be actionable and true: a re-run caps again, so it must not say "retry".
+  assert.match(capped.out, /re-run will cap again/, capped.out);
+  assert.match(capped.out, /NOT recorded/, capped.out);
+
+  // The outage, for contrast — same packet, same verb, different message.
+  const outage = runCli(["reconcile", "--state", writeState(blind)], tmpdir(), {
+    preload: prFactsStub(livePrs({ [stranded.prUrl!]: { reviewsUnreadable: true } })),
+  });
+  assert.equal(outage.code, 0, outage.out);
+  assert.equal(
+    /stopped at the \d+-page cap/.test(outage.out),
+    false,
+    `an outage must not report itself as a capped read:\n${outage.out}`,
+  );
 });

--- a/factory/cli.test.ts
+++ b/factory/cli.test.ts
@@ -2321,3 +2321,48 @@ globalThis.fetch = async (url) => {
   // the cap" needs to be told what claim it invalidates.
   assert.match(run.out, /no competing pull request/, run.out);
 });
+
+/**
+ * The same refusal for the OTHER read that feeds the same verdict. Raised by review: the first
+ * version checked the open-pulls read and left the cross-reference timeline unchecked, so a capped
+ * timeline reached `classifyCompetition` and a competing PR past the cap was missed — the issue then
+ * entered the live scouting set, which is the fail-open this unit is about, one read over.
+ *
+ * The open-pulls read answers cleanly here, so the timeline is the only thing capped and this test
+ * is about the timeline rather than a second copy of the one above.
+ */
+test("a capped cross-reference timeline refuses the tick too", () => {
+  const dir = tmp("foundry-cap2-");
+  const preload = join(dir, "preload.mjs");
+  writeFileSync(
+    preload,
+    `const json = (status, body, headers = {}) =>
+  new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json", ...headers } });
+globalThis.fetch = async (url) => {
+  const u = String(url);
+  // A clean, complete open-pulls read: no next page, and nothing matching by closing keyword, so
+  // the timeline read is reached.
+  if (u.includes("/pulls?state=open")) return json(200, []);
+  // The timeline never runs out of pages.
+  if (u.includes("/timeline")) return json(200, [], { link: "<" + u + "&page=2>; rel=" + String.fromCharCode(34) + "next" + String.fromCharCode(34) });
+  if (/\\/issues\\/\\d+$/.test(u)) {
+    return json(200, {
+      number: 71,
+      html_url: "https://github.com/ravidsrk/orca-fleet/issues/71",
+      state: "open",
+      state_reason: null,
+      closed_at: null,
+      closed_by: null,
+    });
+  }
+  return json(404, { message: "unstubbed " + u });
+};
+`,
+  );
+  const path = join(dir, "state.json");
+  writeFileSync(path, JSON.stringify(emptyLedger()));
+
+  const run = runCli(["tick", "--state", path], tmpdir(), { preload });
+  assert.equal(run.code, 1, run.out);
+  assert.match(run.out, /page cap/, run.out);
+});

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -393,8 +393,7 @@ async function tickWithGithub(state: FactoryState) {
         console.error(crossRefs.error);
         process.exit(1);
       }
-      // BOTH reads that feed the verdict. Checking `pulls` alone let a capped timeline reach
-      // `classifyCompetition`, so a competing PR past the cap was missed — the same fail-open.
+      // BOTH reads feeding the verdict: `pulls` alone let a capped timeline through (same fail-open).
       refuseIfCapped([pulls, crossRefs], key);
       const verdict = classifyCompetition(
         { pulls: pulls.pulls, crossReferencedPullUrls: crossRefs.urls },

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -564,10 +564,6 @@ async function main() {
         process.exit(1);
       }
       refuseIfCapped([pulls, crossRefs], packetForFreeze.repoId);
-      if (!crossRefs.ok) {
-        console.error(crossRefs.error);
-        process.exit(1);
-      }
       const verdict = classifyCompetition(
         { pulls: pulls.pulls, crossReferencedPullUrls: crossRefs.urls },
         packetForFreeze.issueNumber,

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -1115,6 +1115,14 @@ async function main() {
       // one: `syncGithubPr` populates `humanReview` for terminal PRs alone, so an open packet costs
       // nothing here. An error is still reported rather than swallowed, because a writer that
       // starts refusing for a new reason should be visible rather than silently skipped.
+      // A capped review read is not a failure and not an observation: say so, on the same advisory
+      // path the commit read below uses, so it cannot read as "nobody reviewed it" or as a retryable
+      // outage. Reported before the writer, because there is nothing to write.
+      if (synced.reviewTruncated) {
+        owed.push(
+          `${packet.id}: the human-review read on ${packet.repoId} stopped at the ${MAX_LIST_PAGES}-page cap — noReview/reviewCommentsAvg are NOT recorded for this PR, and a re-run will cap again. Read the PR by hand or raise the cap deliberately.`,
+        );
+      }
       if (synced.meta.humanReview) {
         const observed = synced.meta.humanReview;
         const recovered = applyReviewObservation(next, packet.id, observed);

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -34,6 +34,7 @@ import {
   fetchRepoFile,
   listCrossReferencingOpenPulls,
   listOpenPulls,
+  MAX_LIST_PAGES,
   parsePrUrl,
   revertCheck,
   syncGithubPr,
@@ -176,6 +177,23 @@ const ARGV = process.argv.slice(2);
 // The ledger belongs to the repository, not to whatever directory the operator happened to be in.
 // A cwd-relative path silently served the committed seed as live truth from anywhere else, and a
 // mutating command forked a second state file next to it.
+/**
+ * A capped competing-work read cannot support "nothing is in flight".
+ *
+ * The gate exists to assert the ABSENCE of a competitor, and an absence is the one thing a short read
+ * cannot establish. Before issue #69 these reads stopped silently at 100 items; they now follow
+ * GitHub's cursor to a 10-page cap, so this is a loud stop rather than a likely one — but it is
+ * refused rather than warned, because proceeding would publish "no competing pull request" as a fact
+ * the run did not check. Its own message, so a capped read stays distinguishable from a failed one.
+ */
+function refuseIfCapped(reads: { truncated?: boolean }[], what: string): void {
+  if (!reads.some((r) => r.truncated)) return;
+  console.error(
+    `${what}: a competing-work read stopped at the ${MAX_LIST_PAGES}-page cap, so "no competing pull request" is not a fact this run can assert. Narrow the target or raise the cap deliberately.`,
+  );
+  process.exit(1);
+}
+
 const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const STATE_FILE_FLAG = flag(ARGV, "--state");
 const STATE_FILE = resolve(STATE_FILE_FLAG ?? resolve(REPO_ROOT, ".foundry-state.json"));
@@ -338,6 +356,7 @@ async function tickWithGithub(state: FactoryState) {
       console.error(pulls.error);
       process.exit(1);
     }
+    refuseIfCapped([pulls], repo.id);
     const agentsMd = await fetchRepoFile(repo.id, "AGENTS.md");
     const contributing =
       (await fetchRepoFile(repo.id, "CONTRIBUTING.md")) ??
@@ -542,6 +561,11 @@ async function main() {
       )
         ? { ok: true as const, urls: [] as string[] }
         : await listCrossReferencingOpenPulls(packetForFreeze.repoId, packetForFreeze.issueNumber);
+      if (!crossRefs.ok) {
+        console.error(crossRefs.error);
+        process.exit(1);
+      }
+      refuseIfCapped([pulls, crossRefs], packetForFreeze.repoId);
       if (!crossRefs.ok) {
         console.error(crossRefs.error);
         process.exit(1);
@@ -978,6 +1002,7 @@ async function main() {
       console.error(!pulls.ok ? pulls.error : (crossRefs as { error: string }).error);
       process.exit(1);
     }
+    refuseIfCapped([pulls, crossRefs], packet.repoId);
     const verdict = classifyCompetition(
       { pulls: pulls.pulls, crossReferencedPullUrls: crossRefs.urls },
       packet.issueNumber,
@@ -1268,6 +1293,7 @@ async function main() {
         console.error(!pulls.ok ? pulls.error : !crossRefs.ok ? crossRefs.error : "");
         process.exit(1);
       }
+      refuseIfCapped([pulls, crossRefs], packetForDraft.repoId);
       const others = pulls.pulls.filter((p) => p.number !== parsed.number);
       const otherRefs = crossRefs.urls.filter((u) => parsePrUrl(u)?.number !== parsed.number);
       const verdict = classifyCompetition(

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -397,6 +397,11 @@ async function tickWithGithub(state: FactoryState) {
         console.error(crossRefs.error);
         process.exit(1);
       }
+      // Both reads that feed the verdict, not just the pulls one. Raised by review: checking
+      // `pulls` and leaving the timeline unchecked let a capped cross-reference list reach
+      // `classifyCompetition`, so a competing PR past the cap was missed and the issue entered the
+      // live scouting set — the same fail-open, one read over.
+      refuseIfCapped([pulls, crossRefs], key);
       const verdict = classifyCompetition(
         { pulls: pulls.pulls, crossReferencedPullUrls: crossRefs.urls },
         issue.number,

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -178,13 +178,9 @@ const ARGV = process.argv.slice(2);
 // A cwd-relative path silently served the committed seed as live truth from anywhere else, and a
 // mutating command forked a second state file next to it.
 /**
- * A capped competing-work read cannot support "nothing is in flight".
- *
- * The gate exists to assert the ABSENCE of a competitor, and an absence is the one thing a short read
- * cannot establish. Before issue #69 these reads stopped silently at 100 items; they now follow
- * GitHub's cursor to a 10-page cap, so this is a loud stop rather than a likely one — but it is
- * refused rather than warned, because proceeding would publish "no competing pull request" as a fact
- * the run did not check. Its own message, so a capped read stays distinguishable from a failed one.
+ * A capped competing-work read cannot support "nothing is in flight". The gate asserts the ABSENCE
+ * of a competitor, and an absence is what a short read cannot establish — so it is refused, not
+ * warned, with its own message so a capped read stays distinguishable from a failed one (issue #69).
  */
 function refuseIfCapped(reads: { truncated?: boolean }[], what: string): void {
   if (!reads.some((r) => r.truncated)) return;
@@ -397,10 +393,8 @@ async function tickWithGithub(state: FactoryState) {
         console.error(crossRefs.error);
         process.exit(1);
       }
-      // Both reads that feed the verdict, not just the pulls one. Raised by review: checking
-      // `pulls` and leaving the timeline unchecked let a capped cross-reference list reach
-      // `classifyCompetition`, so a competing PR past the cap was missed and the issue entered the
-      // live scouting set — the same fail-open, one read over.
+      // BOTH reads that feed the verdict. Checking `pulls` alone let a capped timeline reach
+      // `classifyCompetition`, so a competing PR past the cap was missed — the same fail-open.
       refuseIfCapped([pulls, crossRefs], key);
       const verdict = classifyCompetition(
         { pulls: pulls.pulls, crossReferencedPullUrls: crossRefs.urls },
@@ -1115,14 +1109,6 @@ async function main() {
       // one: `syncGithubPr` populates `humanReview` for terminal PRs alone, so an open packet costs
       // nothing here. An error is still reported rather than swallowed, because a writer that
       // starts refusing for a new reason should be visible rather than silently skipped.
-      // A capped review read is not a failure and not an observation: say so, on the same advisory
-      // path the commit read below uses, so it cannot read as "nobody reviewed it" or as a retryable
-      // outage. Reported before the writer, because there is nothing to write.
-      if (synced.reviewTruncated) {
-        owed.push(
-          `${packet.id}: the human-review read on ${packet.repoId} stopped at the ${MAX_LIST_PAGES}-page cap — noReview/reviewCommentsAvg are NOT recorded for this PR, and a re-run will cap again. Read the PR by hand or raise the cap deliberately.`,
-        );
-      }
       if (synced.meta.humanReview) {
         const observed = synced.meta.humanReview;
         const recovered = applyReviewObservation(next, packet.id, observed);
@@ -1167,6 +1153,9 @@ async function main() {
         // Same fact the clock reads (issue #39 round 2): a page-capped commit read is not a clean
         // one, and both consumers must say so or the two verbs disagree about what was checked.
         revertTruncated: reverted?.ok ? reverted.truncated : undefined,
+        // The review read's own cap (issue #69), through the parameter both verbs already build so
+        // neither can forget it — this unit shipped that defect twice before.
+        reviewTruncated: synced.reviewTruncated,
       });
       doctrine.push(...checks.fatal);
       owed.push(...checks.advisory);

--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -4461,6 +4461,10 @@ test("a terminal transition with no observed review split records nothing and sa
     false,
     `\`sync\` refuses a terminal packet, so naming it is advice that cannot be followed:\n${gap}`,
   );
+  // ...and the OTHER reason: this reducer cannot tell an outage from a page cap (issue #69), and a
+  // line offering only the retry was misleading for half the cases it fires on.
+  assert.match(gap, /PAGE CAP/, `the advice must cover a capped read as well as an outage:\n${gap}`);
+  assert.match(gap, /cap again/, gap);
   // Not a claim about the wording — a claim about the verb. `sync` really does refuse this packet.
   const refused = applyPrSync(
     merged.state,

--- a/factory/engine.ts
+++ b/factory/engine.ts
@@ -1016,10 +1016,13 @@ function recordTerminalReview(
 ): ScorecardRow[] {
   const observed = meta.humanReview;
   if (!observed) {
+    // NAMES BOTH REASONS: this reducer cannot tell an outage from a page cap (issue #69), and the
+    // advice differs — re-running recovers one and caps again on the other. `packetChecks` does know
+    // and says which; this line must stay true WITHOUT the fact, so it carries both.
     events.push(
       ev(
         "follow-up",
-        `Human review not observed for ${meta.url} — noReview and reviewCommentsAvg NOT recorded for ${packet.repoId}; run \`reconcile\` once GitHub answers the review endpoints (NOT \`sync\`, which refuses a terminal packet: "cannot sync PR from status ...")`,
+        `Human review not observed for ${meta.url} — noReview and reviewCommentsAvg NOT recorded for ${packet.repoId}. If the read FAILED, run \`reconcile\` once GitHub answers the review endpoints (NOT \`sync\`, which refuses a terminal packet: "cannot sync PR from status ..."). If it stopped at its PAGE CAP, a re-run will cap again — read the PR by hand or raise the cap deliberately`,
         id,
       ),
     );

--- a/factory/github-pr.test.ts
+++ b/factory/github-pr.test.ts
@@ -838,12 +838,8 @@ test("fetchHumanReview fails closed on a thrown fetch, a bad status, and a non-l
   if (!badComments.ok) assert.match(badComments.error, /503 on review comments/);
 
   // A 200 whose body is not a list. Without the guard `.filter` throws and the failure arrives as
-  // "fetch failed", which is a different and untrue account of what happened.
-  //
-  // Now asserted PER ENDPOINT rather than against one combined "the review endpoints" message.
-  // Paginating both reads through one helper (issue #69) made the message name which endpoint
-  // returned the non-list, so this tightened rather than moved: the old assertion passed whichever
-  // of the two had failed, and these two cannot.
+  // "fetch failed", an untrue account. Asserted PER ENDPOINT now: paginating both through one helper
+  // made the message name which one, so this tightened — the old assertion passed for either.
   const notListComments = await fetchHumanReview("ravidsrk/orca-fleet", 70, async (url) =>
     String(url).includes("/comments") ? jsonResponse(200, { message: "Not Found" }) : jsonResponse(200, []),
   );

--- a/factory/github-pr.test.ts
+++ b/factory/github-pr.test.ts
@@ -488,12 +488,8 @@ test("syncGithubPr reads the human review split for a terminal PR, and says noth
   assert.equal(unreadable.ok, true);
   if (unreadable.ok) assert.equal(unreadable.meta.humanReview, undefined);
 
-  /**
-   * A CAPPED review read is not observed either, and for the same reason. Raised by review: the
-   * truncation flag was computed and then dropped here, so ten pages of a busy PR's reviews would
-   * have been recorded and published as a complete count — a wrong KPI, which is worse than a
-   * missing one and is the exact failure issue #39 exists to prevent.
-   */
+  // A CAPPED read is not observed either: the flag was computed and dropped here, so ten pages of a
+  // busy PR's reviews would have been published as a complete count — a wrong KPI, worse than none.
   const capped = await syncGithubPr({ url: "https://github.com/ravidsrk/orca-fleet/pull/70" }, async (url) => {
     const u = String(url);
     if (u.includes("/reviews") || u.includes("/comments")) {
@@ -511,9 +507,7 @@ test("syncGithubPr reads the human review split for a terminal PR, and says noth
       undefined,
       "a capped review read was recorded as a complete count",
     );
-    // ...and it is distinguishable from an endpoint FAILURE, because the operator's next move
-    // differs: a failed endpoint is worth retrying, a capped one will cap again. Round 1 of this fix
-    // made both of them a bare absent field, which is two facts wearing one face.
+    // ...and distinguishable from an endpoint FAILURE: retrying helps one and not the other.
     assert.equal(capped.reviewTruncated, true, "a capped review read is indistinguishable from an outage");
   }
   if (unreadable.ok) {
@@ -882,19 +876,13 @@ test("listCommitsSince refuses a 200 whose body is not a list of commits", async
 });
 
 /**
- * Issue #69: five list reads shared `listCommitsSince`'s pre-#39 shape — `per_page=100`, no `page`,
- * no Link follow, no truncation signal — so a truncated success was byte-identical to a complete one.
- * `:61` was the sharpest: it feeds the competing-work gate, an active repository with more than 100
- * open pull requests is ordinary, and a missed open PR means opening a duplicate against work already
- * in flight — the outcome docs/PRODUCT.md §2 exists to prevent.
- *
- * Each read is driven across a page boundary, because "it paginates" is a claim about the SECOND
- * page and a one-page fixture cannot see it.
+ * Issue #69: five list reads shared `listCommitsSince`'s pre-#39 shape, so a truncated success was
+ * byte-identical to a complete one. Each is driven across a page boundary, because "it paginates" is
+ * a claim about the SECOND page and a one-page fixture cannot see it.
  */
 function paged(pages: unknown[][]): typeof fetch {
-  // Per ENDPOINT, not one shared counter: `fetchHumanReview` reads `/reviews` and `/comments` in
-  // parallel, and a single counter handed each of them one page and then ran off the end — which
-  // looked like "pagination works" while proving the opposite.
+  // Per ENDPOINT, not one shared counter: `fetchHumanReview` reads both in parallel, and one counter
+  // gave each a single page — which looked like "pagination works" while proving the opposite.
   const served = new Map<string, number>();
   return (async (url: string | URL | Request) => {
     const key = String(url).split("?")[0];
@@ -960,8 +948,7 @@ test("every paginated list read follows the cursor to the second page", async ()
 });
 
 test("a capped read is distinguishable from a complete one", async () => {
-  // A stub that never stops offering a next page: the cap is what ends it, and `truncated` is the
-  // only thing that says so — the items and the verdict look exactly like a clean read.
+  // Never stops offering a next page: the cap ends it, and `truncated` is the only thing saying so.
   const endless: typeof fetch = (async (url: string | URL | Request) =>
     new Response(JSON.stringify([{ number: 1, html_url: "https://github.com/x/y/pull/1", head: { ref: "a" } }]), {
       status: 200,
@@ -981,10 +968,8 @@ test("a capped read is distinguishable from a complete one", async () => {
   const cappedReview = await fetchHumanReview("ravidsrk/orca-fleet", 70, endless);
   if (cappedReview.ok) assert.equal(cappedReview.truncated, true);
 
-  // EACH endpoint on its own. `truncated` is an OR over two reads, and an endless stub truncates
-  // both, so it could not tell the OR from a read of `reviews` alone. Comments-only is the half that
-  // was unpinned — and it is the more likely one, since a busy PR has far more review comments than
-  // reviews.
+  // EACH endpoint on its own: `truncated` is an OR, and an endless stub truncates both, so it could
+  // not tell the OR from `reviews` alone. Comments-only is the likelier half and was unpinned.
   const commentsOnly: typeof fetch = (async (url: string | URL | Request) => {
     const u = String(url);
     const body = u.includes("/comments") ? [{ user: { login: "a", type: "User" } }] : [];
@@ -1004,10 +989,8 @@ test("a capped read is distinguishable from a complete one", async () => {
 });
 
 /**
- * The SHIPPED cap, not just the mechanism. #83 spent three rounds on exactly this distinction: the
- * terminal boundary's mechanism was thoroughly tested while its default stream list was not, and
- * deleting `process.stderr` left the suite green. A cap the tests read out of the constant they are
- * checking cannot notice the constant changing, so the number is written down here once.
+ * The SHIPPED cap, not just the mechanism — the distinction #83 spent three rounds on. A cap the
+ * tests read out of the constant they check cannot notice it changing, so the number is written here.
  */
 test("the page cap is ten, and both list caps agree", () => {
   assert.equal(MAX_LIST_PAGES, 10);

--- a/factory/github-pr.test.ts
+++ b/factory/github-pr.test.ts
@@ -487,6 +487,31 @@ test("syncGithubPr reads the human review split for a terminal PR, and says noth
   });
   assert.equal(unreadable.ok, true);
   if (unreadable.ok) assert.equal(unreadable.meta.humanReview, undefined);
+
+  /**
+   * A CAPPED review read is not observed either, and for the same reason. Raised by review: the
+   * truncation flag was computed and then dropped here, so ten pages of a busy PR's reviews would
+   * have been recorded and published as a complete count — a wrong KPI, which is worse than a
+   * missing one and is the exact failure issue #39 exists to prevent.
+   */
+  const capped = await syncGithubPr({ url: "https://github.com/ravidsrk/orca-fleet/pull/70" }, async (url) => {
+    const u = String(url);
+    if (u.includes("/reviews") || u.includes("/comments")) {
+      return new Response(JSON.stringify([{ user: { login: "a", type: "User" } }]), {
+        status: 200,
+        headers: { "Content-Type": "application/json", link: `<${u}>; rel="next"` },
+      });
+    }
+    return jsonResponse(200, prBody({}));
+  });
+  assert.equal(capped.ok, true, "a capped read is still a successful sync");
+  if (capped.ok) {
+    assert.equal(
+      capped.meta.humanReview,
+      undefined,
+      "a capped review read was recorded as a complete count",
+    );
+  }
 });
 
 test("listCommitsSince returns the base-branch commits after a moment, with their messages", async () => {

--- a/factory/github-pr.test.ts
+++ b/factory/github-pr.test.ts
@@ -511,6 +511,13 @@ test("syncGithubPr reads the human review split for a terminal PR, and says noth
       undefined,
       "a capped review read was recorded as a complete count",
     );
+    // ...and it is distinguishable from an endpoint FAILURE, because the operator's next move
+    // differs: a failed endpoint is worth retrying, a capped one will cap again. Round 1 of this fix
+    // made both of them a bare absent field, which is two facts wearing one face.
+    assert.equal(capped.reviewTruncated, true, "a capped review read is indistinguishable from an outage");
+  }
+  if (unreadable.ok) {
+    assert.equal(unreadable.reviewTruncated, false, "an outage must not report itself as a capped read");
   }
 });
 

--- a/factory/github-pr.test.ts
+++ b/factory/github-pr.test.ts
@@ -16,6 +16,7 @@ import {
   nextPageUrl,
   revertCheck,
   syncGithubPr,
+  MAX_LIST_PAGES,
 } from "./github-pr.ts";
 import { REVERT_WINDOW_DAYS } from "./scorecard.ts";
 
@@ -812,11 +813,22 @@ test("fetchHumanReview fails closed on a thrown fetch, a bad status, and a non-l
 
   // A 200 whose body is not a list. Without the guard `.filter` throws and the failure arrives as
   // "fetch failed", which is a different and untrue account of what happened.
-  const notList = await fetchHumanReview("ravidsrk/orca-fleet", 70, async (url) =>
+  //
+  // Now asserted PER ENDPOINT rather than against one combined "the review endpoints" message.
+  // Paginating both reads through one helper (issue #69) made the message name which endpoint
+  // returned the non-list, so this tightened rather than moved: the old assertion passed whichever
+  // of the two had failed, and these two cannot.
+  const notListComments = await fetchHumanReview("ravidsrk/orca-fleet", 70, async (url) =>
     String(url).includes("/comments") ? jsonResponse(200, { message: "Not Found" }) : jsonResponse(200, []),
   );
-  assert.equal(notList.ok, false);
-  if (!notList.ok) assert.match(notList.error, /non-list for the review endpoints/);
+  assert.equal(notListComments.ok, false);
+  if (!notListComments.ok) assert.match(notListComments.error, /non-list on review comments/);
+
+  const notListReviews = await fetchHumanReview("ravidsrk/orca-fleet", 70, async (url) =>
+    String(url).includes("/reviews") ? jsonResponse(200, { message: "Not Found" }) : jsonResponse(200, []),
+  );
+  assert.equal(notListReviews.ok, false);
+  if (!notListReviews.ok) assert.match(notListReviews.error, /non-list on reviews/);
 
   const badRepo = await fetchHumanReview("orca-fleet", 70, async () => jsonResponse(200, []));
   assert.equal(badRepo.ok, false);
@@ -835,4 +847,137 @@ test("listCommitsSince refuses a 200 whose body is not a list of commits", async
   });
   assert.equal(threw.ok, false);
   if (!threw.ok) assert.match(threw.error, /network down/);
+});
+
+/**
+ * Issue #69: five list reads shared `listCommitsSince`'s pre-#39 shape — `per_page=100`, no `page`,
+ * no Link follow, no truncation signal — so a truncated success was byte-identical to a complete one.
+ * `:61` was the sharpest: it feeds the competing-work gate, an active repository with more than 100
+ * open pull requests is ordinary, and a missed open PR means opening a duplicate against work already
+ * in flight — the outcome docs/PRODUCT.md §2 exists to prevent.
+ *
+ * Each read is driven across a page boundary, because "it paginates" is a claim about the SECOND
+ * page and a one-page fixture cannot see it.
+ */
+function paged(pages: unknown[][]): typeof fetch {
+  // Per ENDPOINT, not one shared counter: `fetchHumanReview` reads `/reviews` and `/comments` in
+  // parallel, and a single counter handed each of them one page and then ran off the end — which
+  // looked like "pagination works" while proving the opposite.
+  const served = new Map<string, number>();
+  return (async (url: string | URL | Request) => {
+    const key = String(url).split("?")[0];
+    const n = served.get(key) ?? 0;
+    served.set(key, n + 1);
+    const body = pages[n] ?? [];
+    const isLast = n >= pages.length - 1;
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: isLast
+        ? { "Content-Type": "application/json" }
+        : { "Content-Type": "application/json", link: `<${String(url)}&page=${n + 2}>; rel="next"` },
+    });
+  }) as typeof fetch;
+}
+
+test("every paginated list read follows the cursor to the second page", async () => {
+  const pulls = await listOpenPulls(
+    "ravidsrk/orca-fleet",
+    paged([
+      [{ number: 1, html_url: "https://github.com/ravidsrk/orca-fleet/pull/1", head: { ref: "a" } }],
+      [{ number: 2, html_url: "https://github.com/ravidsrk/orca-fleet/pull/2", head: { ref: "b" } }],
+    ]),
+  );
+  assert.equal(pulls.ok, true);
+  if (pulls.ok) {
+    assert.deepEqual(pulls.pulls.map((p) => p.number), [1, 2], "the second page of open pulls was not read");
+    assert.equal(pulls.truncated, false);
+  }
+
+  const crossRefs = await listCrossReferencingOpenPulls(
+    "ravidsrk/orca-fleet",
+    71,
+    paged([
+      [{ event: "labeled" }],
+      [
+        {
+          event: "cross-referenced",
+          source: { issue: { state: "open", html_url: "https://github.com/x/y/pull/9", pull_request: {} } },
+        },
+      ],
+    ]),
+  );
+  assert.equal(crossRefs.ok, true);
+  // The only cross-reference lives on page 2: a one-page read reports "no competing work" here.
+  if (crossRefs.ok) assert.deepEqual(crossRefs.urls, ["https://github.com/x/y/pull/9"]);
+
+  const review = await fetchHumanReview(
+    "ravidsrk/orca-fleet",
+    70,
+    paged([[{ user: { login: "a", type: "User" } }], [{ user: { login: "b", type: "User" } }]]),
+  );
+  assert.equal(review.ok, true);
+  // Two pages per endpoint, both endpoints sharing the stub: 2 reviews and 2 comments.
+  if (review.ok) assert.deepEqual(review.humanReview, { reviews: 2, comments: 2 });
+
+  const closing = await fetchIssueClosingRef(
+    "ravidsrk/orca-fleet",
+    71,
+    paged([[{ event: "labeled" }], [{ event: "closed", commit_id: "abcdef1234567890" }]]),
+  );
+  assert.equal(closing, "commit abcdef1", "the closing commit on page 2 was not seen");
+});
+
+test("a capped read is distinguishable from a complete one", async () => {
+  // A stub that never stops offering a next page: the cap is what ends it, and `truncated` is the
+  // only thing that says so — the items and the verdict look exactly like a clean read.
+  const endless: typeof fetch = (async (url: string | URL | Request) =>
+    new Response(JSON.stringify([{ number: 1, html_url: "https://github.com/x/y/pull/1", head: { ref: "a" } }]), {
+      status: 200,
+      headers: { "Content-Type": "application/json", link: `<${String(url)}>; rel="next"` },
+    })) as typeof fetch;
+
+  const capped = await listOpenPulls("ravidsrk/orca-fleet", endless);
+  assert.equal(capped.ok, true, "a capped read is still a successful read");
+  if (capped.ok) {
+    assert.equal(capped.truncated, true, "the cap was hit and nothing said so");
+    assert.equal(capped.pulls.length, MAX_LIST_PAGES, "one item per page, so the cap bounds the read");
+  }
+
+  const cappedRefs = await listCrossReferencingOpenPulls("ravidsrk/orca-fleet", 71, endless);
+  if (cappedRefs.ok) assert.equal(cappedRefs.truncated, true);
+
+  const cappedReview = await fetchHumanReview("ravidsrk/orca-fleet", 70, endless);
+  if (cappedReview.ok) assert.equal(cappedReview.truncated, true);
+
+  // EACH endpoint on its own. `truncated` is an OR over two reads, and an endless stub truncates
+  // both, so it could not tell the OR from a read of `reviews` alone. Comments-only is the half that
+  // was unpinned — and it is the more likely one, since a busy PR has far more review comments than
+  // reviews.
+  const commentsOnly: typeof fetch = (async (url: string | URL | Request) => {
+    const u = String(url);
+    const body = u.includes("/comments") ? [{ user: { login: "a", type: "User" } }] : [];
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: u.includes("/comments")
+        ? { "Content-Type": "application/json", link: `<${u}>; rel="next"` }
+        : { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+  const halfCapped = await fetchHumanReview("ravidsrk/orca-fleet", 70, commentsOnly);
+  assert.equal(halfCapped.ok, true);
+  if (halfCapped.ok) {
+    assert.equal(halfCapped.truncated, true, "a capped comments read alone must still report truncation");
+    assert.equal(halfCapped.humanReview.reviews, 0);
+  }
+});
+
+/**
+ * The SHIPPED cap, not just the mechanism. #83 spent three rounds on exactly this distinction: the
+ * terminal boundary's mechanism was thoroughly tested while its default stream list was not, and
+ * deleting `process.stderr` left the suite green. A cap the tests read out of the constant they are
+ * checking cannot notice the constant changing, so the number is written down here once.
+ */
+test("the page cap is ten, and both list caps agree", () => {
+  assert.equal(MAX_LIST_PAGES, 10);
+  assert.equal(MAX_COMMIT_PAGES, 10, "the commit read and the list reads must bound alike");
 });

--- a/factory/github-pr.ts
+++ b/factory/github-pr.ts
@@ -688,7 +688,11 @@ export async function syncGithubPr(data: { url: string }, fetchImpl: typeof fetc
     // — the consumer must then say it could not compute the metric rather than record a zero.
     if (pr.merged || pr.state === "closed") {
       const review = await fetchHumanReview(parsed.owner + "/" + parsed.repo, parsed.number, fetchImpl);
-      if (review.ok) meta.humanReview = review.humanReview;
+      // A CAPPED read leaves the field absent, exactly like a failed one, and for the same reason:
+      // "we could not read it" and "nobody reviewed it" are different facts and only one is a KPI.
+      // Raised by review — the flag was returned here and then dropped, so a partial count would
+      // have been recorded and published as a complete read.
+      if (review.ok && !review.truncated) meta.humanReview = review.humanReview;
     }
     return { ok: true as const, meta, title: pr.title ?? "", body: pr.body ?? "" };
   } catch (err) {

--- a/factory/github-pr.ts
+++ b/factory/github-pr.ts
@@ -54,24 +54,30 @@ export interface OpenPull {
 export async function listOpenPulls(
   repoId: string,
   fetchImpl: typeof fetch = fetch,
-): Promise<{ ok: true; pulls: OpenPull[] } | { ok: false; error: string }> {
+): Promise<{ ok: true; pulls: OpenPull[]; truncated: boolean } | { ok: false; error: string }> {
   const [owner, repo] = repoId.split("/");
   if (!owner || !repo) return { ok: false, error: `bad repo id ${repoId}` };
   try {
-    const res = await fetchImpl(`https://api.github.com/repos/${owner}/${repo}/pulls?state=open&per_page=100`, {
-      headers: githubApiHeaders(),
-    });
-    if (!res.ok) return { ok: false, error: `GitHub ${res.status} listing pulls on ${repoId}` };
-    const body = (await res.json()) as {
+    // The highest-severity of the five sites issue #69 names: this feeds the competing-work gate,
+    // and a repository with more than 100 open pull requests is ordinary. A missed open PR means
+    // Foundry opens a duplicate against work already in flight, which is the outcome
+    // docs/PRODUCT.md §2 exists to prevent.
+    const read = await listAllPages<{
       number: number;
       title?: string;
       body?: string | null;
       html_url: string;
       head?: { ref?: string };
-    }[];
+    }>(
+      `https://api.github.com/repos/${owner}/${repo}/pulls?state=open&per_page=100`,
+      `listing pulls on ${repoId}`,
+      fetchImpl,
+    );
+    if (!read.ok) return read;
     return {
       ok: true,
-      pulls: body.map((p) => ({
+      truncated: read.truncated,
+      pulls: read.items.map((p) => ({
         number: p.number,
         title: p.title ?? "",
         body: p.body ?? "",
@@ -89,21 +95,20 @@ export async function listCrossReferencingOpenPulls(
   repoId: string,
   issueNumber: number,
   fetchImpl: typeof fetch = fetch,
-): Promise<{ ok: true; urls: string[] } | { ok: false; error: string }> {
+): Promise<{ ok: true; urls: string[]; truncated: boolean } | { ok: false; error: string }> {
   const [owner, repo] = repoId.split("/");
   if (!owner || !repo) return { ok: false, error: `bad repo id ${repoId}` };
   try {
-    const res = await fetchImpl(
-      `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}/timeline?per_page=100`,
-      { headers: githubApiHeaders() },
-    );
-    if (!res.ok) {
-      return { ok: false, error: `GitHub ${res.status} reading timeline for ${repoId}#${issueNumber}` };
-    }
-    const body = (await res.json()) as {
+    const read = await listAllPages<{
       event?: string;
       source?: { issue?: { state?: string; html_url?: string; pull_request?: unknown } };
-    }[];
+    }>(
+      `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}/timeline?per_page=100`,
+      `reading timeline for ${repoId}#${issueNumber}`,
+      fetchImpl,
+    );
+    if (!read.ok) return read;
+    const body = read.items;
     const urls = body
       .filter(
         (e) =>
@@ -113,7 +118,7 @@ export async function listCrossReferencingOpenPulls(
           typeof e.source.issue.html_url === "string",
       )
       .map((e) => e.source!.issue!.html_url as string);
-    return { ok: true, urls: [...new Set(urls)] };
+    return { ok: true, urls: [...new Set(urls)], truncated: read.truncated };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : "fetch failed" };
   }
@@ -212,16 +217,21 @@ export async function fetchIssueClosingRef(
   const [owner, repo] = repoId.split("/");
   if (!owner || !repo) return undefined;
   try {
-    const res = await fetchImpl(
-      `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}/timeline?per_page=100`,
-      { headers: githubApiHeaders() },
-    );
-    if (!res.ok) return undefined;
-    const body = (await res.json()) as {
+    // Paginated for the same reason as its sibling above, but deliberately WITHOUT a truncation
+    // signal: this function is best-effort by contract (see the docblock), returns `undefined`
+    // rather than an error so it can never turn a refusal into a proceed, and is called only after a
+    // refusal is already decided. A capped read here degrades a message; it cannot change a verdict.
+    const read = await listAllPages<{
       event?: string;
       commit_id?: string | null;
       source?: { issue?: { html_url?: string; pull_request?: unknown } };
-    }[];
+    }>(
+      `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}/timeline?per_page=100`,
+      `reading timeline for ${repoId}#${issueNumber}`,
+      fetchImpl,
+    );
+    if (!read.ok) return undefined;
+    const body = read.items;
     // A commit that closed the issue outright is the more specific answer, so it outranks a
     // cross-reference that merely names it.
     const closingCommit = body.find((e) => e.event === "closed" && typeof e.commit_id === "string");
@@ -405,23 +415,28 @@ export async function fetchHumanReview(
   repoId: string,
   number: number,
   fetchImpl: typeof fetch = fetch,
-): Promise<{ ok: true; humanReview: { reviews: number; comments: number } } | { ok: false; error: string }> {
+): Promise<
+  | { ok: true; humanReview: { reviews: number; comments: number }; truncated: boolean }
+  | { ok: false; error: string }
+> {
   const [owner, repo] = repoId.split("/");
   if (!owner || !repo) return { ok: false, error: `bad repo id ${repoId}` };
   try {
     const base = `https://api.github.com/repos/${owner}/${repo}/pulls/${number}`;
-    const [reviewsRes, commentsRes] = await Promise.all([
-      fetchImpl(`${base}/reviews?per_page=100`, { headers: githubApiHeaders() }),
-      fetchImpl(`${base}/comments?per_page=100`, { headers: githubApiHeaders() }),
+    // A busy PR undercounts human review on a single page, which is the exact metric issue #39
+    // exists to make computable — so an under-read here is a wrong KPI, not a missing one.
+    type Actor = { user?: { login?: string; type?: string } | null };
+    const [reviewsRead, commentsRead] = await Promise.all([
+      listAllPages<Actor>(`${base}/reviews?per_page=100`, "on reviews", fetchImpl),
+      listAllPages<Actor>(`${base}/comments?per_page=100`, "on review comments", fetchImpl),
     ]);
-    if (!reviewsRes.ok) return { ok: false, error: `GitHub ${reviewsRes.status} on reviews` };
-    if (!commentsRes.ok) return { ok: false, error: `GitHub ${commentsRes.status} on review comments` };
-    const reviews = (await reviewsRes.json()) as { user?: { login?: string; type?: string } | null }[];
-    const comments = (await commentsRes.json()) as { user?: { login?: string; type?: string } | null }[];
-    if (!Array.isArray(reviews) || !Array.isArray(comments)) {
-      return { ok: false, error: "GitHub returned a non-list for the review endpoints" };
-    }
-    return { ok: true, humanReview: countHumanReview({ reviews, comments }) };
+    if (!reviewsRead.ok) return reviewsRead;
+    if (!commentsRead.ok) return commentsRead;
+    return {
+      ok: true,
+      humanReview: countHumanReview({ reviews: reviewsRead.items, comments: commentsRead.items }),
+      truncated: reviewsRead.truncated || commentsRead.truncated,
+    };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : "fetch failed" };
   }
@@ -435,6 +450,52 @@ export function nextPageUrl(link: string | null | undefined): string | undefined
     if (match) return match[1];
   }
   return undefined;
+}
+
+/**
+ * How many pages any one list read may follow. Ten pages is 1,000 items — the same bound, and the
+ * same reason, as `MAX_COMMIT_PAGES`: this runs unattended every six hours, and an unbounded follow
+ * is the "excessive automated bulk activity" the AUP names (docs/07-github-app.md).
+ */
+export const MAX_LIST_PAGES = 10;
+
+/**
+ * Every page of a GitHub list endpoint, to a stated cap, saying so when it stops short.
+ *
+ * ONE HOME, because the alternative was five copies. Issue #39 fixed `listCommitsSince` after it was
+ * found truncating in production, and left five siblings with the identical shape — `per_page=100`,
+ * no `page`, no Link follow, no truncation signal. Copying its loop five times would have been five
+ * places for the rule to drift, which is the defect `fixture-counts.ts` was created to end.
+ * `listCommitsSince` reads through here too, so there is one loop and not "the good one plus four".
+ *
+ * `truncated` exists because a short read and a complete one return the same items and the same
+ * verdict. Every consumer already shouts about a read that FAILED; nothing could tell them about one
+ * that merely stopped early.
+ *
+ * `res.headers?.get` is optional because GitHub omits `Link` entirely on a single-page response, and
+ * absent means "no next page" — not an error.
+ */
+async function listAllPages<T>(
+  firstUrl: string,
+  what: string,
+  fetchImpl: typeof fetch,
+  cap: number = MAX_LIST_PAGES,
+): Promise<{ ok: true; items: T[]; truncated: boolean } | { ok: false; error: string }> {
+  let url = firstUrl;
+  const items: T[] = [];
+  for (let page = 0; page < cap; page += 1) {
+    const res = await fetchImpl(url, { headers: githubApiHeaders() });
+    if (!res.ok) return { ok: false, error: `GitHub ${res.status} ${what}` };
+    const body = await res.json();
+    if (!Array.isArray(body)) return { ok: false, error: `GitHub returned a non-list ${what}` };
+    items.push(...(body as T[]));
+    // GitHub's own cursor, followed verbatim rather than a `page=` this code increments: the header
+    // is what the API documents, and the only thing that says "there is more".
+    const next = nextPageUrl(res.headers?.get("link"));
+    if (!next) return { ok: true, items, truncated: false };
+    url = next;
+  }
+  return { ok: true, items, truncated: true };
 }
 
 /**
@@ -484,31 +545,29 @@ export async function listCommitsSince(
   // `revertCheck` below, which is the only caller that can compute it.
   if (opts.until) query.set("until", opts.until);
   if (opts.sha) query.set("sha", opts.sha);
-  let url = `https://api.github.com/repos/${owner}/${repo}/commits?${query}`;
-  const commits: { sha: string; message: string; committedAt: string }[] = [];
   try {
-    for (let page = 0; page < MAX_COMMIT_PAGES; page += 1) {
-      const res = await fetchImpl(url, { headers: githubApiHeaders() });
-      if (!res.ok) return { ok: false, error: `GitHub ${res.status}` };
-      const body = (await res.json()) as {
-        sha?: string;
-        commit?: { message?: string; committer?: { date?: string } | null };
-      }[];
-      if (!Array.isArray(body)) return { ok: false, error: "GitHub returned a non-list for commits" };
-      for (const c of body) {
-        commits.push({
-          sha: c.sha ?? "",
-          message: c.commit?.message ?? "",
-          committedAt: c.commit?.committer?.date ?? "",
-        });
-      }
-      // GitHub's own cursor, followed verbatim rather than a `page=` this code increments: the
-      // header is what the API documents, and it is also the only thing that says "there is more".
-      const next = nextPageUrl(res.headers.get("link"));
-      if (!next) return { ok: true, commits, truncated: false };
-      url = next;
-    }
-    return { ok: true, commits, truncated: true };
+    // Through the same loop as the other five list reads (issue #69). This one was correct first —
+    // #39 wrote it after finding the truncation in production — and it stays the reference, but as a
+    // CALLER of the shared loop rather than the one good copy beside four broken ones.
+    const read = await listAllPages<{
+      sha?: string;
+      commit?: { message?: string; committer?: { date?: string } | null };
+    }>(
+      `https://api.github.com/repos/${owner}/${repo}/commits?${query}`,
+      "for commits",
+      fetchImpl,
+      MAX_COMMIT_PAGES,
+    );
+    if (!read.ok) return read;
+    return {
+      ok: true,
+      truncated: read.truncated,
+      commits: read.items.map((c) => ({
+        sha: c.sha ?? "",
+        message: c.commit?.message ?? "",
+        committedAt: c.commit?.committer?.date ?? "",
+      })),
+    };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : "fetch failed" };
   }

--- a/factory/github-pr.ts
+++ b/factory/github-pr.ts
@@ -686,15 +686,20 @@ export async function syncGithubPr(data: { url: string }, fetchImpl: typeof fetc
     // `fetchHumanReview` for why re-reading an already-terminal PR is wanted rather than tolerated.
     // An open PR costs exactly the one request it always did. A failure leaves `humanReview` ABSENT
     // — the consumer must then say it could not compute the metric rather than record a zero.
+    let reviewTruncated = false;
     if (pr.merged || pr.state === "closed") {
       const review = await fetchHumanReview(parsed.owner + "/" + parsed.repo, parsed.number, fetchImpl);
       // A CAPPED read leaves the field absent, exactly like a failed one, and for the same reason:
       // "we could not read it" and "nobody reviewed it" are different facts and only one is a KPI.
-      // Raised by review — the flag was returned here and then dropped, so a partial count would
-      // have been recorded and published as a complete read.
+      //
+      // But it is REPORTED separately, because the operator's next move differs. A failed endpoint
+      // is worth retrying; a capped one will cap again, and the advice is to look at the PR by hand
+      // or raise the cap deliberately. Round 1 of this fix stored neither and said neither, which
+      // left "absent" meaning two different things — raised by review.
+      reviewTruncated = review.ok && review.truncated;
       if (review.ok && !review.truncated) meta.humanReview = review.humanReview;
     }
-    return { ok: true as const, meta, title: pr.title ?? "", body: pr.body ?? "" };
+    return { ok: true as const, meta, title: pr.title ?? "", body: pr.body ?? "", reviewTruncated };
   } catch (err) {
     return {
       ok: false as const,

--- a/factory/github-pr.ts
+++ b/factory/github-pr.ts
@@ -58,10 +58,8 @@ export async function listOpenPulls(
   const [owner, repo] = repoId.split("/");
   if (!owner || !repo) return { ok: false, error: `bad repo id ${repoId}` };
   try {
-    // The highest-severity of the five sites issue #69 names: this feeds the competing-work gate,
-    // and a repository with more than 100 open pull requests is ordinary. A missed open PR means
-    // Foundry opens a duplicate against work already in flight, which is the outcome
-    // docs/PRODUCT.md §2 exists to prevent.
+    // The sharpest of the five: this feeds the competing-work gate, >100 open PRs is ordinary, and a
+    // missed one means opening a duplicate against work in flight (docs/PRODUCT.md §2).
     const read = await listAllPages<{
       number: number;
       title?: string;
@@ -217,10 +215,9 @@ export async function fetchIssueClosingRef(
   const [owner, repo] = repoId.split("/");
   if (!owner || !repo) return undefined;
   try {
-    // Paginated for the same reason as its sibling above, but deliberately WITHOUT a truncation
-    // signal: this function is best-effort by contract (see the docblock), returns `undefined`
-    // rather than an error so it can never turn a refusal into a proceed, and is called only after a
-    // refusal is already decided. A capped read here degrades a message; it cannot change a verdict.
+    // Paginated, but deliberately WITHOUT a truncation signal: best-effort by contract (docblock
+    // above), called only after a refusal is decided, so a short read degrades a message and cannot
+    // move a verdict.
     const read = await listAllPages<{
       event?: string;
       commit_id?: string | null;
@@ -423,8 +420,7 @@ export async function fetchHumanReview(
   if (!owner || !repo) return { ok: false, error: `bad repo id ${repoId}` };
   try {
     const base = `https://api.github.com/repos/${owner}/${repo}/pulls/${number}`;
-    // A busy PR undercounts human review on a single page, which is the exact metric issue #39
-    // exists to make computable — so an under-read here is a wrong KPI, not a missing one.
+    // A busy PR undercounts on one page: an under-read here is a wrong KPI, not a missing one.
     type Actor = { user?: { login?: string; type?: string } | null };
     const [reviewsRead, commentsRead] = await Promise.all([
       listAllPages<Actor>(`${base}/reviews?per_page=100`, "on reviews", fetchImpl),
@@ -452,28 +448,16 @@ export function nextPageUrl(link: string | null | undefined): string | undefined
   return undefined;
 }
 
-/**
- * How many pages any one list read may follow. Ten pages is 1,000 items — the same bound, and the
- * same reason, as `MAX_COMMIT_PAGES`: this runs unattended every six hours, and an unbounded follow
- * is the "excessive automated bulk activity" the AUP names (docs/07-github-app.md).
- */
+/** Pages one list read may follow: 1,000 items, same bound and reason as `MAX_COMMIT_PAGES` — this
+ * runs unattended every six hours (docs/07-github-app.md's "excessive automated bulk activity"). */
 export const MAX_LIST_PAGES = 10;
 
 /**
- * Every page of a GitHub list endpoint, to a stated cap, saying so when it stops short.
- *
- * ONE HOME, because the alternative was five copies. Issue #39 fixed `listCommitsSince` after it was
- * found truncating in production, and left five siblings with the identical shape — `per_page=100`,
- * no `page`, no Link follow, no truncation signal. Copying its loop five times would have been five
- * places for the rule to drift, which is the defect `fixture-counts.ts` was created to end.
- * `listCommitsSince` reads through here too, so there is one loop and not "the good one plus four".
- *
- * `truncated` exists because a short read and a complete one return the same items and the same
- * verdict. Every consumer already shouts about a read that FAILED; nothing could tell them about one
- * that merely stopped early.
- *
- * `res.headers?.get` is optional because GitHub omits `Link` entirely on a single-page response, and
- * absent means "no next page" — not an error.
+ * Every page of a GitHub list endpoint, to a stated cap, saying so when it stops short. ONE HOME:
+ * #39 fixed `listCommitsSince` and left five siblings identical, and five copies of its loop are five
+ * places to drift — `listCommitsSince` reads through here too. `truncated` exists because a short
+ * read returns the same items and verdict as a complete one. `headers?.get` is optional: GitHub omits
+ * `Link` on a single page, and absent means no next page.
  */
 async function listAllPages<T>(
   firstUrl: string,
@@ -546,9 +530,8 @@ export async function listCommitsSince(
   if (opts.until) query.set("until", opts.until);
   if (opts.sha) query.set("sha", opts.sha);
   try {
-    // Through the same loop as the other five list reads (issue #69). This one was correct first —
-    // #39 wrote it after finding the truncation in production — and it stays the reference, but as a
-    // CALLER of the shared loop rather than the one good copy beside four broken ones.
+    // Through the same loop as the other five (issue #69). Correct first, and still the reference —
+    // but as a CALLER of the shared loop rather than the one good copy.
     const read = await listAllPages<{
       sha?: string;
       commit?: { message?: string; committer?: { date?: string } | null };
@@ -689,13 +672,9 @@ export async function syncGithubPr(data: { url: string }, fetchImpl: typeof fetc
     let reviewTruncated = false;
     if (pr.merged || pr.state === "closed") {
       const review = await fetchHumanReview(parsed.owner + "/" + parsed.repo, parsed.number, fetchImpl);
-      // A CAPPED read leaves the field absent, exactly like a failed one, and for the same reason:
-      // "we could not read it" and "nobody reviewed it" are different facts and only one is a KPI.
-      //
-      // But it is REPORTED separately, because the operator's next move differs. A failed endpoint
-      // is worth retrying; a capped one will cap again, and the advice is to look at the PR by hand
-      // or raise the cap deliberately. Round 1 of this fix stored neither and said neither, which
-      // left "absent" meaning two different things — raised by review.
+      // A CAPPED read leaves the field absent like a failed one — "we could not read it" and
+      // "nobody reviewed it" are different facts and only one is a KPI — but is REPORTED separately,
+      // because a failed endpoint is worth retrying and a capped one will cap again.
       reviewTruncated = review.ok && review.truncated;
       if (review.ok && !review.truncated) meta.humanReview = review.humanReview;
     }

--- a/factory/github-pr.ts
+++ b/factory/github-pr.ts
@@ -672,9 +672,8 @@ export async function syncGithubPr(data: { url: string }, fetchImpl: typeof fetc
     let reviewTruncated = false;
     if (pr.merged || pr.state === "closed") {
       const review = await fetchHumanReview(parsed.owner + "/" + parsed.repo, parsed.number, fetchImpl);
-      // A CAPPED read leaves the field absent like a failed one — "we could not read it" and
-      // "nobody reviewed it" are different facts and only one is a KPI — but is REPORTED separately,
-      // because a failed endpoint is worth retrying and a capped one will cap again.
+      // A CAPPED read leaves the field absent like a failed one, but is REPORTED separately: an
+      // endpoint outage is worth retrying and a capped read is not.
       reviewTruncated = review.ok && review.truncated;
       if (review.ok && !review.truncated) meta.humanReview = review.humanReview;
     }

--- a/factory/ledger-check.ts
+++ b/factory/ledger-check.ts
@@ -29,6 +29,12 @@ export interface LivePrLite {
    * same advisory path a failed read takes, because it is the same fact at a lower strength.
    */
   revertTruncated?: boolean;
+  /**
+   * Did the human-review read stop at its page cap? `revertTruncated`'s fact one endpoint over: a
+   * capped read records nothing, like a failed one, so without this the advisory below says "re-run
+   * when GitHub answers" — advice that cannot work, because it answered and the cap is deterministic.
+   */
+  reviewTruncated?: boolean;
 }
 
 /**
@@ -193,8 +199,13 @@ export function packetChecks(packet: TaskPacket, live: LivePrLite): LedgerReconc
   // sentence the operator should be reading rather than this one.
   const liveTerminal = live.merged || live.state === "closed";
   if (isTerminalReviewSubject(packet) && liveTerminal && packet.prUrl && !packet.prMeta?.humanReview) {
+    // WHY it is missing decides the advice, and the two reasons want opposite advice: a failed
+    // endpoint is worth re-running, a CAPPED read caps again. Emitting both lines in one run told the
+    // operator to re-run and not to re-run about one PR.
     advisory.push(
-      `${packet.id}: the ledger records no human-review observation for a terminal PR — ${packet.repoId}'s noReview and reviewCommentsAvg are computed WITHOUT it, so the KPI's denominator is smaller than the terminal count suggests. Run \`reconcile\` on a pass where GitHub answers the review endpoints (NOT \`sync\`, which refuses a terminal packet), then promote the recovered row into factory/seed.ts`,
+      live.reviewTruncated
+        ? `${packet.id}: the human-review read on ${packet.repoId} stopped at its page cap, so noReview and reviewCommentsAvg are computed WITHOUT this PR. A re-run will cap again — read the PR by hand, or raise the cap deliberately`
+        : `${packet.id}: the ledger records no human-review observation for a terminal PR — ${packet.repoId}'s noReview and reviewCommentsAvg are computed WITHOUT it, so the KPI's denominator is smaller than the terminal count suggests. Run \`reconcile\` on a pass where GitHub answers the review endpoints (NOT \`sync\`, which refuses a terminal packet), then promote the recovered row into factory/seed.ts`,
     );
   }
   return { fatal: out, advisory };

--- a/factory/verify-ledger.ts
+++ b/factory/verify-ledger.ts
@@ -57,6 +57,9 @@ for (const packet of withPr) {
     // the same `reverted: false` a complete one does, so without this the clock cannot tell a
     // clean base branch from one it only half-read — and it would print `ledger ok` over both.
     revertTruncated: reverted?.ok ? reverted.truncated : undefined,
+    // And the same for the review read (issue #69): a capped one records nothing, and the operator
+    // needs to be told the cap did it rather than an outage.
+    reviewTruncated: synced.reviewTruncated,
   });
   fatal.push(...checks.fatal);
   advisory.push(...checks.advisory);


### PR DESCRIPTION
Closes #69

## What

All five list reads follow GitHub's `Link: rel="next"` cursor to a stated cap through **one** shared
loop, report `truncated`, and that flag now reaches an operator on every surface that consumes it.
`listCommitsSince` reads through the same loop.

## Why

Five reads shared `listCommitsSince`'s pre-#39 shape — `per_page=100`, no `page`, no Link follow, no
truncation signal — so **a truncated success was byte-identical to a complete one**.

`listOpenPulls` is the sharpest: it feeds the competing-work gate, a repository with more than 100
open pull requests is ordinary, and a missed open PR means opening a duplicate against work already
in flight — the outcome `docs/PRODUCT.md` §2 exists to prevent. The review endpoints feed `noReview`
and `reviewCommentsAvg`, so an under-read there is a *wrong* KPI rather than a missing one, which is
the exact metric #39 exists to make computable.

**One loop, not five copies.** #39's fix was correct and stays the reference, but copying its body
five times would be five places for the rule to drift — the defect `fixture-counts.ts` exists to end.

## How verified

- **tests**: 327 across 16 files, `suite ok`; `npm run validate` exit 0. Worktree baseline 320/16.
- **mutation audit: 15 mutants, 15 killed, 0 survivors**, across `github-pr.ts`, `cli.ts`,
  `ledger-check.ts` and `verify-ledger.ts` — every site, every flag, and both call sites of
  `packetChecks`.
- **the second page is actually read** — each of the four readers is driven across a page boundary
  with the payload placed on page 2, so a one-page read fails. The stub is keyed **per endpoint**
  because `fetchHumanReview` reads `/reviews` and `/comments` in parallel and a shared counter gave
  each of them one page, which looked like "pagination works" while proving the opposite.
- **a capped read is distinguishable**, asserted three ways: `truncated` on the reader, a real `tick`
  through the CLI refusing, and `syncGithubPr` leaving the KPI unrecorded.
- **the shipped cap is pinned** (`MAX_LIST_PAGES === 10`), not read out of the constant under test —
  the distinction #83 spent three rounds on.

## Notes for review

**A capped competing-work read is REFUSED, not warned.** The gate asserts the *absence* of a
competitor, and an absence is the one thing a short read cannot establish; proceeding would publish
"no competing pull request" as a fact the run never checked. It gets its own message so a capped read
stays distinguishable from a failed one, which is the distinction this issue is about.

**`fetchIssueClosingRef` paginates with no signal, deliberately.** It is best-effort by contract,
returns `undefined` so it can never turn a refusal into a proceed, and runs only after a refusal is
decided. A short read there degrades a message; it cannot move a verdict.

**Four P1s from review, all real, and all one shape: a signal that existed and reached nothing.**

1. *`tick` checked the pulls read and not the timeline* — so a capped cross-reference list reached
   `classifyCompetition` and a competing PR past the cap was missed. Both reads feeding the verdict
   are now checked.
2. *`syncGithubPr` computed `truncated` and dropped it* — ten pages of a busy PR's reviews would have
   been recorded and published as a complete count. A capped read now leaves `humanReview` absent,
   reusing the advisory path a failed read already takes rather than adding a field.
3. *A capped read then looked exactly like an outage* — same absent field, and the operator got retry
   guidance for a condition that reproduces on every run.
4. *The cap advisory lived in `reconcile` alone* — beside `packetChecks`'s generic "re-run when GitHub
   answers" line, so **one run said both re-run and do-not-re-run about the same PR**, and
   `verify-ledger` said neither.

(3) and (4) are fixed together by putting the fact on `LivePrLite`, beside the `revertTruncated`
already there for the identical concern one endpoint over. That is the parameter both verbs already
build, so neither can forget it, and `packetChecks` picks the advisory from the reason: an outage is
worth re-running, a capped read caps again.

**This unit has shipped the one-call-site defect three times** — `revert`, then `revertTruncated`,
now `reviewTruncated` — because an omitted optional field is a runtime `undefined` under
`--experimental-strip-types`, never a compile error. `factory/cli.test.ts` now compares the two
`packetChecks` call sites to each other for exactly those fields. That guard is **by source, not by a
drive**, and the reason is worth stating plainly: `verify-ledger` reads the *committed seed*, where
every merged packet carries an observation, so the review advisory is unreachable from that verb. The
drive is unavailable rather than inconvenient — the same limit the sibling test uses as its control.

**One residual, tracked in #92 rather than buried.** `recordTerminalReview` (the `sync` path) cannot
see the reason, so its line names **both** — true, so no operator is misled, but less precise than
the process that produced it could be. Fixing it means a fourth optional argument through
`applyPrSync`, which is the forgettable-field hazard above; #92 proposes making it a *required* field
so omission is a type error instead. Round 5 returned **zero findings at confidence 4/5** with this
noted in its reasoning, so this merges on the stated exit criteria with the residual filed.

**On size**: this touches five call sites plus two consumer surfaces and landed at 485 net. The
commentary is cut rather than the work — 400 net now, with the 15-mutant audit re-run afterwards.




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR centralizes capped pagination for GitHub list reads and propagates truncation state to safety gates, review synchronization, and operator advisories.
- Adds a shared pagination loop with an explicit ten-page cap and truncation result.
- Refuses competing-work decisions when open-pull or cross-reference reads are incomplete.
- Avoids recording partial review metrics and distinguishes capped reads from transient outages.
- Removes the previously reported unreachable duplicate error branch without weakening the gate.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| factory/github-pr.ts | Centralizes GitHub list pagination and propagates explicit truncation state through pull, timeline, review, and commit reads. |
| factory/cli.ts | Applies fail-closed handling to capped competing-work reads and correctly removes the previously reported duplicate guard. |
| factory/ledger-check.ts | Produces distinct operator guidance when review data is absent because pagination reached its cap. |
| factory/verify-ledger.ts | Passes review-truncation state into shared packet checks so verification and reconciliation report consistently. |
| factory/engine.ts | Preserves incomplete review observations as absent rather than recording partial KPI data. |
| factory/github-pr.test.ts | Exercises multi-page reads, page-cap behavior, and truncation propagation across GitHub endpoints. |
| factory/cli.test.ts | Verifies capped competing-work reads refuse execution and capped review reads receive accurate operator messaging. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(cli): drop a duplicate unreachable c..."](https://github.com/ravidsrk/oss-foundry/commit/0ecbb0887ba3c59acf907181111fae381bfd067d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58277939)</sub>

<!-- /greptile_comment -->