### PR TITLE
docs: the wake rule is conditional in all four places it is stated (#51)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -65,7 +65,9 @@ grants the operator any merge authority.
 - A submitted draft MUST be followed until merged, closed, or quiet: review threads answered,
   bots reconciled. Once threads are answered and the PR has been quiet ≥14 days, the in-flight
   slot MAY release while follow-up duties continue; new maintainer activity re-blocks new work
-  until answered. At ≥45 quiet days the operator SHOULD close politely; closing is a human act.
+  until answered — unless a newer packet already holds the in-flight slot, in which case the older
+  packet keeps its follow-up duty and records a reply owed rather than blocking the newer work. At
+  ≥45 quiet days the operator SHOULD close politely; closing is a human act.
 - Per-repo standing MUST be tracked from terminal outcomes (merge rate over terminal outcomes;
   silence alone never halts) and MUST halt a repository on: a maintainer ask (same hour), any
   revert of the operator's patch, or sustained sub-threshold merge rate with terminal outcomes.

--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -5296,3 +5296,50 @@ test("classifyCompetition treats a foreign owner's mention as no competitor at a
   );
   assert.equal(ours.kind, "adjacent");
 });
+
+/**
+ * The wake rule is stated in four places and #48 made it conditional in code while updating two of
+ * them. `factory/engine.ts`'s own `applyPrSync` docstring and `docs/SPEC.md` §7 kept asserting the
+ * old unconditional re-block — the engine one being the contract on the very function whose
+ * behaviour changed, and the first thing a reader of `applyPrSync` sees (issue #51).
+ *
+ * A drift check rather than a collapse to one source: the four statements serve different readers
+ * (a reducer's contract, a normative spec, a product narrative, a station walkthrough) and merging
+ * them would cost more than it saves. What must not happen is one of them saying the factory blocks
+ * when it does not.
+ *
+ * The exception is matched by CONCEPT, not by one phrasing, because the four say it differently on
+ * purpose — `repliesOwed`'s docstring says "the slot was held by a newer packet" and reads
+ * perfectly. Requiring a literal would force four documents into one voice to satisfy a test.
+ */
+test("every statement of the wake rule carries the held-slot exception", () => {
+  const root = fileURLToPath(new URL("..", import.meta.url));
+  const sources = [
+    "factory/engine.ts",
+    "docs/SPEC.md",
+    "docs/PRODUCT.md",
+    "docs/04-stations.md",
+  ];
+  /** The carve-off #48 introduced, in any of the voices the four documents legitimately use. */
+  const EXCEPTION = /newer packet|holds the in-flight slot|slot was held|already holds the slot/i;
+
+  let statements = 0;
+  for (const rel of sources) {
+    const text = readFileSync(join(root, rel), "utf8");
+    for (const match of text.matchAll(/re-block(?:s|ed|ing)?/gi)) {
+      statements += 1;
+      // A window around the claim, not the whole file: a file may state the rule once correctly and
+      // once not, and a file-wide search would let the correct one cover for the stale one.
+      const from = Math.max(0, match.index - 400);
+      const window = text.slice(from, match.index + 400);
+      assert.match(
+        window,
+        EXCEPTION,
+        `${rel} states the wake rule near offset ${match.index} without the held-slot exception, so it claims the factory blocks when it does not:\n${window.replace(/\s+/g, " ").slice(0, 300)}`,
+      );
+    }
+  }
+  // Not vacuous: a rename or a rewording that stopped saying "re-block" would leave this iterating
+  // over nothing. Four statements today across four files.
+  assert.ok(statements >= 4, `only ${statements} wake-rule statement(s) found — the discovery has drifted`);
+});

