### PR TITLE
test(engine): discover the disclosure quotations instead of listing them (#68)

### DIFF
--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { chmodSync, existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, readdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -47,7 +47,7 @@ import {
   verifyWitnessLogs,
   witnessEvidence,
 } from "./witness.ts";
-import { DISCLOSURE, FOUNDRY_REPO_URL } from "./neighbor.ts";
+import { DISCLOSURE, DISCLOSURE_TAIL, FOUNDRY_REPO_URL } from "./neighbor.ts";
 import { buildPacket, renderEvidencePage, renderPrBody } from "./packet.ts";
 import { evaluatePolicy } from "./policy.ts";
 import { runSandboxDry } from "./sandbox.ts";
@@ -783,17 +783,44 @@ const VERBATIM_BODY = `## Summary\n\nFixes the thing.\n\n## Disclosure\n\n${DISC
  * quietly become a third version nobody ships. Issue #38.
  */
 test("every in-repo quotation of the disclosure block is the constant, byte for byte", () => {
-  const quoting = ["../docs/02-good-neighbor.md", "../docs/PRODUCT.md"];
-  for (const rel of quoting) {
-    const doc = readFileSync(new URL(rel, import.meta.url), "utf8");
+  /**
+   * DISCOVERED, not listed. This was `["../docs/02-good-neighbor.md", "../docs/PRODUCT.md"]` with
+   * `assert.equal(quoting.length, 2)` pinning it at exactly two — and there were already THREE
+   * quotations: `docs/evidence/pkt_ravidsrk_orca-fleet_71.md` was covered only incidentally, by a
+   * separate regeneration test. A new doc carrying a stale block shipped green, which is the class
+   * #38(b) was about (issue #68). `run-tests.ts:8` states the convention: "Discovered, not listed.
+   * A hand-maintained roster is the same silent hole this runner exists to close from the other end."
+   *
+   * `DISCLOSURE_TAIL` is the detector, for exactly the reason `neighbor.ts` gives for its existence:
+   * it tells "carries a Foundry disclosure that is no longer the current block" from "carries no
+   * Foundry disclosure at all". Detecting by the full constant would be vacuous — a doc holding a
+   * STALE block does not contain it, so the miss would define itself out of the search.
+   */
+  const root = fileURLToPath(new URL("..", import.meta.url));
+  const walk = (dir: string): string[] =>
+    readdirSync(dir, { withFileTypes: true }).flatMap((e) =>
+      e.isDirectory() ? walk(join(dir, e.name)) : [join(dir, e.name)],
+    );
+  const candidates = [...walk(join(root, "docs")).filter((f) => f.endsWith(".md")), join(root, "README.md")];
+
+  const quoting: string[] = [];
+  for (const file of candidates) {
+    const doc = readFileSync(file, "utf8");
+    if (!doc.includes(DISCLOSURE_TAIL)) continue;
+    quoting.push(file.slice(root.length));
     assert.ok(
       doc.includes(DISCLOSURE),
-      `${rel} quotes a disclosure block that is not \`DISCLOSURE\` — a doc showing maintainers a version this factory does not send`,
+      `${file.slice(root.length)} quotes a disclosure block that is not \`DISCLOSURE\` — a doc showing maintainers a version this factory does not send`,
     );
   }
