### PR TITLE
fix(witness): name reject, not park, on a failed negative control (#62)

### DIFF
--- a/factory/sandbox.test.ts
+++ b/factory/sandbox.test.ts
@@ -55,10 +55,15 @@ test("negative-control refusal tells the operator to reject, not to press a verb
 });
 
 /**
- * A tracking comment that names a closed issue reads as accounted for — which is how this
- * defect was orphaned when #44 closed (issue #62).
+ * A tracking comment that names an issue reads as accounted for, and it outlives the issue: that is
+ * exactly how this defect was orphaned when #44 closed with the item unfixed (issue #62).
+ *
+ * The rule is "no issue pointer at all", not "no CLOSED issue pointer", and the name says so. A test
+ * cannot tell open from closed without the network, and it should not try — the tracker is the
+ * tracker. Forbidding the pointer outright is both testable and the stronger rule, and it fires on
+ * an OPEN citation too, which was verified rather than assumed.
  */
-test("no KNOWN DEFECT comment in factory/ cites a closed issue", () => {
+test("no KNOWN DEFECT comment in factory/ carries an issue pointer", () => {
   const factory = fileURLToPath(new URL(".", import.meta.url));
   const hits: string[] = [];
   for (const name of readdirSync(factory)) {

--- a/factory/sandbox.test.ts
+++ b/factory/sandbox.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 import { SANDBOX_RULES } from "./sandbox.ts";
+import { witnessEvidence } from "./witness.ts";
 
 /**
  * Doctrine text that tells the operator what to do must name a verb the operator has. The CLI's
@@ -16,4 +20,51 @@ test("sandbox doctrine tells the operator to reject, not to press a verb the CLI
   assert.match(oracle, /\breject\b/i);
   assert.doesNotMatch(oracle, /park the packet/i);
   assert.match(oracle, /do not skip the oracle/i);
+});
+
+/**
+ * Same pin as the sandbox doctrine above, for the SPEC §5 negative-control refusal.
+ * `parked` is a status the engine writes; the operator's stand-down verb is `reject` (issue #62).
+ */
+test("negative-control refusal tells the operator to reject, not to press a verb the CLI lacks", async () => {
+  const runner = async (step: string) => {
+    if (step === "mkdtemp") return { exit: 0, output: "/tmp/foundry-witness-fake" };
+    if (step === "run-tests@head") return { exit: 0, output: "ok" };
+    if (step === "run-tests@revert") return { exit: 0, output: "still ok" };
+    return { exit: 0, output: "" };
+  };
+  const outcome = await witnessEvidence(
+    {
+      packetId: "pkt_ravidsrk_orca-fleet_71",
+      repoId: "ravidsrk/orca-fleet",
+      baseSha: "251fe899c5bd843a7dad71d908c0af3bfcea79e1",
+      headSha: "d91fe2f6725163fab8f9dd42e5c2b0c0c9f0f40d",
+      testCommand: "true",
+      sandbox: "host",
+      wave: 0,
+    },
+    runner,
+    {},
+  );
+  assert.equal(outcome.ok, false);
+  if (!outcome.ok) {
+    assert.match(outcome.error, /\breject\b/i);
+    assert.doesNotMatch(outcome.error, /park the packet/i);
+    assert.match(outcome.error, /does not bind the change/i);
+  }
+});
+
+/**
+ * A tracking comment that names a closed issue reads as accounted for — which is how this
+ * defect was orphaned when #44 closed (issue #62).
+ */
+test("no KNOWN DEFECT comment in factory/ cites a closed issue", () => {
+  const factory = fileURLToPath(new URL(".", import.meta.url));
+  const hits: string[] = [];
+  for (const name of readdirSync(factory)) {
+    if (!name.endsWith(".ts") || name.endsWith(".test.ts")) continue;
+    const text = readFileSync(join(factory, name), "utf8");
+    if (/KNOWN DEFECT[\s\S]{0,200}issue #\d+/.test(text)) hits.push(name);
+  }
+  assert.deepEqual(hits, []);
 });

--- a/factory/witness.ts
+++ b/factory/witness.ts
@@ -478,18 +478,10 @@ export async function witnessEvidence(
   if (revertRun.exit === 0) {
     return {
       ok: false,
-      // KNOWN DEFECT, diagnosed not undiscovered (issue #62): the "park the packet" below names a
-      // verb the operator does not have. `parked` is a status the engine writes on its own; the
-      // operator's stand-down verb is `reject`, as the corrected sibling string in
-      // `factory/sandbox.ts` already says. The wording here should read "reject the packet"; #62
-      // owns that string — delete this comment with that edit, and not before.
-      //
-      // Re-pointed from "issue #44 item 5", which is why the marker is worth keeping honest: #44
-      // closed with this item unfixed, so the pointer named a closed issue and the defect was
-      // owned by nobody. A tracking comment citing a closed issue is worse than none — it reads
-      // as accounted for.
+      // `reject` is the operator's verb; `parked` is a status the engine writes on its own.
+      // A refusal that reads as an instruction must name a button the operator has (issue #62).
       error:
-        "negative control failed — tests stayed green with the production change reverted. The proof does not bind the change; park the packet." +
+        "negative control failed — tests stayed green with the production change reverted. The proof does not bind the change; reject the packet." +
         runFailureDetail(input.testCommand, revertRun.output, toolchain),
     };
   }


### PR DESCRIPTION
Closes #62

## What

The SPEC §5 negative-control refusal in `factory/witness.ts` told the operator to `park the packet`. There is no `park` verb. The operator's stand-down verb is `reject`, matching the sibling string in `factory/sandbox.ts`. The `KNOWN DEFECT` comment that cited a closed issue is deleted with that wording.

## Why

`parked` is a status the engine writes on its own (scope overflow, scorecard halt, policy denial). A refusal that reads as an instruction must name a button the operator actually has. This string was tracked as issue #44 item 5; #44 closed with it unfixed, so the in-file marker pointed at a closed issue and nobody owned the defect.

## How verified

- Baseline before the first edit: `suite ok — 327 tests across 16 files`; allowlist ok.
- After the change: `suite ok — 329 tests across 16 files`; allowlist ok.
- Net LOC: +54 / −11 = 43 (cap 400).

- Greptile: 1 round, confidence 5/5, 0 comments.

Red-by-revert (full suite each time; restore via `/tmp` copy, never `git checkout`):

| Mutation | Failing test |
| --- | --- |
| `reject the packet` → `park the packet` | `negative-control refusal tells the operator to reject, not to press a verb the CLI lacks` (`/\breject\b/i`) |
| hedge: `park the packet or reject the packet` | same test (`/park the packet/i` must be absent) |
| re-insert `KNOWN DEFECT … (issue #44)` | `no KNOWN DEFECT comment in factory/ cites a closed issue` |

Sweep: the only other operator-facing invented-verb of this class was issue #35 (`re-attach`), already corrected to `attach-witness` / `INGEST_INVOCATION`. No further one-word CLI-verb mismatches found in operator-facing refusals.

## Notes for review

- Pin lives in `factory/sandbox.test.ts` next to the sibling doctrine pin, and drives `witnessEvidence` with a revert-stays-green runner (the `revertRun.exit === 0` branch), not a source grep of the string.
- `factory/engine.test.ts` is untouched; its `stagedRunner` `control` stage was read only.
- Deliberate non-goals: no change to engine park-*status* paths; no CLI verb named `park`.






<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR changes the failed negative-control instruction from the nonexistent operator action “park” to “reject” and adds regression coverage.
- Exercises the negative-control refusal through `witnessEvidence`.
- Adds a source-policy test prohibiting issue pointers near `KNOWN DEFECT` markers.
- Removes the obsolete defect-tracking comment from the corrected refusal.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| factory/witness.ts | Corrects the negative-control refusal to instruct operators to reject the packet and removes the obsolete defect marker. |
| factory/sandbox.test.ts | Adds behavioral coverage for the corrected refusal and a policy check for issue-linked KNOWN DEFECT comments. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into ravidsrk/issue-..."](https://github.com/ravidsrk/oss-foundry/commit/94584655cf598f1cdbad4528b585ccb6748bdff4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58280737)</sub>

<!-- /greptile_comment -->