### PR TITLE
test(sandbox): scan KNOWN DEFECT comments one at a time (#99)

### DIFF
--- a/factory/sandbox.test.ts
+++ b/factory/sandbox.test.ts
@@ -121,6 +121,16 @@ test("the KNOWN DEFECT scan reads one comment at a time, not a 200-character win
     true,
     "a block comment must be caught too",
   );
+  // Consecutive `//` lines are ONE comment, so a note whose marker and pointer sit on different
+  // lines of the same run is still that comment tracking that issue. Without this, a regression
+  // that stopped joining runs would weaken the standing scan while every other case here passed.
+  const spread = "// KNOWN DEFECT: the refusal names the wrong verb.\n// Filed as issue #12.\n";
+  assert.equal(
+    commentsIn(spread).some(tracksAnIssue),
+    true,
+    "a marker and a pointer on consecutive // lines are one comment",
+  );
+  assert.equal(commentsIn(spread).length, 1, "the run must be joined into one comment, not two");
 
   // ...and the direction issue #99 is about: two SEPARATE comments, neither of which tracks
   // anything. The old window matched across the gap and reported a violation that was not one.

--- a/factory/sandbox.test.ts
+++ b/factory/sandbox.test.ts
@@ -55,6 +55,37 @@ test("negative-control refusal tells the operator to reject, not to press a verb
 });
 
 /**
+ * Every comment in a source, separately: each block comment, and each run of consecutive `//` lines.
+ *
+ * Separately is the whole point. The first version of the guard below matched
+ * `/KNOWN DEFECT[\s\S]{0,200}issue #\d+/` over the raw file, and `[\s\S]` crosses newlines, code and
+ * the boundary between two comments — so a `KNOWN DEFECT` note with an unrelated `issue #N` mention
+ * 200 characters downstream tripped it (issue #99).
+ */
+function commentsIn(source: string): string[] {
+  const out = [...source.matchAll(/\/\*[\s\S]*?\*\//g)].map((m) => m[0]);
+  let run: string[] = [];
+  for (const line of source.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("//")) {
+      run.push(trimmed);
+      continue;
+    }
+    if (run.length > 0) {
+      out.push(run.join("\n"));
+      run = [];
+    }
+  }
+  if (run.length > 0) out.push(run.join("\n"));
+  return out;
+}
+
+/** One comment that both flags a defect and points at an issue to track it. */
+function tracksAnIssue(comment: string): boolean {
+  return comment.includes("KNOWN DEFECT") && /issue #\d+/.test(comment);
+}
+
+/**
  * A tracking comment that names an issue reads as accounted for, and it outlives the issue: that is
  * exactly how this defect was orphaned when #44 closed with the item unfixed (issue #62).
  *
@@ -66,10 +97,51 @@ test("negative-control refusal tells the operator to reject, not to press a verb
 test("no KNOWN DEFECT comment in factory/ carries an issue pointer", () => {
   const factory = fileURLToPath(new URL(".", import.meta.url));
   const hits: string[] = [];
+  let scanned = 0;
   for (const name of readdirSync(factory)) {
     if (!name.endsWith(".ts") || name.endsWith(".test.ts")) continue;
-    const text = readFileSync(join(factory, name), "utf8");
-    if (/KNOWN DEFECT[\s\S]{0,200}issue #\d+/.test(text)) hits.push(name);
+    scanned += 1;
+    const found = commentsIn(readFileSync(join(factory, name), "utf8"));
+    if (found.some(tracksAnIssue)) hits.push(name);
   }
   assert.deepEqual(hits, []);
+  // Not vacuous: a rename or an extraction that stopped finding comments would pass over nothing.
+  assert.ok(scanned >= 10, `only ${scanned} production file(s) scanned; the discovery has drifted`);
+});
+
+test("the KNOWN DEFECT scan reads one comment at a time, not a 200-character window", () => {
+  // The direction the guard exists for.
+  assert.equal(
+    commentsIn("// KNOWN DEFECT: tracked in issue #12\nconst x = 1;\n").some(tracksAnIssue),
+    true,
+    "a comment that flags a defect and points at an issue must be caught",
+  );
+  assert.equal(
+    commentsIn("/**\n * KNOWN DEFECT, see issue #12.\n */\nconst x = 1;\n").some(tracksAnIssue),
+    true,
+    "a block comment must be caught too",
+  );
+
+  // ...and the direction issue #99 is about: two SEPARATE comments, neither of which tracks
+  // anything. The old window matched across the gap and reported a violation that was not one.
+  const separate = [
+    "// KNOWN DEFECT: the refusal below names the wrong verb.",
+    "const x = 1;",
+    "// Unrelated: this mirrors the shape issue #34 settled.",
+    "const y = 2;",
+  ].join("\n");
+  assert.equal(
+    commentsIn(separate).some(tracksAnIssue),
+    false,
+    "an issue mentioned in a DIFFERENT comment is not this comment tracking it",
+  );
+  // The premise of that case, so it cannot pass by finding no comments at all.
+  assert.equal(commentsIn(separate).length, 2, "the two comments must be extracted as two");
+
+  // A blank line ends a `//` run: two notes separated by one are two comments, not one.
+  assert.equal(
+    commentsIn("// KNOWN DEFECT: something.\n\n// Filed as issue #7.\n").some(tracksAnIssue),
+    false,
+    "a blank line separates two comments",
+  );
 });

