### PR TITLE
test(engine): pin the unsupplied attach-draft body refusal (#67)

### DIFF
--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -838,6 +838,35 @@ test("attach-draft refuses a PR body without the verbatim disclosure block", () 
   const ok = attach(`Fixes #${n}\n\n${DISCLOSURE}`);
   assert.equal(ok.error, undefined, ok.error);
   assert.equal(ok.state.packets[0].status, "submitted");
+
+  /**
+   * An UNSUPPLIED body refuses too, which is what `?? ""` buys and what nothing reached (issue #67).
+   * `body` is optional on the opts type, so rewriting the guard to
+   * `opts.body !== undefined && !opts.body.includes(DISCLOSURE)` — a natural "don't check what
+   * wasn't given" refactor — left the suite green: no test drove this gate without a body.
+   *
+   * `ledger-check.ts` makes the argument this pins: "forgetting a field is not a check". It made
+   * `body: string` REQUIRED and asserts an unsupplied one is reported, while the reducer carrying
+   * the same hazard had no such pin. Not exploitable today — both live call sites pass a body and
+   * both are independently pinned — so the hole is for the future third caller that file anticipates.
+   *
+   * The title has to carry the closing keyword: with no body, `mentionsIssue` reads
+   * `title + "\n"`, and without a match the reducer refuses at THAT gate instead and the disclosure
+   * check is never reached.
+   */
+  const unsupplied = applyAttachDraft(state, started.id, url, {
+    draft: true,
+    headSha: HEAD,
+    title: `Fixes #${n}`,
+  });
+  assert.ok(unsupplied.error, "an attach with no body at all must not bind to a packet");
+  assert.match(unsupplied.error!, /verbatim disclosure/, unsupplied.error!);
+  assert.equal(unsupplied.state.packets[0].status, "draft-ready");
+  assert.equal(
+    unsupplied.state.scorecard.find((r) => r.repoId === repoId)?.opened ?? 0,
+    openedBefore,
+    "a refused attach must not score an opened PR",
+  );
 });
 
 test("tick skips issues that already have a competing PR", () => {


### PR DESCRIPTION
Closes #67

## What

One case added to `attach-draft refuses a PR body without the verbatim disclosure block`: an attach
with **no body at all**. Test-only; `factory/engine.ts` is untouched.

## Why

`?? ""` in `if (!(opts.body ?? "").includes(DISCLOSURE))` is what makes an omitted body refuse, and
nothing reached that gate without one. Verified before writing the test: rewriting it to
`opts.body !== undefined && !opts.body.includes(DISCLOSURE)` — the natural "don't check what wasn't
given" refactor the issue names — left the suite at **334/334, exit 0**.

Not exploitable today: both live call sites pass a body and both are independently pinned. The hole
is for the future third caller that `factory/ledger-check.ts` explicitly anticipates when it argues
*"forgetting a field is not a check"*, makes `body: string` required, and asserts an unsupplied one
is reported. The reducer carried the same hazard with no such pin — that asymmetry is the issue.

## How verified

- **tests**: 334 across 16 files, `suite ok`; `npm run validate` exit 0. Baseline 334/16 (test-only
  addition to an existing test, so the count is unchanged).
- **mutation audit: 2 mutants, 2 killed:**

  | mutation | test that reds |
  |---|---|
  | `?? ""` → `opts.body !== undefined &&` (the issue's exact refactor) | `attach-draft refuses a PR body without the verbatim disclosure block` |
  | the disclosure guard removed entirely | same, plus `attach-draft refuses a browser-opened PR whose body carries no disclosure` |

- **greptile**: 1 round, confidence 5/5, 0 findings.

## Notes for review

**The title must carry the closing keyword, and that is load-bearing rather than incidental.** With
no body, `mentionsIssue` reads `title + "\n"`. Omit the keyword too and the reducer refuses at *that*
gate — the disclosure check is never reached, and the test would pass for the wrong reason while
proving nothing about `?? ""`. The new case supplies `title: \`Fixes #${n}\`` so the refusal is the
one under test, and it asserts the message matches `/verbatim disclosure/` rather than merely that
some error occurred.

**Added inside the existing test rather than as a new one.** Same concern (the SPEC §6 disclosure
MUST on the browser path), same fixture already built, so a separate test would have duplicated the
setup for one extra call. The scorecard assertion is repeated for the new case because a refused
attach must not score an opened PR, and that is a separate failure mode from the refusal itself.




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds regression coverage ensuring `attach-draft` rejects an omitted PR body at the verbatim-disclosure guard.
- Exercises `applyAttachDraft` without a `body` while providing a valid closing-keyword title.
- Verifies the refusal message, unchanged packet status, and unchanged opened-PR score.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| factory/engine.test.ts | Adds focused omitted-body coverage to the existing disclosure-refusal test without changing production behavior. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into ravidsrk/issue-..."](https://github.com/ravidsrk/oss-foundry/commit/0a63e1cbb28ca0be726e4c5343b83e4a64f6b6d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58284068)</sub>

<!-- /greptile_comment -->