--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -5299,47 +5299,61 @@ test("classifyCompetition treats a foreign owner's mention as no competitor at a
 
 /**
  * The wake rule is stated in four places and #48 made it conditional in code while updating two of
- * them. `factory/engine.ts`'s own `applyPrSync` docstring and `docs/SPEC.md` §7 kept asserting the
- * old unconditional re-block — the engine one being the contract on the very function whose
- * behaviour changed, and the first thing a reader of `applyPrSync` sees (issue #51).
+ * them. `applyPrSync`'s own docstring and `docs/SPEC.md` §7 kept asserting the old unconditional
+ * re-block — the engine one being the contract on the very function whose behaviour changed, and the
+ * first thing a reader of `applyPrSync` sees (issue #51).
  *
- * A drift check rather than a collapse to one source: the four statements serve different readers
- * (a reducer's contract, a normative spec, a product narrative, a station walkthrough) and merging
- * them would cost more than it saves. What must not happen is one of them saying the factory blocks
- * when it does not.
+ * A drift check rather than a collapse to one source: the four serve different readers (a reducer
+ * contract, a normative spec, a product narrative, a station walkthrough) and merging them costs
+ * more than it saves. What must not happen is one of them saying the factory blocks when it does not.
  *
- * The exception is matched by CONCEPT, not by one phrasing, because the four say it differently on
- * purpose — `repliesOwed`'s docstring says "the slot was held by a newer packet" and reads
- * perfectly. Requiring a literal would force four documents into one voice to satisfy a test.
+ * THREE things this had to get right, each found by getting it wrong first:
+ *
+ * - PER FILE, not an aggregate count. `docs/04-stations.md` states the rule without the word
+ *   "re-block" at all, so a `re-block`-only trigger never discovered it while two matches in
+ *   `engine.ts` satisfied a count of four — one of the four unvalidated, which review caught.
+ * - PROSE ONLY for `.ts`. `applyPrSync` emits a runtime event, "Maintainer activity … — answer
+ *   threads before any new tick", on the arm where the slot is NOT held; no exception belongs there
+ *   and scanning code strings would demand one.
+ * - NORMALISED. Both the docstring and SPEC.md wrap "new maintainer / activity" across lines, so a
+ *   contiguous match finds neither until the comment markers and newlines are collapsed.
+ *
+ * The exception is matched by CONCEPT, because the four say it differently on purpose —
+ * `repliesOwed` says "the slot was held by a newer packet" and reads perfectly. Requiring a literal
+ * would force four documents into one voice to satisfy a test.
  */
 test("every statement of the wake rule carries the held-slot exception", () => {
   const root = fileURLToPath(new URL("..", import.meta.url));
-  const sources = [
-    "factory/engine.ts",
-    "docs/SPEC.md",
-    "docs/PRODUCT.md",
-    "docs/04-stations.md",
-  ];
-  /** The carve-off #48 introduced, in any of the voices the four documents legitimately use. */
+  const SOURCES = ["factory/engine.ts", "docs/SPEC.md", "docs/PRODUCT.md", "docs/04-stations.md"];
+  /** Either phrasing states the rule; `docs/04-stations.md` uses only the second. */
+  const STATES_RULE = /re-block(?:s|ed|ing)?|maintainer activity/gi;
   const EXCEPTION = /newer packet|holds the in-flight slot|slot was held|already holds the slot/i;
 
-  let statements = 0;
-  for (const rel of sources) {
-    const text = readFileSync(join(root, rel), "utf8");
-    for (const match of text.matchAll(/re-block(?:s|ed|ing)?/gi)) {
-      statements += 1;
-      // A window around the claim, not the whole file: a file may state the rule once correctly and
-      // once not, and a file-wide search would let the correct one cover for the stale one.
-      const from = Math.max(0, match.index - 400);
-      const window = text.slice(from, match.index + 400);
+  for (const rel of SOURCES) {
+    const raw = readFileSync(join(root, rel), "utf8");
+    const prose = rel.endsWith(".md")
+      ? raw
+      : raw
+          .split("\n")
+          .filter((line) => /^\s*(\*|\/\/|\/\*)/.test(line))
+          .map((line) => line.replace(/^\s*(\*\/?|\/\/|\/\*\*?)/, ""))
+          .join(" ");
+    const text = prose.replace(/\s+/g, " ");
+
+    const found = [...text.matchAll(STATES_RULE)];
+    assert.ok(
+      found.length > 0,
+      `${rel} no longer states the wake rule in any recognised phrasing — either it was reworded, in which case this guard needs the new one, or the statement was lost`,
+    );
+    for (const match of found) {
+      // A window, not the whole file: a file may state the rule twice and one copy must not cover
+      // for the other.
+      const window = text.slice(Math.max(0, match.index - 400), match.index + 400);
       assert.match(
         window,
         EXCEPTION,
-        `${rel} states the wake rule near offset ${match.index} without the held-slot exception, so it claims the factory blocks when it does not:\n${window.replace(/\s+/g, " ").slice(0, 300)}`,
+        `${rel} states the wake rule without the held-slot exception, so it claims the factory blocks when it does not:\n…${window.slice(300, 560)}…`,
       );
     }
   }
-  // Not vacuous: a rename or a rewording that stopped saying "re-block" would leave this iterating
-  // over nothing. Four statements today across four files.
-  assert.ok(statements >= 4, `only ${statements} wake-rule statement(s) found — the discovery has drifted`);
 });

--- a/factory/engine.ts
+++ b/factory/engine.ts
@@ -1066,8 +1066,10 @@ function recordTerminalReview(
  * Apply a live PR sync to a submitted/followed-up packet.
  * merged → terminal + scorecard `merged`. closed unmerged → followed-up + scorecard `closedUnmerged`.
  * open: answered threads + ≥QUIET_RELEASE_DAYS quiet releases the in-flight slot; new maintainer
- * activity on a followed-up packet re-blocks the factory until answered; ≥STALE_INTENT_DAYS quiet
- * records a stale-intent note — closing stays a human act.
+ * activity on a followed-up packet re-blocks the factory until answered — unless a newer packet
+ * already holds the in-flight slot, in which case the older packet stays `followed-up` and records
+ * a `reply-owed:` note rather than doubling the count; ≥STALE_INTENT_DAYS quiet records a
+ * stale-intent note — closing stays a human act.
  */
 export function applyPrSync(
   state: FactoryState,


### PR DESCRIPTION
Closes #51

## What

`applyPrSync`'s docstring and `docs/SPEC.md` §7 now carry the held-slot exception #48 introduced, and
a drift check makes all four statements of the wake rule defend themselves.

## Why

#48 made maintainer activity re-block the tick only when no newer packet holds the in-flight slot,
and updated two of the four places the rule is stated. `factory/engine.ts` and `docs/SPEC.md` kept
asserting the old unconditional rule.

The engine one is the sharper: it is the contract on the very function whose behaviour changed, the
first thing a reader of `applyPrSync` sees, and #48 edited that function heavily while leaving it.
That unit's own standard condemns it — `factory/cli.ts`, added by the same PR, says printing
"re-blocks the tick" where the packet stays `followed-up` *"is simply false"*.

On `docs/SPEC.md` the two review axes disagreed and both arguments are recorded on the issue:
standards graded it Required, because SPEC is the repo's normative description and now contradicted
two updated documents; spec-conformance graded it Optional, because the clause carries no RFC-2119
keyword and §8 scopes conformance to "every MUST above". It is amended either way — the disagreement
was about whether it blocks a merge, not about whether the sentence is wrong.

## How verified

- **tests**: 341 across 17 files, `suite ok`; `npm run validate` exit 0. Baseline 340/17.
- **all four statements die on their own**, one mutation at a time:

  | exception removed from | test that reds |
  |---|---|
  | `factory/engine.ts` (`applyPrSync` docstring) | `every statement of the wake rule carries the held-slot exception` |
  | `docs/SPEC.md` §7 | same |
  | `docs/PRODUCT.md` | same |
  | `docs/04-stations.md` | same |

- **the check cannot pass vacuously**: a file that stops stating the rule in any recognised phrasing
  reds on its own assertion, per file rather than on an aggregate count.
- **greptile**: 2 rounds, confidence 5/5, 1 finding fixed, 0 rebutted.

## Notes for review

**A drift check, not a collapse to one source** — the issue offers both. The four serve different
readers (a reducer contract, a normative spec, a product narrative, a station walkthrough) and merging
them costs more than it saves. What must not happen is one of them saying the factory blocks when it
does not.

**Review found the first version validated only three of the four, and that is worth reading.**
`docs/04-stations.md` states the rule without the word "re-block" at all — "moves it back to
`submitted` (answer before any new tick)". A `re-block`-only trigger never discovered it, while two
matches in `engine.ts` satisfied an aggregate count of four. So the check counted to four and left one
unvalidated: exactly the "the roster looks full" failure it exists to prevent. It is now **per file**.

**Two more things it had to get right, both found by getting them wrong:**

- **Prose only, for `.ts`.** `applyPrSync` emits a runtime event — *"Maintainer activity … — answer
  threads before any new tick"* — on the arm where the slot is **not** held. No exception belongs
  there, and scanning code strings demanded one.
- **Normalised.** Both the docstring and SPEC.md wrap `new maintainer / activity` across lines, so a
  contiguous match found neither until comment markers and newlines were collapsed. The first
  version silently matched fewer statements than it appeared to.

**The exception is matched by concept, not by a literal.** The four say it differently on purpose —
`repliesOwed`'s docstring says "the slot was held by a newer packet" and reads perfectly. Requiring
one phrasing would force four documents into a single voice to satisfy a test, which is a worse
outcome than the drift it prevents.




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR aligns the remaining wake-rule documentation with the held-slot exception introduced previously.
- Updates the normative specification and `applyPrSync` contract documentation.
- Adds a cross-document drift test covering the four places where the wake rule is stated.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/SPEC.md | Documents that older packets retain follow-up duties without displacing a newer packet holding the in-flight slot. |
| factory/engine.ts | Updates the `applyPrSync` contract documentation to match the reducer's conditional re-blocking behavior. |
| factory/engine.test.ts | Adds a source-level consistency check for the four documented wake-rule statements. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into ravidsrk/issue-..."](https://github.com/ravidsrk/oss-foundry/commit/a026cf6e7c7517aacc441870453a4a97762bd83d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58287309)</sub>

<!-- /greptile_comment -->