### PR TITLE
test: pin revert-window deadline and leftover #39 minors (#76)

### DIFF
--- a/docs/12-ledger.md
+++ b/docs/12-ledger.md
@@ -206,10 +206,11 @@ scorecard read `0` forever, correct or not.
    literal `rel="next"` and always did, but the only fixture exercising it built
    `` `<next>; rel="next", <next>; rel="last"` `` — both rels pointing at the same URL, `next`
    first — and its page 2 carried no `Link` at all, so relaxing the match to `rel="[a-z]+"` left
-   the suite green. On the header GitHub actually serves for a middle page (`prev`, `next`, `last`,
-   `first`, four distinct URLs) a relaxed parser returns the **`prev`** cursor: pages 1↔2 ping-pong
-   to the cap, a false `truncated: true`, and pages ≥3 never read. A middle-page fixture now kills
-   that mutant.
+   the suite green. On the header GitHub actually serves for a middle page of the **pulls** endpoint
+   (`prev`, `next`, `last`, `first`, four distinct URLs) a relaxed parser returns the **`prev`**
+   cursor: pages 1↔2 ping-pong to the cap, a false `truncated: true`, and pages ≥3 never read. The
+   commits endpoint `listCommitsSince` reads serves `next`, `last`, `first`, `prev` — same four rels,
+   different order. The fixture uses the pulls order so the mutant still dies.
 
 **The evidence for all of the above is re-runnable, not asserted.**
 `node --experimental-strip-types scripts/mutation-audit.ts` applies one single-line mutation per row

--- a/factory/github-pr.test.ts
+++ b/factory/github-pr.test.ts
@@ -393,6 +393,14 @@ test("countHumanReview drops the bots from both review surfaces and keeps them a
     comments: [{ user: { login: "greptile-apps[bot]", type: "Bot" } }],
   });
   assert.deepEqual(botsOnly, { reviews: 0, comments: 0 });
