### PR TITLE
fix: close leftover open-issue holes (#88, #85, #92)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Keep pinned GitHub Action SHAs current (issue #85).
+# A pin nobody updates trades a small supply-chain risk for certain drift.
+# Dependabot opens a PR that bumps the SHA and preserves the `# vX.Y.Z` comment.
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 4

--- a/docs/04-stations.md
+++ b/docs/04-stations.md
@@ -43,23 +43,24 @@ merely *discuss* autonomous agents is not banning them.
 
 **The scanner is a high-recall suggester feeding a human gate, not a sufficient arbiter.** Its miss
 mode is real, and stated here rather than left to be inferred: a phrasing nobody has written a
-pattern for reads as silence. Nine paraphrases of real maintainer ban language were run through it
-and seven reached `ALLOW` (issue #37). The matcher work from that issue is **parked** — three review
-rounds failed on it and the unit hit its cap — so this page describes the scanner as it actually is,
-not as the fix would have left it.
+pattern for reads as silence. The nine paraphrases from issue #37 now classify as `DENY_FORBIDDEN`
+(`factory/policy.test.ts` — "the issue #37 probe paraphrases classify"), including present
+participles, brand-only subjects, allow-list framing, and the colloquial/imperative forms that
+used to reach `ALLOW`. A tenth phrasing nobody has written a pattern for will still read as
+silence. That is why this page still calls the scanner a suggester.
 
-Be exact about what catches a miss, because the two guards cover different cases and only one of
-them covers this one. **Deny-by-default covers the no-evidence case, not the missed-ban case.** A
-repo whose `aiPolicy` is `unknown`, with nothing fetched and no affirmative record, is
-`DENY_UNKNOWN_POLICY` and never `ALLOW` — but
-`hasParsedEvidence` is satisfied by *any* fetched document, so a `CONTRIBUTING` whose refusal the
-scanner cannot read is evidence the gate counts, and **a missed ban on a fetched document reaches
-`ALLOW`.** Verified, not assumed, and pinned in `factory/policy.test.ts` ("deny-by-default covers the
-no-evidence case, not the missed-ban case"): three ban phrasings the scanner does not match, supplied
-as fetched docs, each returned `ALLOW`; the same packet with nothing fetched, and the same packet
-with a fetch that came back empty, both returned `DENY_UNKNOWN_POLICY`. The freeze (§3) is the only
-thing standing there. That is precisely why it is now shown the parsed text — the operator reading
-the maintainer's own words is the guard against a scanner miss, and the gate's default is not.
+Be exact about what catches a remaining miss, because the two guards cover different cases and
+only one of them covers this one. **Deny-by-default covers the no-evidence case, not the
+missed-ban case.** A repo whose `aiPolicy` is `unknown`, with nothing fetched and no affirmative
+record, is `DENY_UNKNOWN_POLICY` and never `ALLOW` — but `hasParsedEvidence` is satisfied by *any*
+fetched document, so a `CONTRIBUTING` whose refusal the scanner cannot read is evidence the gate
+counts, and **a missed ban on a fetched document reaches `ALLOW`.** Verified, not assumed, and
+pinned in `factory/policy.test.ts` ("deny-by-default covers the no-evidence case, not the
+missed-ban case"): ordinary contributing prose, supplied as a fetched document, returned
+`ALLOW`; the same packet with nothing fetched, and the same packet with a fetch that came back
+empty, both returned `DENY_UNKNOWN_POLICY`. The freeze (§3) is the only thing standing there.
+That is precisely why it is now shown the parsed text — the operator reading the maintainer's own
+words is the guard against a scanner miss, and the gate's default is not.
 
 The over-block direction is a real cost too, not a free safety margin. `DENY_FORBIDDEN` is terminal
 and there is no in-tool operator override, so a false positive is not a one-look correction at the
@@ -67,8 +68,10 @@ freeze; it is an allowlisted repo the factory cannot work with until a human edi
 `factory/policy.ts`. Most of `allowlist.yaml` is agent and MCP infrastructure — `background-agents`,
 `awesome-copilot`, `e2b-cookbook`, `mcp-use`, `mastra`, `OpenHands`, `orca-fleet` — whose docs use
 `agent`, `bot` and the brand words as ordinary vocabulary rather than as the subject of a refusal.
-That is why broadening recall here is not the cheap change it looks like, and why it was parked
-rather than half-landed.
+The #37 patterns are therefore statement-shaped (a brand plus an object, an allow-list plus a
+contribution verb, "don't want AI slop") rather than topic-word matches, and the must-ALLOW
+fixtures — a framework README that merely discusses agents, ordinary contributing prose, a
+kernel-style DCO conditional — stay `ALLOW` / `HOLD_CLA`.
 
 Precedence: record `forbidden` → scanned
 ban statement → CLA/DCO (from scan or record conditions) → record conditions → unknown-without-

--- a/factory/ci.test.ts
+++ b/factory/ci.test.ts
@@ -240,8 +240,9 @@ test("the live-GitHub ledger check stays off the pull-request path", () => {
 test("every workflow action is pinned to an immutable commit", () => {
   const seen: string[] = [];
   for (const w of workflows()) {
-    for (const m of w.text.matchAll(/^\s*-?\s*uses:\s*(\S+)/gm)) {
+    for (const m of w.text.matchAll(/^\s*-?\s*uses:\s*(\S+)(.*)$/gm)) {
       const ref = m[1];
+      const comment = m[2];
       seen.push(`${w.name}: ${ref}`);
       const at = ref.lastIndexOf("@");
       assert.notEqual(at, -1, `${w.name} uses \`${ref}\` with no ref at all, so it floats on the default branch`);
@@ -250,9 +251,21 @@ test("every workflow action is pinned to an immutable commit", () => {
         /^[0-9a-f]{40}$/,
         `${w.name} uses \`${ref}\`, a mutable ref. Pin the 40-character commit SHA with a trailing \`# vX.Y.Z\` comment; the upstream owner can retarget a tag, and this runs before every check in the job.`,
       );
+      assert.match(
+        comment,
+        /#\s*v\d+\.\d+\.\d+/,
+        `${w.name} pins \`${ref}\` without a \`# vX.Y.Z\` comment, so Dependabot cannot name the release it is updating`,
+      );
     }
   }
   // The scan itself is not vacuous: a rename or an indentation change that made the pattern miss
   // every `uses:` line would otherwise pass this test by finding nothing to check.
   assert.ok(seen.length >= 4, `action discovery found only ${seen.length} \`uses:\` lines (${seen.join(", ")})`);
+});
+
+test("pinned action SHAs have a keep-current mechanism (issue #85)", () => {
+  const text = readFileSync(join(REPO_ROOT, ".github/dependabot.yml"), "utf8");
+  assert.match(text, /package-ecosystem:\s*github-actions/);
+  assert.match(text, /directory:\s*\//);
+  assert.match(text, /schedule:/);
 });

--- a/factory/cli.test.ts
+++ b/factory/cli.test.ts
@@ -1939,6 +1939,33 @@ test("sync counts a silently merged PR as noReview, and the ledger prints it", (
   );
 });
 
+test("#92: sync names the cap or the outage, not both", () => {
+  const seed = withOpenSubmittedWave1();
+  const inflight = seed.packets.find((p) => p.status === "submitted")!;
+
+  const capped = runCli(["sync", inflight.id, "--threads-answered", "--state", writeState(seed)], tmpdir(), {
+    preload: prFactsStub(
+      livePrs({
+        [inflight.prUrl!]: { state: "closed", merged: true, reviewsTruncated: true },
+      }),
+    ),
+  });
+  assert.equal(capped.code, 0, capped.out);
+  assert.match(capped.out, /PAGE CAP/, capped.out);
+  assert.equal(/FAILED/.test(capped.out), false, `a capped sync must not also name the outage:\n${capped.out}`);
+
+  const outage = runCli(["sync", inflight.id, "--threads-answered", "--state", writeState(seed)], tmpdir(), {
+    preload: prFactsStub(
+      livePrs({
+        [inflight.prUrl!]: { state: "closed", merged: true, reviewsUnreadable: true },
+      }),
+    ),
+  });
+  assert.equal(outage.code, 0, outage.out);
+  assert.match(outage.out, /FAILED/, outage.out);
+  assert.equal(/PAGE CAP/.test(outage.out), false, `an outage sync must not also name the cap:\n${outage.out}`);
+});
+
 /**
  * The seed with one merged packet's review observation stripped — the shape a packet is left in
  * when GitHub's review endpoints were down for the single tick that absorbed its merge.
@@ -2400,6 +2427,51 @@ test("reconcile and verify-ledger hand packetChecks the same fields", () => {
         call,
         new RegExp(`\\b${field}:`),
         `${rel} stopped handing packetChecks \`${field}\`, so that check silently reports it did not run`,
+      );
+    }
+  }
+});
+
+test("applyPrSync call sites supply reviewTruncated (issue #92)", () => {
+  // The same defect class as revertTruncated: an omitted optional field is `undefined` at
+  // runtime under strip-types, never a compile error. The field is required on the opts
+  // object; this guard reds a call site that drops it. Count only the applyPrSync argument
+  // blocks — `packetChecks` also takes `reviewTruncated: synced.reviewTruncated` and is
+  // not this writer.
+  function applyPrSyncOptBlocks(source: string): string[] {
+    const blocks: string[] = [];
+    let searchFrom = 0;
+    while (true) {
+      const at = source.indexOf("applyPrSync(", searchFrom);
+      if (at === -1) break;
+      const brace = source.indexOf("{", at);
+      if (brace === -1) break;
+      let depth = 0;
+      let end = brace;
+      for (let i = brace; i < source.length; i++) {
+        if (source[i] === "{") depth++;
+        else if (source[i] === "}") {
+          depth--;
+          if (depth === 0) {
+            end = i;
+            break;
+          }
+        }
+      }
+      blocks.push(source.slice(brace, end + 1));
+      searchFrom = end + 1;
+    }
+    return blocks;
+  }
+  for (const rel of ["./cli.ts"]) {
+    const source = readFileSync(new URL(rel, import.meta.url), "utf8");
+    const blocks = applyPrSyncOptBlocks(source);
+    assert.equal(blocks.length, 2, `${rel} applyPrSync call-site count drifted`);
+    for (const [i, block] of blocks.entries()) {
+      assert.match(
+        block,
+        /reviewTruncated:\s*synced\.reviewTruncated/,
+        `${rel} applyPrSync #${i + 1} dropped reviewTruncated — a dropped field silently names both reasons again`,
       );
     }
   }

--- a/factory/cli.test.ts
+++ b/factory/cli.test.ts
@@ -1939,6 +1939,55 @@ test("sync counts a silently merged PR as noReview, and the ledger prints it", (
   );
 });
 
+test("#92: sync prints only the advisory this run produced, not the ledger's history", () => {
+  // The ledger is persisted, so a packet that once had an unreadable review carries that event for
+  // as long as the cap keeps it. Scanning all of `state.events` reprinted it after a CLEAN read, and
+  // the operator reads "the read FAILED — run `reconcile`" as the result of the sync they just ran.
+  //
+  // Keyed by event id rather than position or count: `appendEvent` prepends and caps at 80, so a
+  // tail slice reads the wrong end and a length delta is zero exactly when the cap is working.
+  const seed = withOpenSubmittedWave1();
+  const inflight = seed.packets.find((p) => p.status === "submitted")!;
+  const stale: FactoryState = {
+    ...seed,
+    events: [
+      {
+        id: "evt_stale_0001",
+        at: "2026-08-01T00:00:00.000Z",
+        kind: "follow-up",
+        packetId: inflight.id,
+        message: `Human review not observed for ${inflight.prUrl} — noReview and reviewCommentsAvg NOT recorded for ${inflight.repoId}. The read FAILED — run \`reconcile\` once GitHub answers the review endpoints`,
+      },
+      ...seed.events,
+    ],
+  };
+
+  // This sync reads the reviews perfectly. Nothing about it failed.
+  const clean = runCli(["sync", inflight.id, "--threads-answered", "--state", writeState(stale)], tmpdir(), {
+    preload: prFactsStub(
+      livePrs({
+        [inflight.prUrl!]: {
+          state: "closed",
+          merged: true,
+          reviews: [{ login: "ColeMurray", type: "User" }],
+          reviewComments: [{ login: "ColeMurray", type: "User" }],
+        },
+      }),
+    ),
+  });
+  assert.equal(clean.code, 0, clean.out);
+  assert.equal(
+    /ADVISORY[^\n]*Human review not observed/.test(clean.out),
+    false,
+    `a clean sync reprinted a historical advisory:\n${clean.out}`,
+  );
+
+  // ...and the event is still in the ledger, because suppressing the PRINT must not mean losing the
+  // record. `status` and the ledger remain the place history is read.
+  const after = JSON.parse(readFileSync(writeState(stale), "utf8")) as FactoryState;
+  assert.ok(after.events.some((e) => e.id === "evt_stale_0001"), "the historical event must survive");
+});
+
 test("#92: sync names the cap or the outage, not both", () => {
   const seed = withOpenSubmittedWave1();
   const inflight = seed.packets.find((p) => p.status === "submitted")!;

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -1099,7 +1099,10 @@ async function main() {
       if (packet.status === "submitted" || packet.status === "followed-up") {
         // Mechanical absorption only: reconcile never attests threads answered, so it can
         // record merges/closes but never release the in-flight slot.
-        const applied = applyPrSync(next, packet.id, synced.meta, { threadsAnswered: false });
+        const applied = applyPrSync(next, packet.id, synced.meta, {
+          threadsAnswered: false,
+          reviewTruncated: synced.reviewTruncated,
+        });
         if (!applied.error) next = applied.state;
       }
       // The review-KPI recovery (issue #39 round 3), and the reason `syncGithubPr` keeps paying 2
@@ -1270,6 +1273,7 @@ async function main() {
     // Without it, quiet days accrue but the slot is never released.
     const result = applyPrSync(state, id, synced.meta, {
       threadsAnswered: rest.includes("--threads-answered"),
+      reviewTruncated: synced.reviewTruncated,
     });
     if (result.error) {
       console.error(result.error);
@@ -1280,6 +1284,13 @@ async function main() {
     console.log(
       `synced ${id} → ${after?.status}  quiet=${quietDaysOf(synced.meta, new Date().toISOString())}d  draft=${synced.meta.draft} state=${synced.meta.state} merged=${synced.meta.merged}`,
     );
+    // Issue #92: the reason the observation is missing is now on the opts object, so `sync`
+    // can say which. Print it — an event nobody reads is the same as no event.
+    for (const e of result.state.events) {
+      if (e.packetId === id && e.message.includes("Human review not observed")) {
+        console.error(`ADVISORY ${e.message}`);
+      }
+    }
     // Re-check competing work on a still-open submitted/followed-up packet (issue #111).
     if (after && synced.meta.state !== "closed" && !synced.meta.merged) {
       for (const line of competitionAdvisories(after, await readCompetition(after))) {

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -1271,6 +1271,14 @@ async function main() {
     }
     // --threads-answered is the operator's attestation that every review thread has a reply.
     // Without it, quiet days accrue but the slot is never released.
+    // Only THIS sync's events are the operator's business below. The ledger is persisted, so
+    // scanning all of it reprinted a month-old advisory after a clean read, and the operator reads
+    // "the read FAILED" as the current result. Reproduced before fixing.
+    //
+    // By ID, not by position or count: `appendEvent` PREPENDS and caps the ledger at 80, so a tail
+    // slice reads the wrong end and a length delta is 0 exactly when the cap is doing its job. Ids
+    // are unique enough to key on because #88 in this same PR made them so.
+    const eventIdsBefore = new Set(state.events.map((e) => e.id));
     const result = applyPrSync(state, id, synced.meta, {
       threadsAnswered: rest.includes("--threads-answered"),
       reviewTruncated: synced.reviewTruncated,
@@ -1285,8 +1293,10 @@ async function main() {
       `synced ${id} → ${after?.status}  quiet=${quietDaysOf(synced.meta, new Date().toISOString())}d  draft=${synced.meta.draft} state=${synced.meta.state} merged=${synced.meta.merged}`,
     );
     // Issue #92: the reason the observation is missing is now on the opts object, so `sync`
-    // can say which. Print it — an event nobody reads is the same as no event.
+    // can say which. Print it — an event nobody reads is the same as no event. Only the events THIS
+    // call appended: see `eventsBefore`.
     for (const e of result.state.events) {
+      if (eventIdsBefore.has(e.id)) continue;
       if (e.packetId === id && e.message.includes("Human review not observed")) {
         console.error(`ADVISORY ${e.message}`);
       }

--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -1379,7 +1379,7 @@ test("answered threads plus 14 quiet days release the in-flight slot", () => {
   assert.ok(submitted);
   const at = "2026-09-20T00:00:00.000Z";
   const result = applyPrSync(state, submitted!.id, prMetaAt("2026-09-01T00:00:00.000Z"), {
-    threadsAnswered: true,
+    reviewTruncated: false, threadsAnswered: true,
     at,
   });
   assert.equal(result.error, undefined);
@@ -1394,12 +1394,12 @@ test("13 quiet days do not release the slot; unanswered threads never do", () =>
   const submitted = state.packets.find((p) => p.status === "submitted");
   const at = "2026-09-14T00:00:00.000Z";
   const early = applyPrSync(state, submitted!.id, prMetaAt("2026-09-01T00:00:00.000Z"), {
-    threadsAnswered: true,
+    reviewTruncated: false, threadsAnswered: true,
     at,
   });
   assert.equal(early.state.packets.find((p) => p.id === submitted!.id)?.status, "submitted");
   const unanswered = applyPrSync(state, submitted!.id, prMetaAt("2026-08-01T00:00:00.000Z"), {
-    threadsAnswered: false,
+    reviewTruncated: false, threadsAnswered: false,
     at: "2026-09-20T00:00:00.000Z",
   });
   assert.equal(unanswered.state.packets.find((p) => p.id === submitted!.id)?.status, "submitted");
@@ -1409,11 +1409,11 @@ test("maintainer activity on a followed-up packet re-blocks the factory", () => 
   const state = withOpenSubmittedWave1();
   const submitted = state.packets.find((p) => p.status === "submitted");
   const released = applyPrSync(state, submitted!.id, prMetaAt("2026-09-01T00:00:00.000Z"), {
-    threadsAnswered: true,
+    reviewTruncated: false, threadsAnswered: true,
     at: "2026-09-20T00:00:00.000Z",
   });
   const woken = applyPrSync(released.state, submitted!.id, prMetaAt("2026-09-21T08:00:00.000Z", { issueComments: 2 }), {
-    threadsAnswered: false,
+    reviewTruncated: false, threadsAnswered: false,
     at: "2026-09-21T09:00:00.000Z",
   });
   const after = woken.state.packets.find((p) => p.id === submitted!.id);
@@ -1427,7 +1427,7 @@ test("wake does not reclaim submitted when another packet already holds the in-f
   const state = withOpenSubmittedWave1();
   const a = state.packets.find((p) => p.status === "submitted")!;
   const released = applyPrSync(state, a.id, prMetaAt("2026-09-01T00:00:00.000Z"), {
-    threadsAnswered: true,
+    reviewTruncated: false, threadsAnswered: true,
     at: "2026-09-20T00:00:00.000Z",
   });
   assert.equal(released.state.packets.find((p) => p.id === a.id)?.status, "followed-up");
@@ -1447,7 +1447,7 @@ test("wake does not reclaim submitted when another packet already holds the in-f
   assert.equal(inflightCount(withB.packets), 1);
 
   const woken = applyPrSync(withB, a.id, prMetaAt("2026-09-21T08:00:00.000Z", { issueComments: 2 }), {
-    threadsAnswered: false,
+    reviewTruncated: false, threadsAnswered: false,
     at: "2026-09-21T09:00:00.000Z",
   });
   assert.equal(woken.error, undefined);
@@ -1480,7 +1480,7 @@ test("merged and closed syncs write the scorecard and end follow-up", () => {
   const state = withOpenSubmittedWave1();
   const submitted = state.packets.find((p) => p.status === "submitted");
   const merged = applyPrSync(state, submitted!.id, prMetaAt("2026-09-01T00:00:00.000Z", { merged: true, state: "closed" }), {
-    threadsAnswered: true,
+    reviewTruncated: false, threadsAnswered: true,
     at: "2026-09-02T00:00:00.000Z",
   });
   const mergedPacket = merged.state.packets.find((p) => p.id === submitted!.id);
@@ -1489,7 +1489,7 @@ test("merged and closed syncs write the scorecard and end follow-up", () => {
   assert.equal(mergedRow?.merged, 1);
 
   const closed = applyPrSync(state, submitted!.id, prMetaAt("2026-09-01T00:00:00.000Z", { state: "closed" }), {
-    threadsAnswered: true,
+    reviewTruncated: false, threadsAnswered: true,
     at: "2026-09-02T00:00:00.000Z",
   });
   const closedPacket = closed.state.packets.find((p) => p.id === submitted!.id);
@@ -1502,7 +1502,7 @@ test("45 quiet days record a stale-intent note but never auto-close", () => {
   const state = withOpenSubmittedWave1();
   const submitted = state.packets.find((p) => p.status === "submitted");
   const result = applyPrSync(state, submitted!.id, prMetaAt("2026-08-28T00:00:00.000Z"), {
-    threadsAnswered: true,
+    reviewTruncated: false, threadsAnswered: true,
     at: "2026-10-20T00:00:00.000Z",
   });
   const after = result.state.packets.find((p) => p.id === submitted!.id);
@@ -1518,19 +1518,19 @@ test("re-syncing a closed PR writes closedUnmerged exactly once; merged bumps me
   const state = withOpenSubmittedWave1();
   const submitted = state.packets.find((p) => p.status === "submitted");
   const closedMeta = prMetaAt("2026-09-01T00:00:00.000Z", { state: "closed" });
-  const once = applyPrSync(state, submitted!.id, closedMeta, { threadsAnswered: true, at: "2026-09-02T00:00:00.000Z" });
-  const twice = applyPrSync(once.state, submitted!.id, closedMeta, { threadsAnswered: true, at: "2026-09-03T00:00:00.000Z" });
-  const thrice = applyPrSync(twice.state, submitted!.id, closedMeta, { threadsAnswered: true, at: "2026-09-04T00:00:00.000Z" });
+  const once = applyPrSync(state, submitted!.id, closedMeta, { reviewTruncated: false, threadsAnswered: true, at: "2026-09-02T00:00:00.000Z" });
+  const twice = applyPrSync(once.state, submitted!.id, closedMeta, { reviewTruncated: false, threadsAnswered: true, at: "2026-09-03T00:00:00.000Z" });
+  const thrice = applyPrSync(twice.state, submitted!.id, closedMeta, { reviewTruncated: false, threadsAnswered: true, at: "2026-09-04T00:00:00.000Z" });
   const row = thrice.state.scorecard.find((r) => r.repoId === submitted!.repoId);
   assert.equal(row?.closedUnmerged, 1);
 
   const merged = applyPrSync(state, submitted!.id, prMetaAt("2026-09-01T00:00:00.000Z", { merged: true, state: "closed" }), {
-    threadsAnswered: true,
+    reviewTruncated: false, threadsAnswered: true,
     at: "2026-09-02T00:00:00.000Z",
   });
   assert.equal(merged.state.mergedTotal, state.mergedTotal + 1);
   const again = applyPrSync(merged.state, submitted!.id, prMetaAt("2026-09-05T00:00:00.000Z", { merged: true, state: "closed" }), {
-    threadsAnswered: true,
+    reviewTruncated: false, threadsAnswered: true,
     at: "2026-09-06T00:00:00.000Z",
   });
   assert.match(again.error ?? "", /cannot sync/);
@@ -1540,13 +1540,13 @@ test("quiet-day thresholds hold at their exact boundaries", () => {
   const state = withOpenSubmittedWave1();
   const submitted = state.packets.find((p) => p.status === "submitted");
   const at14 = applyPrSync(state, submitted!.id, prMetaAt("2026-09-01T00:00:00.000Z"), {
-    threadsAnswered: true,
+    reviewTruncated: false, threadsAnswered: true,
     at: "2026-09-15T00:00:00.000Z",
   });
   assert.equal(at14.state.packets.find((p) => p.id === submitted!.id)?.status, "followed-up");
 
   const at45 = applyPrSync(state, submitted!.id, prMetaAt("2026-09-01T00:00:00.000Z"), {
-    threadsAnswered: true,
+    reviewTruncated: false, threadsAnswered: true,
     at: "2026-10-16T00:00:00.000Z",
   });
   const after45 = at45.state.packets.find((p) => p.id === submitted!.id);
@@ -1691,7 +1691,7 @@ test("an absorbed close is at rest: reconcile-style re-diff reports no divergenc
     humanReview: { reviews: 1, comments: 2 },
   });
   const absorbed = applyPrSync(state, submitted.id, closedMeta, {
-    threadsAnswered: false,
+    reviewTruncated: false, threadsAnswered: false,
     at: "2026-09-02T00:00:00.000Z",
   });
   const after = absorbed.state.packets.find((p) => p.id === submitted.id)!;
@@ -1713,7 +1713,7 @@ test("an absorbed close is at rest: reconcile-style re-diff reports no divergenc
   // nothing GitHub says), and it must not be silent either.
   const blindMeta = prMetaAt("2026-09-01T00:00:00.000Z", { state: "closed" });
   const blind = applyPrSync(state, submitted.id, blindMeta, {
-    threadsAnswered: false,
+    reviewTruncated: false, threadsAnswered: false,
     at: "2026-09-02T00:00:00.000Z",
   });
   const unobserved = blind.state.packets.find((p) => p.id === submitted.id)!;
@@ -1852,7 +1852,7 @@ test("the reject warning is scoped to submitted, not to every packet that names 
   const seed = withOpenSubmittedWave1();
   const submitted = seed.packets.find((p) => p.status === "submitted")!;
   const released = applyPrSync(seed, submitted.id, prMetaAt("2026-09-01T00:00:00.000Z"), {
-    threadsAnswered: true,
+    reviewTruncated: false, threadsAnswered: true,
     at: "2026-09-20T00:00:00.000Z",
   });
   const followedUp = released.state.packets.find((p) => p.id === submitted.id)!;
@@ -1891,7 +1891,7 @@ test("status does not claim a re-block that the held slot already prevented", ()
   const seed = withOpenSubmittedWave1();
   const a = seed.packets.find((p) => p.status === "submitted")!;
   const released = applyPrSync(seed, a.id, prMetaAt("2026-09-01T00:00:00.000Z"), {
-    threadsAnswered: true,
+    reviewTruncated: false, threadsAnswered: true,
     at: "2026-09-20T00:00:00.000Z",
   });
 
@@ -1912,7 +1912,7 @@ test("status does not claim a re-block that the held slot already prevented", ()
     packets: [{ ...b, status: "gated", station: "freeze" }, ...released.state.packets],
   };
   const woken = applyPrSync(withB, a.id, prMetaAt("2026-09-21T08:00:00.000Z", { issueComments: 2 }), {
-    threadsAnswered: false,
+    reviewTruncated: false, threadsAnswered: false,
     at: "2026-09-21T09:00:00.000Z",
   });
   assert.equal(woken.state.packets.find((p) => p.id === a.id)?.status, "followed-up");
@@ -4517,7 +4517,7 @@ test("applyPrSync writes noReview on the merge transition and names the packet i
       state: "closed",
       humanReview: { reviews: 0, comments: 0 },
     }),
-    { threadsAnswered: true, at: "2026-09-02T00:00:00.000Z" },
+    { reviewTruncated: false, threadsAnswered: true, at: "2026-09-02T00:00:00.000Z" },
   );
   assert.equal(merged.error, undefined);
   const row = scorecardRow(merged.state.scorecard, submitted.repoId)!;
@@ -4539,7 +4539,7 @@ test("applyPrSync folds review comments into the mean on the closedUnmerged tran
       state: "closed",
       humanReview: { reviews: 2, comments: 3 },
     }),
-    { threadsAnswered: true, at: "2026-09-02T00:00:00.000Z" },
+    { reviewTruncated: false, threadsAnswered: true, at: "2026-09-02T00:00:00.000Z" },
   );
   assert.equal(closed.error, undefined);
   const row = scorecardRow(closed.state.scorecard, submitted.repoId)!;
@@ -4559,7 +4559,7 @@ test("applyPrSync folds review comments into the mean on the closedUnmerged tran
     closed.state,
     submitted.id,
     prMetaAt("2026-09-03T00:00:00.000Z", { state: "closed", humanReview: { reviews: 2, comments: 3 } }),
-    { threadsAnswered: true, at: "2026-09-04T00:00:00.000Z" },
+    { reviewTruncated: false, threadsAnswered: true, at: "2026-09-04T00:00:00.000Z" },
   );
   const twice = scorecardRow(again.state.scorecard, submitted.repoId)!;
   assert.equal(twice.humanReviewedPrs, 1, "a second sync of the same close is not a second PR");
@@ -4573,7 +4573,7 @@ test("a terminal transition with no observed review split records nothing and sa
     state,
     submitted.id,
     prMetaAt("2026-09-01T00:00:00.000Z", { merged: true, state: "closed" }),
-    { threadsAnswered: true, at: "2026-09-02T00:00:00.000Z" },
+    { reviewTruncated: false, threadsAnswered: true, at: "2026-09-02T00:00:00.000Z" },
   );
   const row = scorecardRow(merged.state.scorecard, submitted.repoId)!;
   assert.equal(row.noReview, 0, "an unread endpoint must not be recorded as silence");
@@ -4600,16 +4600,16 @@ test("a terminal transition with no observed review split records nothing and sa
     false,
     `\`sync\` refuses a terminal packet, so naming it is advice that cannot be followed:\n${gap}`,
   );
-  // ...and the OTHER reason: this reducer cannot tell an outage from a page cap (issue #69), and a
-  // line offering only the retry was misleading for half the cases it fires on.
-  assert.match(gap, /PAGE CAP/, `the advice must cover a capped read as well as an outage:\n${gap}`);
-  assert.match(gap, /cap again/, gap);
+  // Issue #92: the outage path names the outage, not the cap. Passing `reviewTruncated: false`
+  // is the unread-endpoint case this test built.
+  assert.match(gap, /FAILED/, `the outage line must name the outage:\n${gap}`);
+  assert.equal(/PAGE CAP/.test(gap), false, `an outage must not also name the cap:\n${gap}`);
   // Not a claim about the wording — a claim about the verb. `sync` really does refuse this packet.
   const refused = applyPrSync(
     merged.state,
     submitted.id,
     prMetaAt("2026-09-03T00:00:00.000Z", { merged: true, state: "closed" }),
-    { threadsAnswered: true, at: "2026-09-04T00:00:00.000Z" },
+    { reviewTruncated: false, threadsAnswered: true, at: "2026-09-04T00:00:00.000Z" },
   );
   assert.match(
     refused.error ?? "",
@@ -4621,6 +4621,22 @@ test("a terminal transition with no observed review split records nothing and sa
   assert.equal(recovered.error, undefined, recovered.error);
   assert.equal(recovered.recorded, true, "the named remedy must actually move the KPI");
   assert.equal(scorecardRow(recovered.state.scorecard, submitted.repoId)!.humanReviewedPrs, 1);
+});
+
+test("#92: a capped review read names the cap, not the outage", () => {
+  const state = withOpenSubmittedWave1();
+  const submitted = state.packets.find((p) => p.status === "submitted")!;
+  const merged = applyPrSync(
+    state,
+    submitted.id,
+    prMetaAt("2026-09-01T00:00:00.000Z", { merged: true, state: "closed" }),
+    { reviewTruncated: true, threadsAnswered: true, at: "2026-09-02T00:00:00.000Z" },
+  );
+  const gap = merged.state.events.map((e) => e.message).find((m) => m.includes("Human review not observed"))!;
+  assert.match(gap, /PAGE CAP/, gap);
+  assert.match(gap, /cap again/, gap);
+  assert.equal(/FAILED/.test(gap), false, `a capped read must not also name the outage:\n${gap}`);
+  assert.equal(/run `reconcile`/.test(gap), false, `reconcile will cap again, so it is not the remedy:\n${gap}`);
 });
 
 test("the review-KPI writer and reporter share one predicate, so they cannot disagree", () => {
@@ -5150,7 +5166,7 @@ test("a bare approval is review activity that moves neither counter, and says so
       state: "closed",
       humanReview: { reviews: 1, comments: 0 },
     }),
-    { threadsAnswered: true, at: "2026-09-02T00:00:00.000Z" },
+    { reviewTruncated: false, threadsAnswered: true, at: "2026-09-02T00:00:00.000Z" },
   );
   assert.equal(approved.error, undefined);
   const row = scorecardRow(approved.state.scorecard, submitted.repoId)!;
@@ -5536,7 +5552,7 @@ test("#110: applyPrSync close then packetChecks has no re-witness or disclosure 
       merged: false,
       humanReview: { reviews: 0, comments: 0 },
     },
-    { threadsAnswered: false, at: "2026-08-30T02:25:22.000Z" },
+    { reviewTruncated: false, threadsAnswered: false, at: "2026-08-30T02:25:22.000Z" },
   );
   assert.equal(closed.error, undefined);
   const after = closed.state.packets.find((p) => p.id === submitted.id)!;

--- a/factory/engine.ts
+++ b/factory/engine.ts
@@ -1043,16 +1043,20 @@ function recordTerminalReview(
   meta: PrMeta,
   events: FactoryEvent[],
   id: string,
+  reviewTruncated: boolean,
 ): ScorecardRow[] {
   const observed = meta.humanReview;
   if (!observed) {
-    // NAMES BOTH REASONS: this reducer cannot tell an outage from a page cap (issue #69), and the
-    // advice differs — re-running recovers one and caps again on the other. `packetChecks` does know
-    // and says which; this line must stay true WITHOUT the fact, so it carries both.
+    // ONE reason (issue #92). The fact used to be dropped at `applyPrSync`, so this line named
+    // both an outage and a page cap and the operator had to guess. `reviewTruncated` is required
+    // on the opts object so a call site cannot omit it the way an optional field silently becomes
+    // `undefined` under `--experimental-strip-types`.
     events.push(
       ev(
         "follow-up",
-        `Human review not observed for ${meta.url} — noReview and reviewCommentsAvg NOT recorded for ${packet.repoId}. If the read FAILED, run \`reconcile\` once GitHub answers the review endpoints (NOT \`sync\`, which refuses a terminal packet: "cannot sync PR from status ..."). If it stopped at its PAGE CAP, a re-run will cap again — read the PR by hand or raise the cap deliberately`,
+        reviewTruncated
+          ? `Human review not observed for ${meta.url} — noReview and reviewCommentsAvg NOT recorded for ${packet.repoId}. The read stopped at its PAGE CAP; a re-run will cap again — read the PR by hand or raise the cap deliberately`
+          : `Human review not observed for ${meta.url} — noReview and reviewCommentsAvg NOT recorded for ${packet.repoId}. The read FAILED — run \`reconcile\` once GitHub answers the review endpoints (NOT \`sync\`, which refuses a terminal packet: "cannot sync PR from status ...")`,
         id,
       ),
     );
@@ -1099,7 +1103,7 @@ export function applyPrSync(
   state: FactoryState,
   id: string,
   meta: PrMeta,
-  opts: { threadsAnswered: boolean; at?: string },
+  opts: { threadsAnswered: boolean; reviewTruncated: boolean; at?: string },
 ): { state: FactoryState; error?: string } {
   const packet = state.packets.find((p) => p.id === id);
   if (!packet) return { state, error: `unknown packet ${id}` };
@@ -1116,7 +1120,7 @@ export function applyPrSync(
     // Reachable only from submitted/followed-up; the merged status blocks re-entry, so this fires once.
     next = bump(next, { status: "merged", station: "terminal" });
     scorecard = applyPacketToScorecard(scorecard, packet, "merged");
-    scorecard = recordTerminalReview(scorecard, packet, meta, events, id);
+    scorecard = recordTerminalReview(scorecard, packet, meta, events, id, opts.reviewTruncated);
     mergedNow = true;
     events.push(ev("follow-up", `Merged by maintainers — ${meta.url}`, id));
   } else if (meta.state === "closed") {
@@ -1126,7 +1130,7 @@ export function applyPrSync(
     const firstClose = packet.prMeta?.state !== "closed";
     if (firstClose) {
       scorecard = applyPacketToScorecard(scorecard, packet, "closed");
-      scorecard = recordTerminalReview(scorecard, packet, meta, events, id);
+      scorecard = recordTerminalReview(scorecard, packet, meta, events, id, opts.reviewTruncated);
       events.push(ev("follow-up", `Closed unmerged — scorecard closedUnmerged written for ${packet.repoId}`, id));
     }
   } else {

--- a/factory/engine.ts
+++ b/factory/engine.ts
@@ -2,6 +2,7 @@ import { ALLOWLIST, CAPS, isDenied, repoById, sameRepoId } from "./allowlist.ts"
 import { parsePrUrl, type IssueLiveState } from "./github-pr.ts";
 import type { LiveIssue } from "./github-scout.ts";
 import { factoryHalt } from "./halt.ts";
+import { mintLedgerId } from "./ids.ts";
 import { AGENT_NAME_RE, commitTrailerLine, DISCLOSURE, type DisclosureTrailer } from "./neighbor.ts";
 import { buildPacket, renderPrBody } from "./packet.ts";
 import { planSandbox, runSandboxDry } from "./sandbox.ts";
@@ -934,7 +935,7 @@ function now() {
 
 function ev(kind: FactoryEvent["kind"], message: string, packetId?: string): FactoryEvent {
   return {
-    id: `evt_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`,
+    id: mintLedgerId("evt"),
     at: now(),
     kind,
     packetId,
@@ -1015,7 +1016,7 @@ export function repliesOwed(packet: TaskPacket): FollowUpEntry[] {
 
 function followUpEntry(at: string, kind: FollowUpEntry["kind"], body: string, url?: string): FollowUpEntry {
   return {
-    id: `fu_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`,
+    id: mintLedgerId("fu"),
     at,
     kind,
     body,

--- a/factory/halt.test.ts
+++ b/factory/halt.test.ts
@@ -5,6 +5,7 @@ import { test } from "node:test";
 import { tmp } from "./tmp-dir.ts";
 import { maySelectRepo } from "./engine.ts";
 import { applySecondaryLimitHalt, clearFactoryHalt, factoryHalt } from "./halt.ts";
+import { mintLedgerId } from "./ids.ts";
 import { seedState } from "./seed.ts";
 import { loadFactoryState, saveFactoryState } from "./state.ts";
 
@@ -81,6 +82,28 @@ test("a malformed halt record is refused at load, not read defensively", () => {
   if (!loaded.ok) return;
   assert.ok(factoryHalt(loaded.state));
   assert.equal(maySelectRepo(loaded.state, "ravidsrk/orca-fleet").ok, false);
+});
+
+test("#88: two halt events in the same millisecond do not share an id", () => {
+  const realNow = Date.now;
+  Date.now = () => 1_787_981_801_727;
+  try {
+    const first = applySecondaryLimitHalt(seedState(), {
+      repoId: "ColeMurray/background-agents",
+      at: "2026-08-29T09:00:00.000Z",
+    });
+    const second = applySecondaryLimitHalt(first, {
+      repoId: "ravidsrk/orca-fleet",
+      at: "2026-08-29T09:00:00.001Z",
+    });
+    const haltIds = [first.events[0].id, second.events[0].id];
+    assert.notEqual(haltIds[0], haltIds[1], `same-millisecond halt ids collided: ${haltIds.join(", ")}`);
+    assert.match(haltIds[0], /^evt_halt_/);
+    assert.match(haltIds[1], /^evt_halt_/);
+    assert.notEqual(haltIds[0], mintLedgerId("evt_halt", 1_787_981_801_727, 0));
+  } finally {
+    Date.now = realNow;
+  }
 });
 
 test("only a human clears the halt, and the ledger records who", () => {

--- a/factory/halt.ts
+++ b/factory/halt.ts
@@ -1,3 +1,4 @@
+import { mintLedgerId } from "./ids.ts";
 import type { FactoryEvent, FactoryHalt, FactoryState } from "./types.ts";
 
 /**
@@ -16,7 +17,7 @@ export const SECONDARY_LIMIT_BANNER = "=== FACTORY HALT SIGNAL — secondary rat
 
 function ev(message: string): FactoryEvent {
   return {
-    id: `evt_halt_${Date.now().toString(36)}`,
+    id: mintLedgerId("evt_halt"),
     at: new Date().toISOString(),
     kind: "score",
     message,

--- a/factory/ids.test.ts
+++ b/factory/ids.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { mintLedgerId } from "./ids.ts";
+
+test("two ids minted in the same millisecond differ", () => {
+  const frozen = 1_787_981_801_727;
+  const a = mintLedgerId("evt_halt", frozen, 0.1111111111);
+  const b = mintLedgerId("evt_halt", frozen, 0.2222222222);
+  assert.notEqual(a, b);
+  assert.match(a, /^evt_halt_1787981801727_/);
+  assert.match(b, /^evt_halt_1787981801727_/);
+
+  const many = Array.from({ length: 32 }, (_, i) => mintLedgerId("evt", frozen, (i + 1) / 64));
+  assert.equal(new Set(many).size, many.length, `collision under a frozen clock: ${many.join(", ")}`);
+});
+
+test("the three prefix conventions live on the helper", () => {
+  assert.match(mintLedgerId("evt", 1, 0.5), /^evt_1_/);
+  assert.match(mintLedgerId("fu", 1, 0.5), /^fu_1_/);
+  assert.match(mintLedgerId("evt_halt", 1, 0.5), /^evt_halt_1_/);
+});
+
+/**
+ * Issue #88: uniqueness from `Date.now()` alone is the defect. The helper is the door; a new
+ * template literal that interpolates `Date.now()` into an `id:` is a fourth site.
+ */
+test("no factory id derives uniqueness from Date.now() alone", () => {
+  const dir = fileURLToPath(new URL(".", import.meta.url));
+  const offenders: string[] = [];
+  for (const name of readdirSync(dir)) {
+    if (!name.endsWith(".ts") || name.endsWith(".test.ts")) continue;
+    const text = readFileSync(join(dir, name), "utf8");
+    // An id template that interpolates Date.now() and does not also interpolate Math.random /
+    // mintLedgerId. The helper file itself is the one place the clock is allowed in an id.
+    for (const m of text.matchAll(/id:\s*`([^`]+)`/g)) {
+      const tpl = m[1];
+      if (!tpl.includes("${Date.now()") && !tpl.includes("${Date.now()")) continue;
+      if (name === "ids.ts") continue;
+      offenders.push(`${name}: ${tpl}`);
+    }
+    // Direct Date.now().toString in an id — the halt.ts spelling.
+    if (name !== "ids.ts" && /id:\s*`[^`]*\$\{Date\.now\(\)/.test(text)) {
+      offenders.push(`${name}: interpolates Date.now() into an id`);
+    }
+  }
+  assert.deepEqual(offenders, [], `clock-only ids:\n${offenders.join("\n")}`);
+});

--- a/factory/ids.ts
+++ b/factory/ids.ts
@@ -1,0 +1,25 @@
+/**
+ * Ledger event / follow-up ids (issue #88).
+ *
+ * THREE call sites used to mint these, and two of them already knew the collision class:
+ * `engine.ts` appended `Math.random()`, `halt.ts` did not. Two halt events in the same
+ * millisecond shared an id. The helper is the only door, so a fourth site cannot be written
+ * clock-only.
+ *
+ * `${kind}_${ms}_${entropy}` — the clock names when, the entropy makes two-in-one-ms differ.
+ * Kind is the prefix convention (`evt`, `fu`, `evt_halt`) so it has one home rather than three.
+ */
+export type LedgerIdKind = "evt" | "fu" | "evt_halt";
+
+export function mintLedgerId(
+  kind: LedgerIdKind,
+  nowMs: number = Date.now(),
+  entropy: number = Math.random(),
+): string {
+  // Map `[0, 1)` onto a 5-digit base-36 token. `Number.toString(36).slice(2, 7)` collapses
+  // nearby fractions (and empty-slices `0`) back to clock-only, which is the defect.
+  const span = 36 ** 5;
+  const unit = ((entropy % 1) + 1) % 1;
+  const token = Math.floor(unit * span).toString(36).padStart(5, "0");
+  return `${kind}_${nowMs}_${token}`;
+}

--- a/factory/packet.test.ts
+++ b/factory/packet.test.ts
@@ -78,9 +78,9 @@ test("the evidence page and the divergence list agree about a terminal packet", 
  * only way to catch a scanner miss was to go and read the repo out of band, which is exactly the
  * diligence this tool claims to systematize.
  *
- * Scope note: this landed without the matcher work from the same issue, which is parked. Nothing
- * here asserts what the scanner catches; the ban fixture below is one `main` already matches,
- * chosen so these tests move if the *display* breaks and stay still if recall changes.
+ * Scope note: the matcher half of the same issue lives in `policy.test.ts`. Nothing here asserts
+ * what the scanner catches; the ban fixture below is one the scanner already matches, chosen so
+ * these tests move if the *display* breaks and stay still if recall changes.
  */
 const CLEAN_CONTRIBUTING =
   "Thanks for contributing! Run `pnpm test` before opening a pull request, keep the changeset entry short, and open an issue first for anything large.";

--- a/factory/packet.test.ts
+++ b/factory/packet.test.ts
@@ -160,8 +160,8 @@ test("the freeze prints the words the scanner read, not a boolean", () => {
  * #37 legs 2–3 exist because "the human freeze is blind — fetched docs are discarded". #70 fixed
  * that by printing the parsed text, and then capped the print at 4,000 characters — so for the one
  * case the whole mechanism is for, the human was still blind. The scanner reads the WHOLE document;
- * the freeze showed a prefix. And #37's scanner leg is parked, so "the scanner misses a realistic
- * ban" is a live condition on this tree, not a hypothesis.
+ * the freeze showed a prefix. A remaining scanner miss (a phrasing nobody has written a pattern
+ * for) is still a live condition, even after the #37 probe table classifies.
  *
  * The specific sentence that made it dangerous is the closing one. After 4,000 characters of quoted
  * text the surface said `no ban statement matched in 5234 chars from CONTRIBUTING` — a claim of

--- a/factory/packet.ts
+++ b/factory/packet.ts
@@ -143,9 +143,10 @@ function withheldChars(docs: PolicyDocSource[]): number {
  * CONTRIBUTING" — a claim of coverage over the 1,234 characters the reader had not been given,
  * phrased as reassurance, immediately above the attest. Those two numbers are the fixture in
  * `packet.test.ts` ("the freeze never claims a clean scan over characters it did not show"), so the
- * example is re-derivable rather than illustrative. Combined with the scanner's known-and-parked
- * miss mode (#37) that is an operator approving a contribution to a repository that said in words
- * not to.
+ * example is re-derivable rather than illustrative. Combined with a remaining scanner miss
+ * (a phrasing nobody has written a pattern for — issue #37 closed the nine probe shapes, not
+ * every possible one) that is an operator approving a contribution to a repository that said
+ * in words not to.
  *
  * The fix is loudness, not more text, and the reason is that the excerpt limit is a LEDGER bound:
  * `policyDocs` is stored state, the full document is never kept, and re-fetching at freeze time

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -495,6 +495,9 @@ const SECOND_PERSON_INVITATIONS: string[] = [
   "if you are a bot, leave detailed feedback in the issue",
   "if you are an agent, leave a brief note explaining the change",
   "if you are an agent, leave us a short message first",
+  // The indirect-object reading: a place named, and a comment still asked for.
+  "if you are an agent, leave the repo a comment",
+  "if you are a bot, leave the project a short note",
 ];
 
 const SECOND_PERSON_BANS: string[] = [
@@ -508,6 +511,9 @@ const SECOND_PERSON_BANS: string[] = [
   "if you are an agent, leave immediately",
   "if you are an llm, leave.",
   "if you are a bot, leave us alone",
+  // ...and the row that keeps the exclusion above honest: a place followed by more BAN, not a
+  // comment. If the exclusion were widened to any continuation, this would stop denying.
+  "if you are an agent, leave the repository and never come back",
 ];
 
 test("a second-person invitation to comment is not a ban, and a second-person ban still is", () => {

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -401,32 +401,23 @@ test("the committed policy records parse under the quote guard", () => {
  * Issue #37, leg 4 — the assertion behind a sentence in docs/04-stations.md §2, not a claim about
  * recall.
  *
- * The page used to leave a reader to infer that deny-by-default covers a scanner miss. It does
- * not, and the two guards must not be conflated: `hasParsedEvidence` is satisfied by ANY fetched
- * document, so a `CONTRIBUTING` whose refusal the scanner cannot read is evidence the gate counts,
- * and the packet reaches `ALLOW`. Only the no-evidence case denies.
+ * Deny-by-default covers the no-evidence case. It does not cover a scanner miss: `hasParsedEvidence`
+ * is satisfied by ANY fetched document, so ordinary contributing prose (not a ban) is evidence the
+ * gate counts and the packet reaches `ALLOW`. Only the no-evidence case denies. The freeze is what
+ * stands between a remaining miss and a PR.
  *
- * This is a CHARACTERIZATION test of the gate as it stands, deliberately asserting `ALLOW` on
- * phrasings the scanner misses. It is not a recall assertion and must not be read as endorsing the
- * miss: the matcher work from the same issue is parked, and the freeze display (`renderFreezeEvidence`)
- * is what stands between these strings and a PR. If the matchers are later broadened so that these
- * DENY, this test is the thing that should be rewritten alongside the sentence it pins — that is
- * what it is for.
+ * The original probe paraphrases that used to pin this as `ALLOW` now DENY — that is the matcher
+ * half of #37, asserted by `the issue #37 probe paraphrases classify`. This test keeps the
+ * structural claim and must not be rewritten back into a recall assertion.
  */
 test("deny-by-default covers the no-evidence case, not the missed-ban case", () => {
-  // Paraphrases from the issue's own probe table that this tree's scanner does not match.
-  const missed = [
-    "we are not currently accepting AI-generated contributions",
-    "only human contributors may open pull requests",
-    "we don't want AI slop here",
-  ];
-  for (const text of missed) {
-    assert.equal(
-      evaluatePolicy({ repoId: "mcp-use/mcp-use", issueTitle: "docs typo", contributing: text }).code,
-      "ALLOW",
-      `a ban the scanner cannot read reaches ALLOW: ${text}`,
-    );
-  }
+  // A fetched document the scanner reads as silence is still evidence. That is the miss-shaped
+  // hole deny-by-default does not cover — the freeze is what stands there.
+  assert.equal(
+    evaluatePolicy({ repoId: "mcp-use/mcp-use", issueTitle: "docs typo", contributing: PYDANTIC_WELCOME }).code,
+    "ALLOW",
+    "a fetched document that is not a ban satisfies hasParsedEvidence and reaches ALLOW",
+  );
   // The same packet with nothing fetched is the case deny-by-default actually covers...
   assert.equal(
     evaluatePolicy({ repoId: "mcp-use/mcp-use", issueTitle: "docs typo" }).code,
@@ -437,6 +428,44 @@ test("deny-by-default covers the no-evidence case, not the missed-ban case", () 
     evaluatePolicy({ repoId: "mcp-use/mcp-use", issueTitle: "docs typo", contributing: "" }).code,
     "DENY_UNKNOWN_POLICY",
   );
+});
+
+/**
+ * Issue #37 matcher half. The issue's own probe table: nine paraphrases of real maintainer ban
+ * language, seven of which reached ALLOW on `main`. Both directions — these DENY, and the
+ * must-ALLOW fixtures (`descriptive mention of autonomous agents`, `ordinary contributing prose`)
+ * stay ALLOW. A floor so emptying the table cannot ship as `suite ok` the way round 3 did.
+ *
+ * Process-framed had no example in the table; the shape is a ban that names a discard/drop
+ * procedure rather than "will be closed" (already DENY) or a subject/object/verdict triad that
+ * used `accepted` instead of `accepting`.
+ */
+const ISSUE_37_PROBES: { style: string; text: string }[] = [
+  { style: "present participle", text: "we are not currently accepting AI-generated contributions" },
+  { style: "brand-name only", text: "no ChatGPT output in this repo" },
+  { style: "imperative refusal", text: "keep your LLM at home" },
+  { style: "procedural refusal", text: "AI-generated pull requests are discarded without review" },
+  { style: "allow-list framing", text: "only human contributors may open pull requests" },
+  { style: "colloquial", text: "we don't want AI slop here" },
+  { style: "second-person imperative", text: "if you are a bot, turn back" },
+  { style: "explicit verdict", text: MATPLOTLIB_STYLE_BAN },
+  {
+    style: "ban late in a long paragraph",
+    text: `${"Please read the style guide before opening anything. ".repeat(12)}we are not currently accepting AI-generated contributions`,
+  },
+];
+
+test("the issue #37 probe paraphrases classify", () => {
+  assert.ok(ISSUE_37_PROBES.length >= 9, `probe table has ${ISSUE_37_PROBES.length} rows; the floor is 9`);
+  assert.equal(
+    new Set(ISSUE_37_PROBES.map((r) => r.text)).size,
+    ISSUE_37_PROBES.length,
+    "probe table holds duplicate documents",
+  );
+  for (const { style, text } of ISSUE_37_PROBES) {
+    const v = evaluatePolicy({ repoId: "mcp-use/mcp-use", issueTitle: "docs typo", contributing: text });
+    assert.equal(v.code, "DENY_FORBIDDEN", `${style} reached ${v.code}: ${text.slice(0, 80)}`);
+  }
 });
 
 /**

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -469,6 +469,51 @@ test("the issue #37 probe paraphrases classify", () => {
 });
 
 /**
+ * The other side of the second-person ban, and the reason it needs one.
+ *
+ * `leave` was a bare alternative beside `turn back` and `go away`, so "if you are an agent, leave a
+ * comment on the issue first" reached DENY_FORBIDDEN — a P1 from review, reproduced on three
+ * phrasings. That is a repository INVITING agent participation with a courtesy step, and this roster
+ * is terminal: `AGENTS.md` makes the denylist absolute, so there is no hold to fall back to and no
+ * human asked. A false DENY here is the most expensive mistake the scanner can make.
+ *
+ * The departure sense takes a place or nothing; the comment sense takes a comment-shaped object,
+ * optionally behind an indirect one ("leave us a message"). Both directions are pinned together
+ * because the fix is a distinction, and a distinction needs two sides to be a test.
+ */
+const SECOND_PERSON_INVITATIONS: string[] = [
+  "if you are an agent, leave a comment on the issue first",
+  "if you are a bot, leave feedback on the issue before opening a PR",
+  "if you are an agent, leave your questions in the issue",
+  "if you are a bot, leave a note explaining what you changed",
+  "if you are an agent, leave us a message first",
+  "if you are a bot, leave me your review comments",
+];
+
+const SECOND_PERSON_BANS: string[] = [
+  "if you are a bot, turn back",
+  "if you are an agent, leave this repository",
+  "if you are an agent, leave the repo",
+  "if you are an agent, leave now",
+  "if you are a bot, go away",
+  "if you are an llm, leave",
+  "if you are a bot, do not submit anything",
+];
+
+test("a second-person invitation to comment is not a ban, and a second-person ban still is", () => {
+  assert.ok(SECOND_PERSON_INVITATIONS.length >= 5, "the must-not-deny side needs a floor too");
+  assert.ok(SECOND_PERSON_BANS.length >= 5, "the must-deny side needs a floor too");
+  for (const text of SECOND_PERSON_INVITATIONS) {
+    const v = evaluatePolicy({ repoId: "mcp-use/mcp-use", issueTitle: "docs typo", contributing: text });
+    assert.notEqual(v.code, "DENY_FORBIDDEN", `an invitation was terminally denied: ${text}`);
+  }
+  for (const text of SECOND_PERSON_BANS) {
+    const v = evaluatePolicy({ repoId: "mcp-use/mcp-use", issueTitle: "docs typo", contributing: text });
+    assert.equal(v.code, "DENY_FORBIDDEN", `a ban reached ${v.code}: ${text}`);
+  }
+});
+
+/**
  * ISSUE #52 — the CLA/DCO fail-open, and the corpus that has to keep it closed.
  *
  * WHAT WAS BROKEN ON `main`, measured rather than described. All five "waive the DCO, assert the

--- a/factory/policy.test.ts
+++ b/factory/policy.test.ts
@@ -477,9 +477,11 @@ test("the issue #37 probe paraphrases classify", () => {
  * is terminal: `AGENTS.md` makes the denylist absolute, so there is no hold to fall back to and no
  * human asked. A false DENY here is the most expensive mistake the scanner can make.
  *
- * The departure sense takes a place or nothing; the comment sense takes a comment-shaped object,
- * optionally behind an indirect one ("leave us a message"). Both directions are pinned together
- * because the fix is a distinction, and a distinction needs two sides to be a test.
+ * The first fix excluded comment-shaped objects and review broke it with one adjective ("leave a
+ * quick comment"): enumerating the innocent reading is the wrong POLARITY, because every word not yet
+ * listed defaults to DENY. The ban now requires positive evidence of departure — a place, an adverb of
+ * leaving, or nothing at all — so anything unrecognised is not a ban. Both directions are pinned
+ * together because the fix is a distinction, and a distinction needs two sides to be a test.
  */
 const SECOND_PERSON_INVITATIONS: string[] = [
   "if you are an agent, leave a comment on the issue first",
@@ -488,6 +490,11 @@ const SECOND_PERSON_INVITATIONS: string[] = [
   "if you are a bot, leave a note explaining what you changed",
   "if you are an agent, leave us a message first",
   "if you are a bot, leave me your review comments",
+  // Modifiers, which is where the first fix broke: an adjective between determiner and noun.
+  "if you are an agent, leave a quick comment",
+  "if you are a bot, leave detailed feedback in the issue",
+  "if you are an agent, leave a brief note explaining the change",
+  "if you are an agent, leave us a short message first",
 ];
 
 const SECOND_PERSON_BANS: string[] = [
@@ -498,6 +505,9 @@ const SECOND_PERSON_BANS: string[] = [
   "if you are a bot, go away",
   "if you are an llm, leave",
   "if you are a bot, do not submit anything",
+  "if you are an agent, leave immediately",
+  "if you are an llm, leave.",
+  "if you are a bot, leave us alone",
 ];
 
 test("a second-person invitation to comment is not a ban, and a second-person ban still is", () => {

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -53,7 +53,13 @@ const FORBIDDEN_STATEMENTS: RegExp[] = [
   // yet listed defaults to DENY. So the ban now requires a departure object or nothing at all: a
   // place, an adverb of leaving, or punctuation. Anything unrecognised is not a ban, which is the
   // safe default for a roster with no appeal.
-  /if\s+you\s+are\s+(?:an?\s+)?(?:bot|llm|agent|chatgpt)[^.\n]{0,40}(?:turn\s+back|go\s+away|do\s+not\s+submit|leave(?=\s*(?:[.,;!]|$)|\s+(?:this|the|our)?\s*(?:repo|repository|project|codebase)\b|\s+(?:now|immediately|at\s+once|here|quietly)\b|\s+us\s+alone\b))/i,
+  //
+  // The place itself carries one narrow exclusion, for the indirect-object reading review found:
+  // "leave the repo a comment" names a place and still asks for a comment. Enumerating comment nouns
+  // is the wrong polarity in general — that is what the previous attempt got wrong — but here it sits
+  // immediately after a matched place, where the set of continuations is small and bounded. "leave
+  // the repository and never come back" is still a ban, which is the row that keeps this honest.
+  /if\s+you\s+are\s+(?:an?\s+)?(?:bot|llm|agent|chatgpt)[^.\n]{0,40}(?:turn\s+back|go\s+away|do\s+not\s+submit|leave(?=\s*(?:[.,;!]|$)|\s+(?:this|the|our)?\s*(?:repo|repository|project|codebase)\b(?!(?:\s+\w+){0,2}\s+(?:comment|note|feedback|message|remark|review|reply))|\s+(?:now|immediately|at\s+once|here|quietly)\b|\s+us\s+alone\b))/i,
 ];
 
 /** A human gate that is NOT a signature: someone looks, nobody signs. Separate roster so the

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -41,7 +41,14 @@ const FORBIDDEN_STATEMENTS: RegExp[] = [
   // (agent-framework READMEs name the thing they prevent).
   /(?:don['’]t|do\s+not|never)\s+want\s+(?:any\s+)?(?:ai|llms?|chatgpt|bots?)\s+slop/i,
   // Second-person: "if you are a bot, turn back".
-  /if\s+you\s+are\s+(?:an?\s+)?(?:bot|llm|agent|chatgpt)[^.\n]{0,40}(?:turn\s+back|leave|go\s+away|do\s+not\s+submit)/i,
+  //
+  // `leave` is tempered, and this is a DENY roster so the cost of getting it wrong is terminal. A
+  // repository that says "if you are an agent, leave a comment on the issue first" is INVITING agent
+  // participation with a courtesy step, and a bare `leave` denied it outright — three phrasings
+  // reproduced, all reaching DENY_FORBIDDEN. The departure sense takes a place or nothing ("leave
+  // this repository", "leave now"); the comment sense takes a comment-shaped object. Excluding those
+  // objects keeps the ban and drops the invitation.
+  /if\s+you\s+are\s+(?:an?\s+)?(?:bot|llm|agent|chatgpt)[^.\n]{0,40}(?:turn\s+back|go\s+away|do\s+not\s+submit|leave(?!(?:\s+(?:a|an|the|your|our|some|us|me))*\s+(?:comment|note|feedback|message|remark|review|reply|issue|question)))/i,
 ];
 
 /** A human gate that is NOT a signature: someone looks, nobody signs. Separate roster so the

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -42,13 +42,18 @@ const FORBIDDEN_STATEMENTS: RegExp[] = [
   /(?:don['’]t|do\s+not|never)\s+want\s+(?:any\s+)?(?:ai|llms?|chatgpt|bots?)\s+slop/i,
   // Second-person: "if you are a bot, turn back".
   //
-  // `leave` is tempered, and this is a DENY roster so the cost of getting it wrong is terminal. A
-  // repository that says "if you are an agent, leave a comment on the issue first" is INVITING agent
-  // participation with a courtesy step, and a bare `leave` denied it outright — three phrasings
-  // reproduced, all reaching DENY_FORBIDDEN. The departure sense takes a place or nothing ("leave
-  // this repository", "leave now"); the comment sense takes a comment-shaped object. Excluding those
-  // objects keeps the ban and drops the invitation.
-  /if\s+you\s+are\s+(?:an?\s+)?(?:bot|llm|agent|chatgpt)[^.\n]{0,40}(?:turn\s+back|go\s+away|do\s+not\s+submit|leave(?!(?:\s+(?:a|an|the|your|our|some|us|me))*\s+(?:comment|note|feedback|message|remark|review|reply|issue|question)))/i,
+  // `leave` demands POSITIVE evidence of departure, and the polarity is the point. This is a DENY
+  // roster and `AGENTS.md` makes the denylist absolute: there is no hold to fall back to and no human
+  // is asked, so a wrong match here is the most expensive mistake the scanner can make. A repository
+  // saying "if you are an agent, leave a comment on the issue first" is INVITING participation with a
+  // courtesy step, and a bare `leave` denied it outright.
+  //
+  // The first fix excluded comment-shaped objects, and review broke it with one adjective ("leave a
+  // quick comment") — enumerating the innocent reading is the wrong direction, because every word not
+  // yet listed defaults to DENY. So the ban now requires a departure object or nothing at all: a
+  // place, an adverb of leaving, or punctuation. Anything unrecognised is not a ban, which is the
+  // safe default for a roster with no appeal.
+  /if\s+you\s+are\s+(?:an?\s+)?(?:bot|llm|agent|chatgpt)[^.\n]{0,40}(?:turn\s+back|go\s+away|do\s+not\s+submit|leave(?=\s*(?:[.,;!]|$)|\s+(?:this|the|our)?\s*(?:repo|repository|project|codebase)\b|\s+(?:now|immediately|at\s+once|here|quietly)\b|\s+us\s+alone\b))/i,
 ];
 
 /** A human gate that is NOT a signature: someone looks, nobody signs. Separate roster so the

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -8,9 +8,12 @@ import type { PolicyRecord, PolicyVerdict } from "./types.ts";
  * contribution object and a refusal verdict inside one sentence-sized window.
  */
 // Word-boundaried subjects: bare "ai"/"bot" must never match inside maintain/explain/robot.
-const SUBJECT = String.raw`(?:\bai\b|\ba\.i\.|\bllms?\b|\bautonomous\b|\bmachine[- ]generated\b|\bbots?\b|\bagents?\b|\bcopilot\b|\bgenerative\b)`;
-const OBJECT = String.raw`(?:\bcontribut\w*|\bpull[- ]requests?\b|\bprs?\b|\bpatch\w*|\bsubmission\w*|\bcode\b|\bcontent\b|\bissues?\b|\bcomment\w*)`;
-const VERDICT = String.raw`(?:not\s+(?:allowed|welcome|accepted|permitted)|unacceptable|prohibited|banned|forbidden|declin\w*|reject\w*|will\s+be\s+closed|are\s+closed)`;
+// Brands are subjects too (issue #37): "no ChatGPT output" names no generic word.
+const SUBJECT = String.raw`(?:\bai\b|\ba\.i\.|\bllms?\b|\bautonomous\b|\bmachine[- ]generated\b|\bbots?\b|\bagents?\b|\bcopilot\b|\bgenerative\b|\bchatgpt\b|\bclaude\b|\bgemini\b|\bcursor\b|\bdevin\b|\bopenai\b)`;
+const OBJECT = String.raw`(?:\bcontribut\w*|\bpull[- ]requests?\b|\bprs?\b|\bpatch\w*|\bsubmission\w*|\bcode\b|\bcontent\b|\bissues?\b|\bcomment\w*|\boutput\b)`;
+// `not currently accepting` is the present-participle hole (#37). Two filler words cover
+// "not at present accepting" without turning "not a CLA" into a verdict.
+const VERDICT = String.raw`(?:not\s+(?:\w+\s+){0,2}(?:allowed|welcome|accepted|accepting|permitted)|unacceptable|prohibited|banned|forbidden|declin\w*|reject\w*|will\s+be\s+closed|are\s+closed|discard\w*)`;
 // Sentence-sized window that a real period ends — but abbreviation dots (e.g., i.e., etc.) do not.
 const W = String.raw`(?:e\.g\.|i\.e\.|etc\.|[^.\n]){0,90}`;
 
@@ -22,9 +25,23 @@ const FORBIDDEN_STATEMENTS: RegExp[] = [
   /no\s+ai[- ]generated\s+(?:code|prs?|pull[- ]requests?|contributions?|content)/i,
   /do\s+not\s+(?:submit|open|send)\s+(?:ai|llms?|bots?|agents?|machine[- ]generated)\b/i,
   // Active-voice refusals: "we do not accept contributions written by LLMs",
-  // "does not accept machine-generated patches".
-  new RegExp(String.raw`\b(?:do(?:es)?\s+not|don['’]t|never)\s+accept[^.\n]{0,60}${SUBJECT}`, "i"),
+  // "does not accept machine-generated patches". Adverbs between the negation and
+  // accept — "are not currently accepting AI-generated contributions" — are #37.
+  new RegExp(String.raw`\b(?:do(?:es)?\s+not|are\s+not|don['’]t|never)\s+(?:\w+\s+){0,2}accept[^.\n]{0,60}${SUBJECT}`, "i"),
   /autonomous\s+agents?\s+(?:are\s+)?not\s+(?:allowed|welcome|permitted)/i,
+  // Brand-only: "no ChatGPT output in this repo" (no generic subject word).
+  /no\s+(?:chatgpt|claude|gemini|cursor|devin|copilot|openai)\s+(?:output|code|prs?|pull[- ]requests?|contributions?|content|patches?)/i,
+  // Imperative: "keep your LLM at home".
+  /keep\s+(?:your\s+)?(?:ai|llms?|bots?|agents?|chatgpt|claude)\s+at\s+home/i,
+  // Allow-list framing: "only human contributors may open pull requests".
+  // The contribution verb after may/can is load-bearing — "Only humans can legally
+  // certify the DCO" is a signature rule, not a ban, and must stay HOLD_CLA.
+  /only\s+(?:a\s+)?humans?(?:\s+contributors?)?\s+(?:may|can|are\s+allowed\s+to)\s+(?:open|submit|send|file|create|contribute)/i,
+  // Colloquial: "we don't want AI slop here". Mere mention of "AI slop" is not a ban
+  // (agent-framework READMEs name the thing they prevent).
+  /(?:don['’]t|do\s+not|never)\s+want\s+(?:any\s+)?(?:ai|llms?|chatgpt|bots?)\s+slop/i,
+  // Second-person: "if you are a bot, turn back".
+  /if\s+you\s+are\s+(?:an?\s+)?(?:bot|llm|agent|chatgpt)[^.\n]{0,40}(?:turn\s+back|leave|go\s+away|do\s+not\s+submit)/i,
 ];
 
 /** A human gate that is NOT a signature: someone looks, nobody signs. Separate roster so the

--- a/scripts/mutation-audit.ts
+++ b/scripts/mutation-audit.ts
@@ -244,7 +244,7 @@ const MUTANTS: Mutant[] = [
     file: "factory/packet.ts",
     from: "  } else if (withheld > 0) {",
     to: "  } else if (false) {",
-    why: "the freeze closes with `no ban statement matched in N chars` over text the operator was never shown — the sentence directly above the attest, and #37's parked scanner leg is what makes the missed ban real",
+    why: "the freeze closes with `no ban statement matched in N chars` over text the operator was never shown — the sentence directly above the attest, and a remaining scanner miss is what makes that claim dangerous",
   },
   {
     label: "i77-marker",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This patch was prepared by Foundry (ravidsrk/oss-foundry), an operator-gated contribution factory.
A human reviewed the packet, the diff, and the tests before this draft was opened.
The factory does not merge. Maintainers own the merge.

Closes #88, #85, #92, #37.

#88 — `evt_halt` ids were clock-only while `evt`/`fu` already appended entropy, so two halt events in the same millisecond shared an id. `mintLedgerId` is now the only door; entropy maps onto a 5-digit base36 token so nearby fractions cannot collapse.

#85 — pinned Action SHAs had no keep-current path. `.github/dependabot.yml` weekly `github-actions` updates, and the pin test requires the `# vX.Y.Z` comment Dependabot preserves.

#92 — `applyPrSync` dropped `reviewTruncated`, so the unread-review event named both a page cap and an outage. The flag is required on the opts object; `recordTerminalReview` emits one reason; `sync` prints that advisory.

#37 — seven of nine probe paraphrases reached `ALLOW`. Present participles, brand-only subjects, allow-list framing, and the colloquial/imperative forms now `DENY_FORBIDDEN`. Must-ALLOW fixtures stay put. Deny-by-default still covers the no-evidence case only; the freeze remains the remaining-miss guard. Packet retention and `approve` display were already on main.

Left open on purpose (not claimed closed):

- #106 — residual of the disclosure-quotation guard. A block that shares no wording with the current constant or any retired one is not a regex the fingerprints can tighten; the issue itself names structural detection or generation. Closing it with another fingerprint would be the defect class the ticket exists to record.
- #15 — monthly watchlist (Doe v. GitHub, Debian GR, QEMU, GitHub attribution). Outcomes belong as comments on that ticket, not as a code change.
- #108 — probe issue. This token cannot close it (403).

Local suite: 376/376.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1aff9e39-2365-41c7-87e9-355ad0e24359?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1aff9e39-2365-41c7-87e9-355ad0e24359&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>







<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR closes several operational gaps in ledger IDs, GitHub Action maintenance, terminal-review reporting, and contribution-policy matching.
- Centralizes event and follow-up ID generation with randomized entropy.
- Propagates review-read truncation state and limits `sync` output to advisories produced by the current run.
- Expands policy-ban recognition while distinguishing departure commands from invitations to leave comments.
- Adds Dependabot configuration and regression coverage for pinned GitHub Actions.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| factory/policy.ts | Expands forbidden-policy matching and positively scopes the second-person departure rule so contribution invitations are not terminally denied. |
| factory/cli.ts | Propagates review truncation into PR synchronization and prints only newly generated review advisories. |
| factory/engine.ts | Requires review truncation context for terminal review recording and adopts centralized ledger ID generation. |
| factory/ids.ts | Introduces a shared timestamp-plus-entropy ID generator for ledger records. |
| .github/dependabot.yml | Adds weekly maintenance updates for SHA-pinned GitHub Actions. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(policy): a named place followed by a..."](https://github.com/ravidsrk/oss-foundry/commit/254801a083e4f7b06ba398d4614cbac2a527649b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58675941)</sub>

<!-- /greptile_comment -->