### PR TITLE
docs: name the unknown precondition on deny-by-default (#73)

### DIFF
--- a/docs/04-stations.md
+++ b/docs/04-stations.md
@@ -50,7 +50,8 @@ not as the fix would have left it.
 
 Be exact about what catches a miss, because the two guards cover different cases and only one of
 them covers this one. **Deny-by-default covers the no-evidence case, not the missed-ban case.** A
-repo with nothing fetched and no affirmative record is `DENY_UNKNOWN_POLICY` and never `ALLOW` — but
+repo whose `aiPolicy` is `unknown`, with nothing fetched and no affirmative record, is
+`DENY_UNKNOWN_POLICY` and never `ALLOW` — but
 `hasParsedEvidence` is satisfied by *any* fetched document, so a `CONTRIBUTING` whose refusal the
 scanner cannot read is evidence the gate counts, and **a missed ban on a fetched document reaches
 `ALLOW`.** Verified, not assumed, and pinned in `factory/policy.test.ts` ("deny-by-default covers the

--- a/factory/state.test.ts
+++ b/factory/state.test.ts
@@ -7,6 +7,7 @@ import { buildPacket } from "./packet.ts";
 import { applyReviewToScorecard, emptyScorecard, health, mergeRate } from "./scorecard.ts";
 import { seedState } from "./seed.ts";
 import { loadFactoryState, saveFactoryState } from "./state.ts";
+import { evaluatePolicy } from "./policy.ts";
 
 test("missing state file loads seed and does not invent a file", () => {
   const path = join(tmp("foundry-"), "missing.json");
@@ -429,4 +430,14 @@ test("the review split and merge facts a sync records survive a round trip", () 
   const absentPath = join(tmp("foundry-"), "absent-prmeta.json");
   writeFileSync(absentPath, JSON.stringify({ ...loaded.state, packets: absent }));
   assert.equal(loadFactoryState(absentPath).ok, true, "optional must still mean optional");
+});
+
+/**
+ * docs/04-stations.md §2: deny-by-default fires only for `aiPolicy: unknown`.
+ * frontguard is owner + silent + unfetched and still ALLOW (issue #73).
+ */
+test("an owner repo with nothing fetched is ALLOW, not DENY_UNKNOWN_POLICY", () => {
+  const v = evaluatePolicy({ repoId: "ravidsrk/frontguard", issueTitle: "docs typo" });
+  assert.equal(v.record?.stance, "silent");
+  assert.equal(v.code, "ALLOW");
 });


### PR DESCRIPTION
Closes #73

## What

`docs/04-stations.md` said a repo with nothing fetched and no affirmative record is `DENY_UNKNOWN_POLICY` and never `ALLOW`. That guard is conditional: it fires only when `aiPolicy` is `unknown`. The sentence now names that precondition. A test pins the live counterexample so the page cannot drift back.

Headline claim is unchanged: deny-by-default covers the no-evidence case, not the missed-ban case.

## Why

The paragraph opens with "Be exact about what catches a miss." A supporting sentence that overstates which repos the guard covers is worth a clause even though it is not a safety hole today — the affected repos are operator-owned or human-classified at allowlist time.

Verified live against `evaluatePolicy` (nothing fetched):

| repo | aiPolicy | record | verdict |
|---|---|---|---|
| `ravidsrk/frontguard` | owner | silent (committed) | `ALLOW` |
| `ravidsrk/orca-fleet` | owner | silent (record removed) | `ALLOW` |
| `github/awesome-copilot` | welcome | silent (record removed) | `ALLOW` |
| `mcp-use/mcp-use` (control) | unknown | silent | `DENY_UNKNOWN_POLICY` |

The issue's claim is true. Passing `undefined` as the second argument is not "records removed" — the default parameter still loads `policyRecordFor(repoId)` — so orca-fleet / awesome-copilot were checked with an explicit silent record.

The pin lives in `factory/state.test.ts` because `factory/policy.test.ts` is off limits (parked PR #91) and `factory/engine.test.ts` is owned elsewhere.

## How verified

- Baseline: `suite ok — 334 tests across 16 files`; `factory/validate-allowlist.ts` ok.
- After change: `suite ok — 335 tests across 16 files`.
- Mutation (copy to `/tmp`, not `git checkout`): drop `repo.aiPolicy === "unknown" &&` so the guard becomes `if (!hasParsedEvidence)`. Named failure: `an owner repo with nothing fetched is ALLOW, not DENY_UNKNOWN_POLICY` (`DENY_UNKNOWN_POLICY` vs `ALLOW`). Restore from backup, suite green at 335.
- Greptile: round 1, confidence 5, zero comments.

## Notes for review

- Did not edit `factory/policy.ts` / `factory/policy.test.ts` / `factory/engine.ts` / `docs/SPEC.md`.
- Did not pin orca-fleet / awesome-copilot in the test — the acceptance asked for the owner-with-nothing-fetched case; frontguard is that live fixture. The throwaway script covered the other two.
- Net +12 LOC.




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Clarifies that the deny-by-default no-evidence guard applies when `aiPolicy` is `unknown`, and adds a regression test demonstrating that an owner-classified repository with no fetched evidence remains allowed.
- Qualifies the policy explanation in `docs/04-stations.md`.
- Adds the `ravidsrk/frontguard` counterexample to `factory/state.test.ts`.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/04-stations.md | Accurately adds the missing `aiPolicy: unknown` precondition to the deny-by-default explanation. |
| factory/state.test.ts | Adds a regression assertion for the documented owner-policy counterexample without changing production behavior. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into ravidsrk/issue-..."](https://github.com/ravidsrk/oss-foundry/commit/39cdf5cc28ad46fb9dfdb66c9536e3e3ebdc0e80) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58284049)</sub>

<!-- /greptile_comment -->