+
+  // The two lists are filtered independently, so a bot review plus a human line-comment is
+  // {reviews: 0, comments: 1} on the live path — not unreachable (issue #76).
+  const commentOnBot = countHumanReview({
+    reviews: [{ user: { login: "greptile-apps[bot]", type: "Bot" } }],
+    comments: [{ user: { login: "ravidsrk", type: "User" } }],
+  });
+  assert.deepEqual(commentOnBot, { reviews: 0, comments: 1 });
 });
 
 test("syncGithubPr reads the human review split for a terminal PR, and says nothing when it cannot", async () => {

--- a/factory/ledger-check.test.ts
+++ b/factory/ledger-check.test.ts
@@ -591,3 +591,39 @@ test("the revert FATAL names the step that can actually green it — the seed ed
   assert.match(line, /reconcile/);
   assert.match(line, /revert pkt_ravidsrk_orca-fleet_42 --reason/);
 });
+
+test("a missing review observation is not advised while the outcome itself is a FATAL", () => {
+  // liveTerminal: while ledger and GitHub disagree about merged-vs-open, the FATAL is the sentence
+  // the operator should read. Widening `live.merged || live.state === "closed"` to true would emit
+  // the KPI advisory beside that FATAL — noise on a line that already stops the clock (issue #76).
+  const merged = seedState().packets.find((p) => p.id === "pkt_ravidsrk_orca-fleet_42")!;
+  const blind = { ...merged, prMeta: { ...merged.prMeta!, humanReview: undefined } };
+  const disagreeing = {
+    state: "open" as const,
+    merged: false,
+    draft: merged.prMeta!.draft,
+    headSha: merged.prMeta!.headSha,
+    body: VERBATIM_BODY,
+  };
+  const checks = packetChecks(blind, disagreeing);
+  assert.equal(checks.fatal.some((f) => /ledger says merged/.test(f)), true, checks.fatal.join("\n"));
+  assert.equal(
+    checks.advisory.some((a) => /no human-review observation/.test(a)),
+    false,
+    `the KPI advisory must not ride along with the outcome FATAL:\n${checks.advisory.join("\n")}`,
+  );
+
+  const agreeing = packetChecks(blind, {
+    state: "closed",
+    merged: true,
+    draft: merged.prMeta!.draft,
+    headSha: merged.prMeta!.headSha,
+    body: VERBATIM_BODY,
+    revert: { reverted: false, why: "none" },
+  });
+  assert.equal(
+    agreeing.advisory.some((a) => /no human-review observation/.test(a)),
+    true,
+    `the same hole must still surface once the outcome agrees:\n${agreeing.advisory.join("\n")}`,
+  );
+});

--- a/factory/scorecard.test.ts
+++ b/factory/scorecard.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  applyReviewToScorecard,
+  classifyRevert,
+  emptyScorecard,
+  REVERT_WINDOW_DAYS,
+  revertWindow,
+  scorecardRow,
+} from "./scorecard.ts";
+
+const MERGE = "36d0f23708adbdf911e4df050ed516821278a9fc";
+const MERGED_AT = "2026-08-27T07:04:52Z";
+
+test("the revert window is closed at the deadline instant", () => {
+  // "within 30 days of merge" includes the instant the window closes (issue #76). Day 1 and day 31
+  // cannot see `<=` flipped to `<`. Closed, not open: both halves share this predicate, and a
+  // rollback dated exactly 30 days after the merge is still within 30 days.
+  const deadline = new Date(Date.parse(MERGED_AT) + REVERT_WINDOW_DAYS * 86_400_000).toISOString();
+  const atDeadline = revertWindow(MERGED_AT, deadline);
+  assert.equal(atDeadline.known, true);
+  if (atDeadline.known) {
+    assert.equal(atDeadline.within, true, "a rollback at mergedAt+30d is inside the window");
+    assert.equal(atDeadline.deadline, deadline);
+    assert.equal(atDeadline.days, 30);
+  }
+
+  const hit = classifyRevert({
+    mergeCommitSha: MERGE,
+    mergedAt: MERGED_AT,
+    commits: [
+      {
+        sha: "ffff1110000000000000000000000000000000aa",
+        message: `This reverts commit ${MERGE}.`,
+        committedAt: deadline,
+      },
+    ],
+  });
+  assert.equal(hit.reverted, true, "classifyRevert must count a revert at the deadline instant");
+
+  const justAfter = new Date(Date.parse(deadline) + 1).toISOString();
+  const late = revertWindow(MERGED_AT, justAfter);
+  if (late.known) assert.equal(late.within, false, "one millisecond past the deadline is outside");
+});
+
+test("a comments-only split is review activity, not noReview", () => {
+  // countHumanReview filters bots per list, so a bot review plus a human line-comment is
+  // {reviews: 0, comments: >0} on the live path. The named engine.test.ts case never passes that
+  // split, so `&& observed.comments === 0` survived (issue #76).
+  const repo = "ravidsrk/orca-fleet";
+  const rows = applyReviewToScorecard(emptyScorecard(), repo, { reviews: 0, comments: 1 });
+  const row = scorecardRow(rows, repo)!;
+  assert.equal(row.noReview, 0, "a human review comment is not zero activity");
+  assert.equal(row.humanReviewedPrs, 1);
+  assert.equal(row.humanReviewComments, 1);
+});