--- a/factory/sandbox.test.ts
+++ b/factory/sandbox.test.ts
@@ -55,24 +55,40 @@ test("negative-control refusal tells the operator to reject, not to press a verb
 });
 
 /**
- * The `//` that starts a trailing comment, or -1. String contents are masked to the same width
- * first, so the `//` in a URL inside a string literal cannot fabricate a comment — inventing one is
- * how a scan starts reporting violations that are not there, which is the whole subject of #99.
+ * The `//` that starts a trailing comment, or -1. String contents are blanked first, so the `//` in
+ * a URL inside a string literal cannot fabricate a comment — inventing one is how a scan starts
+ * reporting violations that are not there, which is the whole subject of #99.
+ *
+ * The mask is a copy of the line with characters overwritten in place, never a string built up by
+ * concatenation. Width is then preserved by construction rather than by getting the arithmetic right
+ * at every branch, and the returned index is an index into the real line.
  */
 function trailingCommentAt(line: string): number {
-  let masked = "";
+  const masked = [...line];
   let quote = "";
-  for (const char of line) {
+  for (let at = 0; at < line.length; at += 1) {
+    const char = line[at];
     if (quote === "") {
       if (char === '"' || char === "'" || char === "`") quote = char;
-      masked += char;
       continue;
     }
-    // Inside a literal: keep the width, drop the content, and let the closing quote through.
-    masked += char === quote ? char : " ";
-    if (char === quote) quote = "";
+    // Inside a literal. A backslash escapes the next character, so an escaped quote does NOT close
+    // the literal. Miss this and the literal ends early, `const s = "a \\" // KNOWN DEFECT: issue
+    // #1";` yields a comment carrying both a marker and a pointer, and the guard reports a violation
+    // against correct source — the same false-positive class this whole change exists to remove.
+    if (char === "\\") {
+      masked[at] = " ";
+      if (at + 1 < line.length) masked[at + 1] = " ";
+      at += 1;
+      continue;
+    }
+    if (char === quote) {
+      quote = "";
+      continue;
+    }
+    masked[at] = " ";
   }
-  return masked.indexOf("//");
+  return masked.join("").indexOf("//");
 }
 
 /**
@@ -182,6 +198,24 @@ test("the KNOWN DEFECT scan reads one comment at a time, not a 200-character win
     ["// see issue #12"],
     "the real trailing comment is still found on a line that also contains a URL",
   );
+  // An escaped quote does not end the literal. Without this the literal ends early and the rest of
+  // the string reads as a comment carrying BOTH a marker and a pointer — a violation reported
+  // against correct source, which is the defect class this change exists to remove. Reproduced
+  // before the fix, so this is a regression test and not a hypothetical.
+  assert.deepEqual(
+    commentsIn(String.raw`const s = "a \" // KNOWN DEFECT: tracked in issue #12";` + "\n"),
+    [],
+    "an escaped quote does not end the literal, so nothing after it is a comment",
+  );
+  // The same line with a genuine trailing note still yields exactly that note, so the escape
+  // handling closes the hole without blinding the scan to the case it is for.
+  assert.deepEqual(
+    commentsIn(String.raw`const s = "a \" b";  // KNOWN DEFECT: tracked in issue #12` + "\n"),
+    ["// KNOWN DEFECT: tracked in issue #12"],
+    "a real note after a literal containing an escaped quote is still found",
+  );
+  // A trailing backslash cannot walk the mask off the end of the line.
+  assert.deepEqual(commentsIn('const s = "a \\\n'), [], "a literal ending in a backslash is safe");
 
   // ...and the direction issue #99 is about: two SEPARATE comments, neither of which tracks
   // anything. The old window matched across the gap and reported a violation that was not one.

--- a/factory/sandbox.test.ts
+++ b/factory/sandbox.test.ts
@@ -55,7 +55,29 @@ test("negative-control refusal tells the operator to reject, not to press a verb
 });
 
 /**
- * Every comment in a source, separately: each block comment, and each run of consecutive `//` lines.
+ * The `//` that starts a trailing comment, or -1. String contents are masked to the same width
+ * first, so the `//` in a URL inside a string literal cannot fabricate a comment — inventing one is
+ * how a scan starts reporting violations that are not there, which is the whole subject of #99.
+ */
+function trailingCommentAt(line: string): number {
+  let masked = "";
+  let quote = "";
+  for (const char of line) {
+    if (quote === "") {
+      if (char === '"' || char === "'" || char === "`") quote = char;
+      masked += char;
+      continue;
+    }
+    // Inside a literal: keep the width, drop the content, and let the closing quote through.
+    masked += char === quote ? char : " ";
+    if (char === quote) quote = "";
+  }
+  return masked.indexOf("//");
+}
+
+/**
+ * Every comment in a source, separately: each block comment, each run of consecutive `//` lines, and
+ * each trailing comment written after code.
  *
  * Separately is the whole point. The first version of the guard below matched
  * `/KNOWN DEFECT[\s\S]{0,200}issue #\d+/` over the raw file, and `[\s\S]` crosses newlines, code and
@@ -65,18 +87,22 @@ test("negative-control refusal tells the operator to reject, not to press a verb
 function commentsIn(source: string): string[] {
   const out = [...source.matchAll(/\/\*[\s\S]*?\*\//g)].map((m) => m[0]);
   let run: string[] = [];
+  const endRun = () => {
+    if (run.length > 0) out.push(run.join("\n"));
+    run = [];
+  };
   for (const line of source.split("\n")) {
     const trimmed = line.trim();
     if (trimmed.startsWith("//")) {
       run.push(trimmed);
       continue;
     }
-    if (run.length > 0) {
-      out.push(run.join("\n"));
-      run = [];
-    }
+    endRun();
+    // A note written after code is its own comment, not part of any run around it.
+    const at = trailingCommentAt(line);
+    if (at >= 0) out.push(line.slice(at));
   }
-  if (run.length > 0) out.push(run.join("\n"));
+  endRun();
   return out;
 }
 
@@ -131,6 +157,31 @@ test("the KNOWN DEFECT scan reads one comment at a time, not a 200-character win
     "a marker and a pointer on consecutive // lines are one comment",
   );
   assert.equal(commentsIn(spread).length, 1, "the run must be joined into one comment, not two");
+  // A note written after code, which the first version of the extractor skipped entirely — and
+  // production files here do use trailing `//` comments, so that was live coverage missing.
+  assert.equal(
+    commentsIn('const x = 1;  // KNOWN DEFECT: tracked in issue #12\n').some(tracksAnIssue),
+    true,
+    "a trailing comment after code must be scanned",
+  );
+  // A trailing note stands alone: it does not absorb the separate comment on the next line.
+  assert.equal(
+    commentsIn("const x = 1;  // KNOWN DEFECT: wrong verb.\n// Filed as issue #12.\n").some(tracksAnIssue),
+    false,
+    "a trailing comment is not joined to the comment below it",
+  );
+  // The reason string contents are masked: a URL in a literal must not become a comment. If it did,
+  // the code line would read as a comment and could carry a marker into a pointer that is not there.
+  assert.deepEqual(
+    commentsIn('const u = "https://example.invalid/a";\n'),
+    [],
+    "a // inside a string literal is not a comment",
+  );
+  assert.deepEqual(
+    commentsIn('const u = "https://example.invalid/a";  // see issue #12\n'),
+    ["// see issue #12"],
+    "the real trailing comment is still found on a line that also contains a URL",
+  );
 
   // ...and the direction issue #99 is about: two SEPARATE comments, neither of which tracks
   // anything. The old window matched across the gap and reported a violation that was not one.


### PR DESCRIPTION
Closes #99

## What

`KNOWN DEFECT` comments are now scanned one at a time — each block comment, and each run of
consecutive `//` lines — instead of by a 200-character window over the raw file.

## Why

The guard added in #97 matched `/KNOWN DEFECT[\s\S]{0,200}issue #\d+/` against whole file text.
`[\s\S]` crosses newlines, code, and the boundary between two comments, so a defect note with an
unrelated `issue #N` mention 200 characters downstream reported a violation that was not one. Proven
on the exact fixture now in the suite: the old regex matches it, the new scan does not.

A guard that reds on correct code is worse than no guard — it gets deleted rather than fixed.

## How verified

- tests: `the KNOWN DEFECT scan reads one comment at a time, not a 200-character window` — pins both
  directions, since the point is a distinction. One comment carrying both marker and pointer is
  caught (on one line, across a joined `//` run, and in a block comment); two separate comments are
  not, and neither are two `//` notes split by a blank line. Each negative case also asserts how many
  comments were extracted, so it cannot pass by finding none.
- The standing scan asserts it saw ≥ 10 production files, so an extraction that stopped finding
  comments cannot pass over nothing.
- mutation audit, 11 mutants, all killed: `commentsIn` reverted to a raw-file window; consecutive
  lines no longer joined; trailing comments not extracted; string masking made concatenation-based so
  width is lost; the closing quote no longer ending a literal; escape handling removed; an escape
  consuming only itself; each half of the predicate dropped in turn; block comments not extracted;
  production-file discovery matching nothing.
- suite: `node --experimental-strip-types factory/run-tests.ts` → 342 tests / 17 files, pass 342.
- greptile: 4 rounds, confidence 5/5, 3 findings fixed, 0 rebutted.

## Notes for review

The consecutive-line fixture came from round 1's P2, which was correct: both original positive cases
put the marker and pointer on one line, so a mutant that stopped joining `//` runs survived the whole
suite. Confirmed surviving before the fix, and it reds by name after.

Round 2's P2 came from the review bot and was also correct: trailing comments after code were skipped
entirely, and production files here do use them, so that was live coverage missing. Extending to them
required masking string literals first — otherwise the `//` in a URL fabricates a comment, which would
make a code line read as prose and reintroduce exactly the false-positive class this branch fixes.
Both halves are pinned.

Round 3's P1 was also from the bot, and it **falsified a claim I had written into this body**: I said
escapes could not produce a false comment here. They can, and it reproduced first try —
`const s = "a \" // KNOWN DEFECT: tracked in issue #12";` fabricated a comment carrying both a marker
and a pointer. Fixed and pinned in both directions. The lesson is recorded in the commit rather than
smoothed over: the fix for a false-positive class had reintroduced it.

Scope: the extractor is lexical rather than a tokeniser. It now handles both cases that can fabricate
a comment — a `//` inside a literal, and an escape inside one. It does not model regex literals; a
`//` there is an empty regex, not text that can carry a marker and a pointer. A real tokeniser would
be a dependency for one guard.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces the raw 200-character defect scan with comment-by-comment extraction to avoid matching markers and issue references across unrelated comments.
- Groups consecutive standalone `//` lines while keeping separated and trailing comments distinct.
- Masks quoted string contents and escaped characters before locating trailing comments.
- Adds regression coverage for block comments, trailing comments, string-contained URLs, escaped quotes, and comment boundaries.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| factory/sandbox.test.ts | Adds lexical comment extraction and focused regression tests; both previously reported defects are fixed at the current head. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(sandbox): an escaped quote does not ..."](https://github.com/ravidsrk/oss-foundry/commit/52122753c2e203fb2a0238b0d5dcb002e2b2c101) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58289811)</sub>

<!-- /greptile_comment -->