### PR TITLE
test: pin freeze policyNotes and committed-record blocks (#72)

### DIFF
--- a/factory/packet.test.ts
+++ b/factory/packet.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import { repoById } from "./allowlist.ts";
 import { assertDisjointCounts } from "./fixture-counts.ts";
 import { evidenceIsStale, needsRewitness, packetDivergences } from "./ledger-check.ts";
 import { DISCLOSURE } from "./neighbor.ts";
@@ -85,13 +86,15 @@ const CLEAN_CONTRIBUTING =
 /** A phrasing `main`'s scanner already matches — the display is under test here, not the matcher. */
 const BAN_AGENTS_MD = "AI-generated pull requests are not welcome in this repository.";
 
-function freezePacket(docs: { agentsMd?: string; contributing?: string }) {
+function freezePacket(docs: { agentsMd?: string; contributing?: string; repoId?: string }) {
+  const repoId = docs.repoId ?? "mcp-use/mcp-use";
   return buildPacket({
-    repoId: "mcp-use/mcp-use",
+    repoId,
     issueNumber: 999,
     issueTitle: "docs typo",
-    issueUrl: "https://github.com/mcp-use/mcp-use/issues/999",
-    ...docs,
+    issueUrl: `https://github.com/${repoId}/issues/999`,
+    agentsMd: docs.agentsMd,
+    contributing: docs.contributing,
   });
 }
 
@@ -342,4 +345,41 @@ test("a document that was fetched but came back empty is an absence, not a clean
   assert.equal(/no ban statement matched/i.test(bothEmpty), false, bothEmpty);
   const oneReal = renderFreezeEvidence(freezePacket({ agentsMd: "", contributing: CLEAN_CONTRIBUTING }));
   assert.match(oneReal, new RegExp(`no ban statement matched in ${CLEAN_CONTRIBUTING.length} chars`, "i"));
+});
+
+/**
+ * Issue #72. The freeze promises policyNotes and the committed record (docs/04-stations.md);
+ * neither was pinned. A welcome quote lives only in the record block — matchedPhrases is empty on ALLOW.
+ */
+test("the freeze prints the allowlist policyNotes the scanner also read", () => {
+  // freezePacket's default repo has empty notes, so that fixture skips the block.
+  const packet = freezePacket({ contributing: CLEAN_CONTRIBUTING, repoId: "ColeMurray/background-agents" });
+  assert.equal(packet.policy.code, "ALLOW");
+  const notes = repoById(packet.repoId)?.policyNotes;
+  assert.ok(notes, "this repo is the fixture because it has notes; without them the block is skipped");
+
+  const lines = renderFreezeEvidence(packet).split("\n");
+  const header = `  allowlist.yaml policyNotes — ${notes.length} chars, written by us, not the repo:`;
+  assert.ok(lines.includes(header), `policyNotes header missing:\n${lines.join("\n")}`);
+  assert.ok(lines.includes(`  | ${notes}`), `policyNotes quote missing:\n${lines.join("\n")}`);
+});
+
+test("a welcome record's quote is shown only in the committed-record block", () => {
+  const packet = freezePacket({ contributing: CLEAN_CONTRIBUTING, repoId: "github/awesome-copilot" });
+  assert.equal(packet.policy.code, "ALLOW");
+  assert.equal(packet.policy.matchedPhrases.length, 0, "ALLOW must not quote the record via matchedPhrases");
+  const record = packet.policy.record;
+  assert.equal(record?.stance, "welcome");
+  assert.ok(record, "awesome-copilot is the fixture because it carries a welcome record");
+  assert.equal(CLEAN_CONTRIBUTING.includes(record.quote), false);
+
+  const lines = renderFreezeEvidence(packet).split("\n");
+  const header = `  Committed policy record — ${record.source} (fetched ${record.fetchedAt}, stance ${record.stance}):`;
+  assert.ok(lines.includes(header), `committed-record header missing:\n${lines.join("\n")}`);
+  assert.ok(lines.includes(`  | ${record.quote}`), `committed-record quote missing:\n${lines.join("\n")}`);
+  assert.equal(
+    lines.filter((line) => line.includes(record.quote)).length,
+    1,
+    "the quote must not also appear in fetched docs or matched phrases",
+  );
 });


### PR DESCRIPTION
Closes #72

## What

Pin the two freeze-evidence render blocks that `docs/04-stations.md` promises: `allowlist.yaml policyNotes` and the committed policy record. Tests only; `factory/packet.ts` is unchanged.

## Why

Deleting either block shipped 327 tests green. `freezePacket`'s default repo has empty notes, so that fixture skipped the first block. A welcome record's quote appears only in the second because `matchedPhrases` is empty on ALLOW — deleting it silently removes the only place an operator sees the record's own words.

## How verified

- Baseline: `suite ok — 327 tests across 16 files`
- After tests: `suite ok — 329 tests across 16 files`
- Deletability before pins (full suite still green at 327):
  - delete the `allowlist.yaml policyNotes` block → 327 green
  - delete the `Committed policy record` block → 327 green
- Red-by-revert after pins (full suite):

  | Mutation | Failing test |
  | --- | --- |
  | delete `if (notes)` policyNotes push in `factory/packet.ts` | `the freeze prints the allowlist policyNotes the scanner also read` |
  | delete `if (record)` committed-record push in `factory/packet.ts` | `a welcome record's quote is shown only in the committed-record block` |

- Restore after each mutation → 329 green
- Greptile: 1 round, confidence 5/5, 0 comments

## Notes for review

- The welcome-record case has its own named test. On ALLOW, `matchedPhrases` is empty, so the quote is asserted as present exactly once — in the committed-record block.
- `freezePacket` now accepts `repoId` so the policyNotes fixture can use a repo that actually has notes (`ColeMurray/background-agents`); the welcome fixture uses `github/awesome-copilot`.
- Deliberate non-goals: no production change; silent/conditional records are not separately pinned (deleting the record block still reds the welcome test).
- Net LOC: +40 (44 insertions, 4 deletions).




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds regression coverage ensuring freeze evidence retains allowlist policy notes and committed policy records.
- Extends the packet fixture helper to select repositories with relevant policy metadata.
- Verifies policy-note headers and quotes are rendered.
- Verifies a welcome-record quote appears exactly once in the committed-record block.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| factory/packet.test.ts | Adds focused regression tests for the two promised freeze-evidence blocks without changing production behavior. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into ravidsrk/issue-..."](https://github.com/ravidsrk/oss-foundry/commit/8db6665fa745274a075c7e6ada42fc7eec235e04) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58281157)</sub>

<!-- /greptile_comment -->