--- a/factory/scorecard.test.ts
+++ b/factory/scorecard.test.ts
@@ -13,9 +13,9 @@ const MERGE = "36d0f23708adbdf911e4df050ed516821278a9fc";
 const MERGED_AT = "2026-08-27T07:04:52Z";
 
 test("the revert window is closed at the deadline instant", () => {
-  // "within 30 days of merge" includes the instant the window closes (issue #76). Day 1 and day 31
-  // cannot see `<=` flipped to `<`. Closed, not open: both halves share this predicate, and a
-  // rollback dated exactly 30 days after the merge is still within 30 days.
+  // "within 30 days of merge" includes the closing instant (issue #76). Closed, not open:
+  // applyRevert already records day 30. GitHub's commit `until` is exclusive ("before this date"),
+  // so the mechanical read never feeds this instant; the operator `--at` path can, and must agree.
   const deadline = new Date(Date.parse(MERGED_AT) + REVERT_WINDOW_DAYS * 86_400_000).toISOString();
   const atDeadline = revertWindow(MERGED_AT, deadline);
   assert.equal(atDeadline.known, true);

--- a/factory/scorecard.ts
+++ b/factory/scorecard.ts
@@ -176,7 +176,8 @@ export function revertWindow(
     // Both bounds, because both callers need both. `classifyRevert` filters pre-merge commits in
     // its own loop and so never asked this predicate for the lower one; the operator path reaches
     // here directly with `--at` and did. An impossible pre-merge rollback that passes increments
-    // `reverts`, and `health()` turns that into a permanent `stop`.
+    // `reverts`, and `health()` turns that into a permanent `stop`. Closed at the deadline too:
+    // "within 30 days" includes that instant (issue #76).
     within: atMs >= mergedMs && atMs <= deadlineMs,
     deadline: new Date(deadlineMs).toISOString(),
     days: Math.floor((atMs - mergedMs) / 86_400_000),

--- a/factory/scorecard.ts
+++ b/factory/scorecard.ts
@@ -176,8 +176,7 @@ export function revertWindow(
     // Both bounds, because both callers need both. `classifyRevert` filters pre-merge commits in
     // its own loop and so never asked this predicate for the lower one; the operator path reaches
     // here directly with `--at` and did. An impossible pre-merge rollback that passes increments
-    // `reverts`, and `health()` turns that into a permanent `stop`. Closed at the deadline too:
-    // "within 30 days" includes that instant (issue #76).
+    // `reverts`, and `health()` turns that into a permanent `stop`.
     within: atMs >= mergedMs && atMs <= deadlineMs,
     deadline: new Date(deadlineMs).toISOString(),
     days: Math.floor((atMs - mergedMs) / 86_400_000),


### PR DESCRIPTION
Closes #76

## What

Triage of the six residual minors from #39's round-3 review, with a pin or an explicit disposition for each. No latch. No change to the revert-window inequality — it was already closed at both ends.

## Why

#76 recorded six non-blocking survivors so they would not be lost. Several were already closed by #81/#83. The rest were unpinned tests and one wording error.

Dispositions:

1. **Revert window exact bound — pinned (closed interval).** Lower bound (merge instant) was already pinned (`factory/engine.test.ts` `atMerge`). Operator-path day 30 was already pinned (`day 30 is inside the window`). `classifyRevert` / `revertWindow` at the exact deadline ISO were not. Chose **closed** (`atMs <= deadlineMs`): "within 30 days of merge" includes that instant, and `applyRevert` already records day 30. GitHub's commit `until` is exclusive ("before this date"), so the mechanical read never feeds this instant; the operator `--at` path can, and must agree. Flipping `<=` to `<` was untested by day 1 / day 31.

2. **`at < mergedMs` shadowed at the exact-merge-instant — already-fixed, clause is not dead.** The exact-merge-instant of the merge commit is excluded by the self-revert `continue` (`sha === merge`), and `at < mergedMs` is false at equality anyway. The clause **is** reachable for a different SHA with `committedAt < mergedAt`. Already pinned by `a commit that names our merge but predates it is not a revert of it` (`factory/engine.test.ts`). After #81, `revertWindow` also excludes pre-merge; the loop clause only changes the why-string (silent skip vs "late"). No new test.

3. **Two unpinned invariants.**
   - `liveTerminal` — **pinned.** Widening `live.merged || live.state === "closed"` to `true` emitted the KPI advisory beside the outcome FATAL. Test: `a missing review observation is not advised while the outcome itself is a FATAL`.
   - `if (recovered.error)` in `factory/cli.ts` — **deliberately not pinned.** Diagnostic-only (`owed.push` of a writer refusal). Harm is a missing advisory line on a rejected/parked packet whose live PR is closed. Pinning it needs a full CLI reconcile fixture; not worth the LOC against the 400-net cap.

4. **Window-read / result-final latch — deliberately not done.** Same judgement as #39: a latch adds a seed field and a force-push-rewrite hazard. A revert first seen after day 30 (clock down) must still be seen. The read is already constant-width (`until = mergedAt + 30d`).

5. **Link `rel` wording — fixed.** Item 9 of `docs/12-ledger.md` claimed GitHub serves `prev, next, last, first` for the middle page `listCommitsSince` reads. That order is the **pulls** endpoint; the **commits** endpoint serves `next, last, first, prev`. Fixture left as the stricter pulls order (it is what kills the relaxed-`rel` mutant).

6. **`noReview` test name overclaims — pinned the conjunction, did not rename.** `factory/engine.test.ts` is off-limits (concurrent). The name is now true: `{reviews: 0, comments: >0}` is reachable on the live path (`countHumanReview` filters bots per list, so a bot review plus a human line-comment is comments-only) and `applyReviewToScorecard` must not treat it as silence.

## How verified

- Baseline before edits: `suite ok — 334 tests across 16 files`; `allowlist ok`.
- After: `suite ok — 337 tests across 17 files` (3 new tests).
- Red-by-revert (copy to `/tmp`, mutate, full suite, restore; never `git checkout` / `stash`):

  | mutation | failing test |
  |---|---|
  | `factory/scorecard.ts` `atMs <= deadlineMs` → `atMs < deadlineMs` | `the revert window is closed at the deadline instant` |
  | `factory/scorecard.ts` `reviews === 0 && comments === 0` → `reviews === 0` | `a comments-only split is review activity, not noReview` |
  | `factory/ledger-check.ts` `liveTerminal = live.merged \|\| live.state === "closed"` → `true` | `a missing review observation is not advised while the outcome itself is a FATAL` |
  | `factory/github-pr.ts` comments counted only when a human review exists | `countHumanReview drops the bots from both review surfaces and keeps them apart` |

- Greptile: round 1 confidence 4, 1 P1 (`until` exclusive vs closed predicate) — rebutted: inequality unchanged from `main` (`factory/scorecard.ts:180`); day 30 already recorded (`factory/engine.test.ts:4768-4773`); `until` at `factory/github-pr.ts:597-602` is GitHub's exclusive "before this date", pre-existing. Round 2: **0 comments, confidence 5**.

## Notes for review

- `factory/policy.ts`, `factory/engine.ts`, `docs/SPEC.md` and their tests were not touched.
- Net +101 LOC (105 insertions, 4 deletions).
- Do not merge from this PR; that is the maintainer's.




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds regression coverage for the closed revert-window deadline, comments-only human review activity, terminal review advisories, and independent bot filtering, while correcting the documented ordering of GitHub pagination relations.
- Adds an exact-deadline test for revert classification and window calculation.
- Pins comments-only review activity so it is not classified as `noReview`.
- Ensures missing-review advisories appear only when the live terminal outcome agrees with the ledger.
- Extends bot-filter coverage across independently counted review surfaces.
- Corrects endpoint-specific pagination wording in the ledger documentation.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| factory/scorecard.test.ts | Adds discovered, valid regression tests for the closed revert deadline and comments-only review scoring. |
| factory/ledger-check.test.ts | Pins suppression of a review-observation advisory while a conflicting live outcome already produces a fatal result. |
| factory/github-pr.test.ts | Extends review counting coverage to independently filter bot reviews and human line comments. |
| docs/12-ledger.md | Clarifies that pagination relation ordering differs between GitHub’s pulls and commits endpoints. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into ravidsrk/issue-..."](https://github.com/ravidsrk/oss-foundry/commit/596267a3d7895b2aaf8505b32b6a422b9dc7a985) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58284553)</sub>

<!-- /greptile_comment -->