### PR TITLE
test(halt): pin canonicalisation against a pre-#44 ledger (#57)

### DIFF
--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -967,6 +967,61 @@ test("halt typed in GitHub's casing halts the roster's repo, not a repo that doe
   assert.equal(applyHalt(halted.state, "COLEMURRAY/BACKGROUND-AGENTS", "again").state.bans, 1);
 });
 
+/**
+ * The same halt against a ledger whose stored ids are OFF-canonical — which is what every ledger
+ * written before #44 looks like, and `loadFactoryState` accepts them. `.foundry-state.json` is the
+ * operator's live gitignored file, so this is the ordinary upgrade path rather than a contrived
+ * state.
+ *
+ * The test above cannot see these two lines, because the seed it uses is already canonical and plain
+ * `===` satisfies it. Reverting either `sameRepoId` in `applyHalt` to `===` left the suite at
+ * 327/327 (issue #57), and each revert reproduces verbatim the failure the function's own docblock
+ * says it prevents: report success, bump `bans`, and leave the work running.
+ */
+test("halt moves an off-canonical row and packet — the shape a pre-#44 ledger has", () => {
+  const canonical = "ColeMurray/background-agents";
+  const OFF = "COLEMURRAY/BACKGROUND-AGENTS";
+  const seed = seedState();
+  const inflightBefore = seed.packets.filter(
+    (p) => p.repoId === canonical && INFLIGHT_STATUSES.includes(p.status),
+  );
+  assert.ok(inflightBefore.length > 0, "the seed must hold an in-flight packet or this binds nothing");
+  assert.ok(
+    seed.scorecard.some((r) => r.repoId === canonical),
+    "the seed must hold the row this rewrites, or the fixture proves nothing",
+  );
+
+  const state: FactoryState = {
+    ...seed,
+    packets: seed.packets.map((p) => (p.repoId === canonical ? { ...p, repoId: OFF } : p)),
+    scorecard: seed.scorecard.map((r) => (r.repoId === canonical ? { ...r, repoId: OFF } : r)),
+  };
+
+  const halted = applyHalt(state, "colemurray/background-agents", "maintainer asked us to stop");
+  assert.equal(halted.error, undefined);
+  assert.equal(halted.repoId, canonical);
+
+  // The scorecard half. Under a raw `===` the row keeps tone=neutral/health=good while `bans`
+  // still counts the halt, so `status` reads as halted and `maySelectRepo` waves the repo through.
+  const row = halted.state.scorecard.find((r) => r.repoId === OFF)!;
+  assert.ok(row, "the off-canonical row disappeared instead of being updated");
+  assert.equal(row.maintainerTone, "banned", "the off-canonical row was not banned");
+  assert.equal(health(row), "stop");
+  assert.equal(halted.state.bans, 1);
+  const gate = maySelectRepo(halted.state, canonical);
+  assert.equal(gate.ok, false, "a halted repo whose row is stored off-canonical is still selectable");
+
+  // The packet half. Under a raw `===` the halt returns no error, bans the repo, and leaves the
+  // packet in flight — the exact "halted nothing" the sibling test's docblock names.
+  for (const before of inflightBefore) {
+    assert.equal(
+      halted.state.packets.find((p) => p.id === before.id)!.status,
+      "parked",
+      `${before.id} stayed in flight through a halt because its stored repoId is off-canonical`,
+    );
+  }
+});
+
 test("halt still refuses a repo the roster does not know, loudly", () => {
   // The fail-CLOSED half. Case-insensitivity must widen matching, not admit strangers.
   for (const id of ["attacker/not-a-repo", "attacker/background-agents", "background-agents"]) {
@@ -5057,4 +5112,58 @@ test("applyRevert writes the note and the counter together", () => {
   assert.ok(refused.error);
   assert.equal(refused.state.scorecard.reduce((a, r) => a + r.reverts, 0), 0);
   assert.equal(refused.state.packets.filter((p) => revertNote(p)).length, 0);
+});
+
+/**
+ * The other two canonicalisation sites the #57 audit found unpinned.
+ *
+ * That issue said seven of the nine were pinned and asked for a sweep to confirm none was pinned
+ * only incidentally by a canonical fixture. The sweep disproved its own premise: reverting
+ * `engine.ts:183` or `scorecard.ts:114` to a raw `===` also left the suite green. Both are the same
+ * pre-#44 upgrade path as the halt above — a ledger whose stored ids are off-canonical, which
+ * `loadFactoryState` accepts.
+ */
+test("an off-canonical stored packet is still found, so the tick cannot build a second one", () => {
+  const first = applyQueueLive(blank(), live("ravidsrk/orca-fleet", 71));
+  assert.ok(first.packet, `the fixture must queue a packet or this binds nothing: ${first.reason}`);
+
+  // The same ledger, with the packet stored the way a pre-canonicalisation state file holds it —
+  // and TERMINAL, because `applyQueueLive` returns "in-flight" before it ever reaches the duplicate
+  // guard. A merged packet is the case that matters anyway: the guard exists so the factory does not
+  // work an issue it has already finished.
+  const off: FactoryState = {
+    ...first.state,
+    packets: first.state.packets.map((p) => ({ ...p, repoId: p.repoId.toUpperCase(), status: "merged" as const })),
+  };
+  const again = applyQueueLive(off, live("ravidsrk/orca-fleet", 71));
+  assert.equal(
+    again.reason,
+    "duplicate",
+    "the duplicate guard missed an off-canonical packet, so the tick queued a second packet for one issue",
+  );
+  assert.equal(
+    again.state.packets.length,
+    off.packets.length,
+    "the ledger grew a second packet for an issue that already had one",
+  );
+});
+
+test("applyReviewToScorecard finds an off-canonical row, and only that row", () => {
+  const rows = emptyScorecard().map((r) =>
+    r.repoId === "ravidsrk/orca-fleet" ? { ...r, repoId: "RAVIDSRK/ORCA-FLEET" } : r,
+  );
+  assert.ok(rows.length > 1, "more than one row, or 'only that row' is not a claim");
+
+  const after = applyReviewToScorecard(rows, "ravidsrk/orca-fleet", { reviews: 0, comments: 0 });
+  const row = after.find((r) => r.repoId === "RAVIDSRK/ORCA-FLEET")!;
+  // Under a raw `===` the observation is written to NO row: the KPI is silently dropped, which is
+  // worse than a failed read because nothing reports it.
+  assert.equal(row.noReview, 1, "the review observation was written to no row at all");
+  // ...and the guard must still be a guard: #39's review found that removing it wrote the split into
+  // every allowlist row, inflating the factory-wide sum 8x.
+  assert.equal(
+    after.filter((r) => r.noReview > 0).length,
+    1,
+    "the observation landed on more than the row it was for",
+  );
 });


### PR DESCRIPTION
Closes #57

## What

An off-canonical fixture — the shape a pre-#44 ledger actually has — so `applyHalt`'s two
canonicalisation call sites die under a raw `===`. Plus the sweep the issue asked for, which found
two more unpinned sites and pins those too.

## Why

Reverting either `sameRepoId` in `applyHalt` to `===` left the suite at **327/327**. The shipped code
is correct, so this is a coverage hole rather than a live defect — but each revert reproduces
verbatim the failure the function's own docblock says it prevents: report success, bump `bans`, leave
the row `tone=neutral health=good`, and leave the packet in flight. A halt that says "halted" and
halts nothing.

The existing test cannot see those lines because it uses `seedState()`, whose ids are already
canonical, so plain `===` satisfies it. The reachable population is not hypothetical:
canonicalisation is new in #44, every ledger written before it holds off-canonical ids in
`packets[].repoId` and `scorecard[].repoId`, and `loadFactoryState` accepts them.
`.foundry-state.json` is the operator's live gitignored file.

## How verified

- **tests**: 330 across 16 files, `suite ok`; `npm run validate` exit 0. Baseline was 327/16.
- **the two sites the issue names, each dying on its own** — one mutation at a time, full suite, then
  restored and re-verified green:

  | mutation | test that reds |
  |---|---|
  | `engine.ts:321` `sameRepoId(r.repoId, canonical)` → `r.repoId === canonical` | `halt moves an off-canonical row and packet — the shape a pre-#44 ledger has` |
  | `engine.ts:331` `!sameRepoId(packet.repoId, canonical)` → `packet.repoId !== canonical` | same |

- **the audit bullet, and it disproved the issue's own premise.** #57 says seven of the nine sites
  are pinned and asks for a sweep confirming none was pinned only incidentally. Mutating **all nine**
  found two more survivors:

  | site | what a raw `===` costs | now reds |
  |---|---|---|
  | `engine.ts:183` duplicate-packet guard | the tick builds a **second packet** for an issue that already has one | `an off-canonical stored packet is still found, so the tick cannot build a second one` |
  | `scorecard.ts:114` `applyReviewToScorecard` | the observation is written to **no row at all** — the KPI is silently dropped | `applyReviewToScorecard finds an off-canonical row, and only that row` |

  Final sweep: **9 sites, 9 killed, 0 survivors**, across `allowlist.ts`, `engine.ts` and
  `scorecard.ts`.
- **greptile**: 1 round, confidence 5/5, 0 findings.

## Notes for review

**A unit test on `applyHalt` rather than extending the CLI-driven test.** The issue proposed
extending *halt typed in GitHub's casing…*; I added a focused test beside it instead, because the
reducer test can assert the exact facts (the row flipped, the packet parked, `bans` counted) rather
than parsing `status` stdout, and each of the two lines then fails for its own reason. The
CLI-driven test is left alone.

**The duplicate-guard fixture had to be made TERMINAL, and that is worth knowing.** My first
attempt stored the packet off-canonical and in flight; `applyQueueLive` returns `"in-flight"` before
it ever reaches the duplicate guard, so the test failed on unmutated code. A merged packet is the
case that matters anyway — the guard exists so the factory does not re-work an issue it has already
finished.

**`applyReviewToScorecard` is asserted in both directions.** Not just "the off-canonical row was
updated" but "only that row was", because #39's review found that removing the guard entirely wrote
the split into every allowlist row and would have inflated the factory-wide sum 8×. A test that only
checked the first direction would pass with the guard deleted.

**Not done**: the two newly-found sites are pinned but their *docblocks* are untouched, and I did not
go looking for canonicalisation-shaped defects outside `sameRepoId` — that would be a different
sweep than the one the issue asked for.




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds regression coverage for repository-ID canonicalisation against pre-#44 ledger shapes.
- Verifies that halting updates off-canonical scorecard rows and parks matching in-flight packets.
- Verifies that completed off-canonical packets still prevent duplicate queueing.
- Verifies that review observations update exactly one matching off-canonical scorecard row.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| factory/engine.test.ts | Adds focused regression tests covering four canonicalisation-sensitive behaviors using off-canonical persisted repository IDs. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into ravidsrk/issue-..."](https://github.com/ravidsrk/oss-foundry/commit/ac6ba2274bd06e0bdcf9d9a06a314c00e0ae2dc2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58280136)</sub>

<!-- /greptile_comment -->