-  // ...and the list is not empty of its own accord: a rename that moved these files would leave
-  // the loop above iterating over nothing and passing.
-  assert.equal(quoting.length, 2, "both quoting docs must stay in the list");
+
+  // ...and the search is not vacuous: a rename, a moved directory, or a detector that stopped
+  // matching would leave the loop above iterating over nothing and passing. Three today, and the
+  // floor is what makes losing one cost a visible edit.
+  assert.ok(
+    quoting.length >= 3,
+    `only ${quoting.length} in-repo quotation(s) found (${quoting.join(", ")}) — the discovery has drifted`,
+  );
 });
 
 test("attach-draft refuses a PR body without the verbatim disclosure block", () => {

--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -47,7 +47,7 @@ import {
   verifyWitnessLogs,
   witnessEvidence,
 } from "./witness.ts";
-import { DISCLOSURE, DISCLOSURE_TAIL, FOUNDRY_REPO_URL } from "./neighbor.ts";
+import { DISCLOSURE, FOUNDRY_REPO_URL } from "./neighbor.ts";
 import { buildPacket, renderEvidencePage, renderPrBody } from "./packet.ts";
 import { evaluatePolicy } from "./policy.ts";
 import { runSandboxDry } from "./sandbox.ts";

--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -791,11 +791,29 @@ test("every in-repo quotation of the disclosure block is the constant, byte for 
    * #38(b) was about (issue #68). `run-tests.ts:8` states the convention: "Discovered, not listed.
    * A hand-maintained roster is the same silent hole this runner exists to close from the other end."
    *
-   * `DISCLOSURE_TAIL` is the detector, for exactly the reason `neighbor.ts` gives for its existence:
-   * it tells "carries a Foundry disclosure that is no longer the current block" from "carries no
-   * Foundry disclosure at all". Detecting by the full constant would be vacuous — a doc holding a
-   * STALE block does not contain it, so the miss would define itself out of the search.
+   * THE DETECTOR CANNOT BE DERIVED FROM `DISCLOSURE`, and that is the whole difficulty. Matching on
+   * the constant is vacuous — a doc holding a STALE block does not contain it, so the miss defines
+   * itself out of the search. The first attempt used `DISCLOSURE_TAIL`, which review caught: a stale
+   * block whose SECOND or THIRD line drifted is skipped by that too, and the three real quotations
+   * still satisfy the floor, so the suite stays green over it.
+   *
+   * So these are deliberate LITERALS, one per line of the block, and a doc matching ANY of them must
+   * carry the whole current constant. Drift in one line leaves the other two fingerprints matching.
+   * They are asserted against the live constant below, which is what stops them rotting into
+   * something that describes no version at all.
    */
+  const FINGERPRINTS = [
+    "prepared by Foundry",
+    "reviewed the packet, the diff, and the tests",
+    "The factory does not merge",
+  ];
+  for (const print of FINGERPRINTS) {
+    assert.ok(
+      DISCLOSURE.includes(print),
+      `the fingerprint ${JSON.stringify(print)} no longer appears in DISCLOSURE, so it can only find blocks this factory never sent`,
+    );
+  }
+
   const root = fileURLToPath(new URL("..", import.meta.url));
   const walk = (dir: string): string[] =>
     readdirSync(dir, { withFileTypes: true }).flatMap((e) =>
@@ -806,7 +824,7 @@ test("every in-repo quotation of the disclosure block is the constant, byte for 
   const quoting: string[] = [];
   for (const file of candidates) {
     const doc = readFileSync(file, "utf8");
-    if (!doc.includes(DISCLOSURE_TAIL)) continue;
+    if (!FINGERPRINTS.some((print) => doc.includes(print))) continue;
     quoting.push(file.slice(root.length));
     assert.ok(
       doc.includes(DISCLOSURE),


### PR DESCRIPTION
Closes #68

## What

The disclosure-quotation test now **discovers** quotations by walking `docs/` recursively plus
`README.md`, instead of iterating a two-element literal list. Test-only.

## Why

The roster was `["../docs/02-good-neighbor.md", "../docs/PRODUCT.md"]` with
`assert.equal(quoting.length, 2)` pinning it at exactly two — and there were already **three**
in-repo quotations. `docs/evidence/pkt_ravidsrk_orca-fleet_71.md` was covered only incidentally, by a
separate regeneration test.

Measured both ways rather than argued. With a new doc carrying the stale unqualified block:

| test | result |
|---|---|
| the old roster | `suite ok — 340 tests`, exit 0 |
| this one | reds, naming `docs/stale-example.md` |

That is the class #38(b) was about, and `factory/run-tests.ts:8` already states the convention:
*"Discovered, not listed. A hand-maintained roster is the same silent hole this runner exists to
close from the other end."*

## How verified

- **tests**: 340 across 17 files, `suite ok`; `npm run validate` exit 0. Count unchanged — this
  replaces a test rather than adding one.
- **a stale block is caught however it drifted**, verified per direction in three separate runs,
  because assertions stop at the first failure and an aggregate check would have proven only one:

  | stale variant | result |
  |---|---|
  | first line drifted (pre-ADR-0004 unqualified) | caught |
  | second line drifted | caught |
  | third line drifted | caught |

- **the discovery cannot pass vacuously**: forcing the detector to match nothing reds on the floor
  (`only 0 in-repo quotation(s) found`), and breaking one fingerprint reds with
  `the fingerprint "…" no longer appears in DISCLOSURE`.
- **greptile**: 2 rounds, confidence 5/5, 1 finding fixed, 0 rebutted.

## Notes for review

**The detector cannot be derived from `DISCLOSURE`, and that is the whole difficulty.** Matching on
the constant is vacuous: a doc holding a *stale* block does not contain it, so the miss defines
itself out of the search.

**My first attempt used `DISCLOSURE_TAIL` and review was right to reject it.** That only catches a
block whose *first* line drifted — one whose second or third line drifted is skipped before the
full-block assertion, and the three genuine quotations still satisfy the floor, so the suite stays
green over exactly the miss this issue is about. Recorded rather than quietly replaced, because the
reasoning ("the tail is stable across the ADR-0004 qualifier change") was plausible and wrong.

**So the fingerprints are deliberate literals, one per line**, and a doc matching *any* of them must
carry the whole current block — drift in one line leaves the other two matching. Each is asserted
against the live constant, which is what stops them rotting into strings that describe no version
this factory ever sent; that guard is itself verified by breaking a fingerprint.

**Measured for false positives before choosing them**: all three fingerprints hit exactly the three
real quotations and no prose. Docs discuss the disclosure often, so a looser marker such as
`"Foundry"` would have made this test fire on half of `docs/`.

**The floor is `>= 3`, not `== 3`.** An equality assertion is what pinned the old roster at two while
a third quotation existed. A floor makes losing one cost a visible edit without forbidding a fourth.




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The disclosure-quotation test now recursively discovers Markdown quotations under `docs/` and in `README.md`, validates fingerprint literals against the current disclosure, and enforces a non-vacuous discovery floor.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| factory/engine.test.ts | Replaces the fixed quotation roster with recursive discovery and removes the previously reported obsolete disclosure import. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(engine): drop the dead DISCLOSURE\_T..."](https://github.com/ravidsrk/oss-foundry/commit/7848a4c4851b679f59888f6831ad7e4ade768100) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58286227)</sub>

<!-- /greptile_comment -->