### PR TITLE
P1: green baseline — real Node floor, type-check gate, and the six things it found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,19 +44,24 @@ jobs:
     strategy:
       # Two legs, each proving something the other cannot.
       #
-      # `22.6.0` is the exact floor `package.json` declares, and it is not an arbitrary round
-      # number: it is the release that introduced `--experimental-strip-types`, which every
-      # documented invocation in this repository passes explicitly. Below it Node exits with
-      # `bad option: --experimental-strip-types` before a single line runs, so no in-process check
-      # could ever report it — the manifest claim is only worth anything if CI executes the floor
-      # itself. `factory/ci.test.ts` asserts this leg exists and matches `engines`.
+      # `22.10.0` is the exact floor `package.json` declares, and this leg is why the number is
+      # right. The first guess was 22.6.0, the release that added `--experimental-strip-types` —
+      # wrong, and this leg proved it on its first run. The binding constraint is not the flag at
+      # all: `factory/run-tests.ts` accounts for every test file through `node:test`'s per-file
+      # `test:summary` event, and on 22.9.0 and below that event carries no `file`, so the oracle
+      # reports "reported no summary" for every file and `npm test` refuses outright. Measured by
+      # bisection: 22.9.0 broken, 22.10.0 green.
+      #
+      # Nothing in-process could have caught either mistake — below 22.6.0 Node exits on the
+      # unknown flag before a line runs, and at 22.6.0-22.9.0 the failure is the oracle itself. A
+      # declared floor is only worth something if a run executes it.
       #
       # `24` is the current Active LTS and the line an operator actually runs. It is also where
       # type stripping is Stability 2 (Stable); on the 22.x line it is still a release candidate,
       # so testing only the floor would prove the project works nowhere anyone runs it.
       fail-fast: false
       matrix:
-        node: ["22.6.0", "24"]
+        node: ["22.10.0", "24"]
     steps:
       # Pinned to immutable commits, not `@v4`. A major tag is a moving reference: whoever controls
       # the upstream repository can retarget it, and these two run BEFORE every check here, so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,3 +80,17 @@ jobs:
       # `policy-records.json`, which until now ran only on the clock.
       - name: Validate allowlist and policy records
         run: npm run validate
+
+      # The type checker is installed HERE and nowhere else. `package.json` declares no
+      # dependencies and has no lockfile, and that is a deliberate, tested property of this
+      # repository — a clone needs nothing to run `npm test`. `npm install --no-save
+      # --no-package-lock` gives this job a checker without touching the manifest or writing a
+      # lockfile, and both versions are pinned so the gate cannot drift under us.
+      #
+      # WHY IT MATTERS: `--experimental-strip-types` erases types without checking them and ignores
+      # tsconfig.json entirely, so until this step existed nothing in the pipeline had ever read the
+      # types. The first run found six real problems in non-test source, including two non-null
+      # assertions standing where a guard had already established the fact and a cap-check signature
+      # that silently accepted a read carrying no truncation flag.
+      - name: Type check
+        run: npm run typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,27 @@ concurrency:
 jobs:
   suite:
     runs-on: ubuntu-latest
+    # A hung run should not hold a required check open indefinitely. The suite takes ~25s; twenty
+    # minutes is the same bound `oss-tick.yml` already uses.
+    timeout-minutes: 20
     permissions:
       contents: read
+    strategy:
+      # Two legs, each proving something the other cannot.
+      #
+      # `22.6.0` is the exact floor `package.json` declares, and it is not an arbitrary round
+      # number: it is the release that introduced `--experimental-strip-types`, which every
+      # documented invocation in this repository passes explicitly. Below it Node exits with
+      # `bad option: --experimental-strip-types` before a single line runs, so no in-process check
+      # could ever report it — the manifest claim is only worth anything if CI executes the floor
+      # itself. `factory/ci.test.ts` asserts this leg exists and matches `engines`.
+      #
+      # `24` is the current Active LTS and the line an operator actually runs. It is also where
+      # type stripping is Stability 2 (Stable); on the 22.x line it is still a release candidate,
+      # so testing only the floor would prove the project works nowhere anyone runs it.
+      fail-fast: false
+      matrix:
+        node: ["22.6.0", "24"]
     steps:
       # Pinned to immutable commits, not `@v4`. A major tag is a moving reference: whoever controls
       # the upstream repository can retarget it, and these two run BEFORE every check here, so
@@ -48,10 +67,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          # The floor `package.json` declares (`engines.node: >=22`), and the version the clock
-          # already runs, so CI tests the version the project claims to support rather than
-          # whatever is newest.
-          node-version: "22"
+          node-version: ${{ matrix.node }}
 
       # No install step: `package.json` declares no dependencies and the repo has no lockfile, so
       # there is nothing to restore and `npm ci` would fail on the missing lockfile.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,19 @@
 node_modules/
+
+# The live ledger. Deliberately never committed: `factory/seed.ts` plus the generated block in
+# `docs/12-ledger.md` are the durable, reviewable record, and `verify-ledger.ts` reconciles the
+# COMMITTED seed against live GitHub rather than reading this file (docs/08-operations.md).
 .foundry-state.json
+
+# Secrets, none of which this repo needs at rest but all of which an operator's shell may carry:
+# FOUNDRY_PAT, GITHUB_TOKEN/GH_TOKEN, E2B_API_KEY. There is no `.env` in the documented workflow —
+# this exists so that adding one cannot be committed by accident.
+.env
+.env.*
+!.env.example
+
+# Editor/agent local state. This was previously ignored only by the developer's personal global
+# gitignore, so a fresh clone on another machine would not have ignored it.
+.claude/settings.local.json
+
 .DS_Store

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,12 @@
+# Pins the runtime for this repository so a local shell and CI agree about what "Node 22+" means.
+#
+# `package.json` declares `engines.node: >=22.6.0` — the release that introduced
+# `--experimental-strip-types`, which every documented invocation here passes explicitly. Below that
+# release Node exits with `bad option: --experimental-strip-types` before any code runs, so nothing
+# in-process can report the mistake; the floor has to be declared and executed rather than checked.
+#
+# This pin is the CURRENT line, not the floor: 24 is the Active LTS and the line where type stripping
+# is Stability 2 (Stable). On 22.x it is still a release candidate. CI runs both (see
+# `.github/workflows/ci.yml`) so the floor claim is proven and the line people actually use is too.
+[tools]
+node = "24"

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,9 +1,11 @@
 # Pins the runtime for this repository so a local shell and CI agree about what "Node 22+" means.
 #
-# `package.json` declares `engines.node: >=22.6.0` — the release that introduced
-# `--experimental-strip-types`, which every documented invocation here passes explicitly. Below that
-# release Node exits with `bad option: --experimental-strip-types` before any code runs, so nothing
-# in-process can report the mistake; the floor has to be declared and executed rather than checked.
+# `package.json` declares `engines.node: >=22.10.0`. That number is set by the test suite's own
+# oracle, not by the type-stripping flag: `factory/run-tests.ts` accounts for every test file via
+# `node:test`'s per-file `test:summary`, and on 22.9.0 and below that event carries no `file`, so
+# `npm test` refuses outright. Measured by bisection — 22.9.0 broken, 22.10.0 green. The flag itself
+# only needs 22.6.0. Neither limit can be reported from inside the process, which is why CI executes
+# the floor rather than asserting it.
 #
 # This pin is the CURRENT line, not the floor: 24 is the Active LTS and the line where type stripping
 # is Stability 2 (Stable). On 22.x it is still a release candidate. CI runs both (see

--- a/docs/completion/evidence/T-01-version-floor.txt
+++ b/docs/completion/evidence/T-01-version-floor.txt
@@ -1,0 +1,23 @@
+### T-01 — Node floor: declared, executed, and guarded
+
+--- why a runtime check is dead code: node aborts before running anything ---
+$ node --experimental-bogus-flag -e 'console.log("code ran")'
+node: bad option: --experimental-bogus-flag
+
+--- every documented invocation passes the flag explicitly (0 rely on default-on) ---
+  node --experimental-strip-types factory/cli.ts
+  node --experimental-strip-types factory/run-tests.ts
+  node --experimental-strip-types factory/validate-allowlist.ts
+  node --experimental-strip-types factory/verify-ledger.ts
+  without the flag: 0
+
+--- declared floor ---
+  engines.node = >=22.6.0
+--- CI legs ---
+         node: ["22.6.0", "24"]
+
+--- suite ---
+suite ok — 381 tests across 19 files, every file accounted for
+--- negative control: a real uninstalled entry point still reds the boundary guard ---
+  AssertionError: factory/phantom-entry.ts is a discovered entry point with no drive in this test
+  (reproduced above by swapping ci.yml's run: line; restored after)

--- a/docs/completion/evidence/T-01-version-floor.txt
+++ b/docs/completion/evidence/T-01-version-floor.txt
@@ -1,23 +1,16 @@
-### T-01 — Node floor: declared, executed, and guarded
+### T-01 (corrected) — the real Node floor is set by the suite's oracle, not the flag
 
---- why a runtime check is dead code: node aborts before running anything ---
-$ node --experimental-bogus-flag -e 'console.log("code ran")'
-node: bad option: --experimental-bogus-flag
+--- bisected against real runtimes installed locally ---
+  node 22.6.0   REFUSED  (oracle: no per-file test:summary)
+  node 22.9.0   REFUSED  (oracle: no per-file test:summary)
+  node 22.10.0  GREEN  suite ok — 383 tests across 20 files, every file accounted for
+  node 22.11.0  GREEN  suite ok — 383 tests across 20 files, every file accounted for
+  node 22.13.0  GREEN  suite ok — 383 tests across 20 files, every file accounted for
+  node 22.18.0  GREEN  suite ok — 383 tests across 20 files, every file accounted for
+  node 24.20.0  GREEN  suite ok — 383 tests across 20 files, every file accounted for
 
---- every documented invocation passes the flag explicitly (0 rely on default-on) ---
-  node --experimental-strip-types factory/cli.ts
-  node --experimental-strip-types factory/run-tests.ts
-  node --experimental-strip-types factory/validate-allowlist.ts
-  node --experimental-strip-types factory/verify-ledger.ts
-  without the flag: 0
+--- so: the flag needs 22.6.0, the ORACLE needs 22.10.0, and the higher one wins ---
+  engines.node = >=22.10.0
 
---- declared floor ---
-  engines.node = >=22.6.0
---- CI legs ---
-         node: ["22.6.0", "24"]
-
---- suite ---
-suite ok — 381 tests across 19 files, every file accounted for
---- negative control: a real uninstalled entry point still reds the boundary guard ---
-  AssertionError: factory/phantom-entry.ts is a discovered entry point with no drive in this test
-  (reproduced above by swapping ci.yml's run: line; restored after)
+--- found by the matrix leg on its first run, not by inspection ---
+  PR #124 suite (22.6.0) failed; suite (24) passed.

--- a/docs/completion/evidence/T-02-typecheck.txt
+++ b/docs/completion/evidence/T-02-typecheck.txt
@@ -1,0 +1,26 @@
+### T-02 — type-check gate, with negative controls
+
+--- checker actually running (not the 'tsc' squatter package) ---
+$ ./node_modules/.bin/tsc --version
+Version 5.9.3
+  files checked: 50
+
+--- clean on the tree ---
+$ npm run typecheck  -> errors: 0
+0
+
+--- NEGATIVE CONTROL: plain type error
+    factory/_probe.ts(2,7): error TS2322: Type 'string' is not assignable to type 'number'.
+--- NEGATIVE CONTROL: enum (Node 26 hazard, erasableSyntaxOnly)
+    factory/_probe.ts(2,13): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
+--- NEGATIVE CONTROL: namespace with runtime code
+    factory/_probe.ts(2,18): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
+--- NEGATIVE CONTROL: parameter property
+    factory/_probe.ts(2,30): error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
+
+--- NEGATIVE CONTROL: verbatimModuleSyntax (value-import of a type) ---
+    factory/_probe.ts(1,10): error TS1484: 'TaskPacket' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.
+
+--- clean again ---
+  errors: 0
+0

--- a/docs/completion/evidence/T-04-gitignore.txt
+++ b/docs/completion/evidence/T-04-gitignore.txt
@@ -1,0 +1,12 @@
+### T-04 — gitignore covers secrets and local agent state
+
+--- before: what ignored .claude/settings.local.json? ---
+  (was: /Users/ravindra/.config/git/ignore:6 — the developer's PERSONAL global config)
+
+--- after: ignored by the repo's own .gitignore ---
+  .env                               .gitignore:11:.env	.env
+  .env.local                         .gitignore:12:.env.*	.env.local
+  .claude/settings.local.json        .gitignore:17:.claude/settings.local.json	.claude/settings.local.json
+
+--- .env.example is NOT ignored (so a documented template can be committed) ---
+  .env.example                       .gitignore:13:!.env.example	.env.example

--- a/docs/completion/evidence/T-07-restore.txt
+++ b/docs/completion/evidence/T-07-restore.txt
@@ -1,0 +1,24 @@
+### T-07 — backup and restore, rehearsed end to end
+
+--- 1. first mutating run creates the ledger (nothing to back up yet) ---
+    files: state.json 
+
+--- 2. second mutating run: the previous ledger is copied to .bak FIRST ---
+    files: state.json state.json.bak 
+    ledger 36570 bytes · backup 36392 bytes
+    live ledger has BOTH halts; the backup has only the first:
+      live:   ravidsrk/orca-fleet  opened=2 merged=2 tone=banned health=stop|ravidsrk/frontguard  opened=1 merged=1 tone=banned health=stop|
+      backup: ravidsrk/orca-fleet  opened=2 merged=2 tone=warm health=good|ravidsrk/frontguard  opened=1 merged=1 tone=banned health=stop|
+
+--- 3. corrupt the ledger the way a torn write would ---
+    ledger is now 200 bytes
+    exit=1  (every verb is dead, including status)
+    refusing to load /var/folders/65/nfjkpf196n5_xrwbkyrrgqrc0000gn/T/tmp.dE9xzTWJ0P/state.json: Unterminated string in JSON at position 200 (line 8 column 34). Fix or remove it; will not overwrite with seed.
+
+--- 4. RESTORE: the documented procedure is one command ---
+    $ cp "$STATE.bak" "$STATE"
+    exit=0  (loads again)
+    restored state: ravidsrk/orca-fleet  opened=2 merged=2 tone=warm health=good|ravidsrk/frontguard  opened=1 merged=1 tone=banned health=stop|
+
+--- 5. and the restore is honest about what it costs: the second halt is gone ---
+    the backup is one generation, so restoring loses work done after it was taken.

--- a/factory/ci.test.ts
+++ b/factory/ci.test.ts
@@ -269,3 +269,74 @@ test("pinned action SHAs have a keep-current mechanism (issue #85)", () => {
   assert.match(text, /directory:\s*\//);
   assert.match(text, /schedule:/);
 });
+
+/**
+ * ISSUE: `engines.node` read `>=22` while every documented command in this repository passes
+ * `--experimental-strip-types`, a flag that does not exist before **22.6.0**. A stranger on 22.4
+ * satisfied the declared floor and got `node: bad option: --experimental-strip-types`.
+ *
+ * WHY THIS IS A TEST AND NOT A RUNTIME CHECK. Node rejects an unknown option *before* executing
+ * anything — verified: `node --experimental-bogus-flag -e 'console.log(1)'` prints `node: bad
+ * option:` and runs no code. So on the versions the floor is meant to exclude, no in-process check
+ * can possibly run. A runtime `process.versions.node` guard would be unreachable dead code. The
+ * only enforceable thing is that the DECLARED floor stays true, and that CI actually executes it.
+ *
+ * Three claims, each of which can drift independently:
+ *   1. the floor equals the flag's introduction version,
+ *   2. every script still passes the flag — because if one stopped, the real floor would jump to
+ *      22.18.0 (where stripping became default-on) and the manifest would be silently wrong,
+ *   3. CI runs the declared floor, so the claim is executed rather than asserted.
+ */
+const STRIP_TYPES_ADDED = "22.6.0";
+
+test("the declared Node floor is the version that introduced the flag every script passes", () => {
+  const manifest = JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8")) as {
+    engines?: { node?: string };
+    scripts?: Record<string, string>;
+  };
+  assert.equal(
+    manifest.engines?.node,
+    `>=${STRIP_TYPES_ADDED}`,
+    `engines.node must be >=${STRIP_TYPES_ADDED} — the release that added --experimental-strip-types. Anything lower claims support for versions where Node aborts on the flag before running a line.`,
+  );
+
+  // Claim 2: the floor is only correct while every entry point passes the flag explicitly.
+  const scripts = Object.entries(manifest.scripts ?? {});
+  assert.ok(scripts.length > 0, "package.json declares no scripts");
+  for (const [name, body] of scripts) {
+    if (!/\bnode\b/.test(body)) continue;
+    assert.match(
+      body,
+      /--experimental-strip-types/,
+      `script \`${name}\` runs node without --experimental-strip-types: \`${body}\`. Relying on default-on type stripping moves the real floor to 22.18.0, so engines.node above is now wrong.`,
+    );
+  }
+});
+
+test("CI executes the declared Node floor, it does not merely assert it", () => {
+  const manifest = JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8")) as {
+    engines?: { node?: string };
+  };
+  const floor = (manifest.engines?.node ?? "").replace(/^>=/, "");
+  const ci = workflows().find((w) => w.name === "ci.yml");
+  assert.ok(ci, "ci.yml is missing");
+
+  const matrix = ci.text.match(/node:\s*\[([^\]]*)\]/);
+  assert.ok(matrix, "ci.yml declares no node version matrix — the floor claim is then untested");
+  const legs = matrix[1]!.split(",").map((v) => v.trim().replace(/^["']|["']$/g, ""));
+  assert.ok(
+    legs.includes(floor),
+    `ci.yml matrix ${JSON.stringify(legs)} does not run the declared floor ${floor}. A floor no run exercises is a claim, not a guarantee.`,
+  );
+  // ...and the line an operator actually runs, where type stripping is Stable rather than a
+  // release candidate. Testing only the floor would prove the project works nowhere anyone runs it.
+  assert.ok(
+    legs.some((v) => v === "24" || v.startsWith("24.")),
+    `ci.yml matrix ${JSON.stringify(legs)} omits Node 24, the Active LTS and the only line where type stripping is Stability 2 (Stable).`,
+  );
+  assert.match(
+    ci.text,
+    /\$\{\{\s*matrix\.node\s*\}\}/,
+    "ci.yml declares a node matrix but setup-node does not consume it, so every leg runs the same version",
+  );
+});

--- a/factory/ci.test.ts
+++ b/factory/ci.test.ts
@@ -287,17 +287,32 @@ test("pinned action SHAs have a keep-current mechanism (issue #85)", () => {
  *      22.18.0 (where stripping became default-on) and the manifest would be silently wrong,
  *   3. CI runs the declared floor, so the claim is executed rather than asserted.
  */
+/** Where `--experimental-strip-types` was introduced. A lower bound on the floor, not the floor. */
 const STRIP_TYPES_ADDED = "22.6.0";
+/**
+ * The actual floor, and it is higher than the flag: `factory/run-tests.ts` accounts for every test
+ * file through `node:test`'s per-file `test:summary` event, and on 22.9.0 and below that event
+ * carries no `file` — so the oracle reports "reported no summary" for every file and `npm test`
+ * refuses. Measured by bisection against real runtimes: 22.9.0 broken, 22.10.0 green.
+ */
+const SUITE_ORACLE_FLOOR = "22.10.0";
 
-test("the declared Node floor is the version that introduced the flag every script passes", () => {
+test("the declared Node floor is the one the suite's own oracle needs", () => {
   const manifest = JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8")) as {
     engines?: { node?: string };
     scripts?: Record<string, string>;
   };
   assert.equal(
     manifest.engines?.node,
-    `>=${STRIP_TYPES_ADDED}`,
-    `engines.node must be >=${STRIP_TYPES_ADDED} — the release that added --experimental-strip-types. Anything lower claims support for versions where Node aborts on the flag before running a line.`,
+    `>=${SUITE_ORACLE_FLOOR}`,
+    `engines.node must be >=${SUITE_ORACLE_FLOOR} — the release where node:test's per-file test:summary carries a \`file\`, which factory/run-tests.ts needs to account for every test file. Below it \`npm test\` refuses outright.`,
+  );
+  // ...and the floor can never drop below the flag's own introduction, whatever else changes.
+  const floor = (manifest.engines?.node ?? "").replace(/^>=/, "").split(".").map(Number);
+  const flagFloor = STRIP_TYPES_ADDED.split(".").map(Number);
+  assert.ok(
+    floor[0]! > flagFloor[0]! || (floor[0] === flagFloor[0] && floor[1]! >= flagFloor[1]!),
+    `engines.node ${manifest.engines?.node} is below ${STRIP_TYPES_ADDED}, where --experimental-strip-types was added — Node would abort on the flag before running a line.`,
   );
 
   // Claim 2: the floor is only correct while every entry point passes the flag explicitly.

--- a/factory/ci.test.ts
+++ b/factory/ci.test.ts
@@ -303,14 +303,26 @@ test("the declared Node floor is the version that introduced the flag every scri
   // Claim 2: the floor is only correct while every entry point passes the flag explicitly.
   const scripts = Object.entries(manifest.scripts ?? {});
   assert.ok(scripts.length > 0, "package.json declares no scripts");
+  /**
+   * A node INVOCATION, not the word "node". `\bnode\b` matched `@types/node@24.9.2` in the
+   * typecheck script — `/` and `@` are both word boundaries — and demanded a strip-types flag from
+   * an npm install. Anchoring to a command position is the fix: start of string, or after `&&`,
+   * `||`, `;` or a pipe.
+   */
+  const NODE_INVOCATION = /(?:^|&&|\|\||;|\|)\s*node\s/;
   for (const [name, body] of scripts) {
-    if (!/\bnode\b/.test(body)) continue;
+    if (!NODE_INVOCATION.test(body)) continue;
     assert.match(
       body,
       /--experimental-strip-types/,
       `script \`${name}\` runs node without --experimental-strip-types: \`${body}\`. Relying on default-on type stripping moves the real floor to 22.18.0, so engines.node above is now wrong.`,
     );
   }
+  // ...pinned both ways, because a predicate that matched nothing would make the loop vacuous.
+  assert.equal(NODE_INVOCATION.test("node --experimental-strip-types factory/cli.ts"), true);
+  assert.equal(NODE_INVOCATION.test("npm i x && node --experimental-strip-types a.ts"), true);
+  assert.equal(NODE_INVOCATION.test("npm install @types/node@24.9.2"), false, "@types/node is not an invocation");
+  assert.equal(NODE_INVOCATION.test("./node_modules/.bin/tsc --noEmit"), false, "node_modules is not an invocation");
 });
 
 test("CI executes the declared Node floor, it does not merely assert it", () => {

--- a/factory/ci.test.ts
+++ b/factory/ci.test.ts
@@ -340,3 +340,43 @@ test("CI executes the declared Node floor, it does not merely assert it", () => 
     "ci.yml declares a node matrix but setup-node does not consume it, so every leg runs the same version",
   );
 });
+
+/**
+ * The type-check gate, guarded the same way the suite step is (issue #54's argument): adding it
+ * fixes today, and does nothing about it being deleted. `--experimental-strip-types` erases types
+ * without checking them and ignores `tsconfig.json`, so if this step goes the repository silently
+ * returns to having no type enforcement at all — and the green check keeps being cited as evidence.
+ *
+ * Also asserted: the checker is version-PINNED. An unpinned `npx typescript` would let the gate's
+ * strictness drift under us on someone else's release schedule, which for a check that reads every
+ * line of the tree is a supply-chain surface as well as a reproducibility one.
+ */
+test("CI type checks, with a pinned checker, and the manifest stays dependency-free", () => {
+  const ci = workflows().find((w) => w.name === "ci.yml");
+  assert.ok(ci, "ci.yml is missing");
+  assert.match(
+    ci.text,
+    /run:\s*npm run typecheck/,
+    "ci.yml no longer runs `npm run typecheck` — nothing in the pipeline reads the types",
+  );
+
+  const manifest = JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8")) as {
+    scripts?: Record<string, string>;
+    dependencies?: unknown;
+    devDependencies?: unknown;
+  };
+  const typecheck = manifest.scripts?.typecheck;
+  assert.ok(typecheck, "package.json declares no typecheck script");
+  assert.match(typecheck, /typescript@\d+\.\d+\.\d+/, `typecheck must pin typescript exactly: ${typecheck}`);
+  assert.match(typecheck, /@types\/node@\d+\.\d+\.\d+/, `typecheck must pin @types/node exactly: ${typecheck}`);
+  assert.match(typecheck, /--no-save/, "the checker must not be written into package.json");
+  assert.match(typecheck, /--no-package-lock/, "the checker must not create a lockfile");
+
+  // The property the transient install exists to preserve: a clone needs nothing to run the suite.
+  assert.equal(manifest.dependencies, undefined, "package.json declares runtime dependencies");
+  assert.equal(
+    manifest.devDependencies,
+    undefined,
+    "package.json declares devDependencies — the type checker is meant to be installed transiently by the typecheck script, so a clone still needs no install to run `npm test`",
+  );
+});

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -183,7 +183,18 @@ const ARGV = process.argv.slice(2);
  * of a competitor, and an absence is what a short read cannot establish — so it is refused, not
  * warned, with its own message so a capped read stays distinguishable from a failed one (issue #69).
  */
-function refuseIfCapped(reads: { truncated?: boolean }[], what: string): void {
+/**
+ * A page-capped read cannot support "no competing pull request", so it is a refusal, not a warning.
+ *
+ * `truncated` is REQUIRED, not optional, and that is the whole point of the signature. It used to be
+ * `truncated?: boolean`, which silently accepted the keyword-hit short-circuit below — a synthesised
+ * `{ ok: true, urls: [] }` carrying no flag at all. That read as "not truncated" because `undefined`
+ * is falsy. The behaviour was right by accident (the short-circuit's verdict comes from `pulls`,
+ * which IS checked here), but the type let a reader omit the flag and get a pass, which is the
+ * "truncated success silently disables the FATAL" shape docs/12-ledger.md names. Required means the
+ * next synthesised success has to say which it is, out loud, or it does not compile.
+ */
+function refuseIfCapped(reads: { truncated: boolean }[], what: string): void {
   if (!reads.some((r) => r.truncated)) return;
   console.error(
     `${what}: a competing-work read stopped at the ${MAX_LIST_PAGES}-page cap, so "no competing pull request" is not a fact this run can assert. Narrow the target or raise the cap deliberately.`,
@@ -388,7 +399,7 @@ async function tickWithGithub(state: FactoryState) {
       // without spending a timeline call per issue.
       const keywordHit = findCompetingPull(pulls.pulls, issue.number, issue.url, repo.id);
       const crossRefs = keywordHit
-        ? { ok: true as const, urls: [] as string[] }
+        ? { ok: true as const, urls: [] as string[], truncated: false }
         : await listCrossReferencingOpenPulls(repo.id, issue.number);
       if (!crossRefs.ok) {
         console.error(crossRefs.error);
@@ -558,7 +569,7 @@ async function main() {
         packetForFreeze.issueUrl,
         packetForFreeze.repoId,
       )
-        ? { ok: true as const, urls: [] as string[] }
+        ? { ok: true as const, urls: [] as string[], truncated: false }
         : await listCrossReferencingOpenPulls(packetForFreeze.repoId, packetForFreeze.issueNumber);
       if (!crossRefs.ok) {
         console.error(crossRefs.error);
@@ -1002,7 +1013,7 @@ async function main() {
     const pulls = await listOpenPulls(packet.repoId);
     const crossRefs = pulls.ok
       ? findCompetingPull(pulls.pulls, packet.issueNumber, packet.issueUrl, packet.repoId)
-        ? { ok: true as const, urls: [] as string[] }
+        ? { ok: true as const, urls: [] as string[], truncated: false }
         : await listCrossReferencingOpenPulls(packet.repoId, packet.issueNumber)
       : pulls;
     if (!pulls.ok || !crossRefs.ok) {

--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -68,6 +68,7 @@ import { seedState } from "./seed.ts";
 import { asOpenSubmitted, wave1Packet, withOpenSubmittedWave1 } from "./seed-fixtures.ts";
 import { loadFactoryState } from "./state.ts";
 import type { LiveIssue as ScoutIssue } from "./github-scout.ts";
+import type { EvidenceManifest } from "./types.ts";
 import { INFLIGHT_STATUSES, inflightCount, type FactoryState } from "./types.ts";
 
 function blank(): FactoryState {
@@ -2981,7 +2982,15 @@ function boundWitness(
   };
 }
 
-function manifestWith(witness: unknown, extra: Record<string, unknown> = {}) {
+/**
+ * A manifest carrying an arbitrary `witness`, INCLUDING a malformed one. The parameter is `unknown`
+ * on purpose: most callers here hand it something the validator must reject — wrong provider, wrong
+ * subject, identical log hashes, a missing field — and a fixture that could only build valid
+ * witnesses could not test a single refusal. The cast on the return is the boundary where that
+ * intent meets the typed API, and it is safe precisely because `applyAttachEvidence` re-validates
+ * shape at runtime; that re-validation is what these tests are checking.
+ */
+function manifestWith(witness: unknown, extra: Record<string, unknown> = {}): EvidenceManifest {
   return {
     baseSha: BASE,
     headSha: HEAD,
@@ -2991,7 +3000,8 @@ function manifestWith(witness: unknown, extra: Record<string, unknown> = {}) {
     filesChanged: 1,
     diffLines: 1,
     notes: [],
-    witness,
+    // Cast here, not at the call sites: see this function's docblock. Callers pass junk on purpose.
+    witness: witness as EvidenceManifest["witness"],
     ...extra,
   };
 }

--- a/factory/engine.ts
+++ b/factory/engine.ts
@@ -407,8 +407,17 @@ export function isPlaceholderSha(sha: string | undefined): boolean {
   return !isBoundSha(sha);
 }
 
-/** Full SHA-1, not abbreviated, not a known fake, not a single repeated nibble. */
-export function isBoundSha(sha: string | undefined): boolean {
+/**
+ * Full SHA-1, not abbreviated, not a known fake, not a single repeated nibble.
+ *
+ * A type PREDICATE, not a `boolean`, and the difference is load-bearing rather than cosmetic. As a
+ * plain boolean it narrowed nothing, so `applyAttachDraft` had to write `opts.headSha!` twice —
+ * non-null assertions standing exactly where the guard above them had already established the
+ * fact. A `!` is an instruction to the compiler to stop checking, and two of them sat on the path
+ * that binds an external PR to a packet. Now the guard does the narrowing it was always doing at
+ * runtime, and the assertions are gone rather than trusted.
+ */
+export function isBoundSha(sha: string | undefined): sha is string {
   if (!sha) return false;
   const s = sha.trim().toLowerCase();
   if (s === "origin/head" || s.startsWith("deadbeef")) return false;
@@ -879,8 +888,8 @@ export function applyAttachDraft(
   if (!isBoundSha(opts.headSha)) {
     return { state, error: "PR head SHA is required and must match reviewed evidence" };
   }
-  if (!isBoundSha(expected) || opts.headSha!.toLowerCase() !== expected.toLowerCase()) {
-    return { state, error: `PR head ${opts.headSha!.slice(0, 7)} does not match evidence head` };
+  if (!isBoundSha(expected) || opts.headSha.toLowerCase() !== expected.toLowerCase()) {
+    return { state, error: `PR head ${opts.headSha.slice(0, 7)} does not match evidence head` };
   }
   const linked = `${opts.title ?? ""}\n${opts.body ?? ""}`;
   if (!mentionsIssue(linked, packet.issueNumber, packet.issueUrl, packet.repoId)) {

--- a/factory/run-tests.test.ts
+++ b/factory/run-tests.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { tmp } from "./tmp-dir.ts";
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+
+/**
+ * The suite's own oracle depends on one property the type definitions do not admit exists.
+ *
+ * `factory/run-tests.ts` refuses a run in which any file reported zero tests or any failing test,
+ * and it reads the failure count from `node:test`'s `test:summary` event as `counts.failed`.
+ * `@types/node` (checked through 24.9.2) omits `failed` from that shape, so the source carries a
+ * narrow cast. A cast is a promise to the compiler, and an unchecked promise about the one field the
+ * whole suite's verdict rests on is worth nothing.
+ *
+ * So the promise is checked at runtime. If a future Node drops or renames `failed`, this reds —
+ * loudly, here — instead of `run-tests.ts` silently reading `undefined`, evaluating `undefined > 0`
+ * as false, and reporting a suite that has failures as green.
+ *
+ * SPAWNED, not run in-process. `node:test`'s `run()` called from inside a test emits no per-file
+ * summary — attempted first, and it reported zero summaries rather than one. A child process is
+ * also the honest shape: it observes what the real oracle observes, in the same conditions.
+ *
+ * The probe is written to a FILE rather than passed with `--eval`, and that is not incidental.
+ * Under `--input-type=module --eval`, `run({ files: [...] })` emits no per-file summary at all —
+ * confirmed against a working file-based probe side by side. Two false negatives came out of that
+ * before the cause was clear: first `process.argv` shifts under `--eval` so the path was
+ * `undefined`, and then even with the path supplied by environment the eval form still emitted
+ * nothing. Both looked identical to "the property is missing", which is precisely the wrong
+ * conclusion for this test to reach by accident.
+ */
+const PROBE = `
+import { run } from "node:test";
+const counts = [];
+const stream = run({ files: [process.env.PROBE_FILE], concurrency: false });
+stream.on("test:summary", (e) => { if (typeof e.file === "string") counts.push(e.counts); });
+stream.on("data", () => {});
+stream.on("end", () => { process.stdout.write(JSON.stringify(counts)); });
+`;
+
+test("node:test's per-file summary really carries a numeric `failed` count", () => {
+  // `ids.test.ts` is the probe target: fast, no scratch-dir dependency, and a file the oracle
+  // accounts for anyway.
+  const probePath = join(tmp("foundry-oracle-probe"), "probe.mjs");
+  writeFileSync(probePath, PROBE);
+  // `NODE_TEST_CONTEXT` must be DELETED, not blanked. Node keys "am I inside a test file?" on the
+  // variable's presence, so an inherited one makes the child print `run() is being called
+  // recursively within a test file. skipping running files.` and emit nothing — the third false
+  // negative this test produced before the cause was found, and again indistinguishable from the
+  // property being absent. Setting it to "" is still setting it.
+  const childEnv: Record<string, string | undefined> = { ...process.env, PROBE_FILE: "factory/ids.test.ts" };
+  delete childEnv.NODE_TEST_CONTEXT;
+  const out = execFileSync(process.execPath, ["--experimental-strip-types", probePath], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+    env: childEnv,
+  });
+  const summaries = JSON.parse(out) as Record<string, unknown>[];
+
+  assert.equal(summaries.length, 1, `expected one per-file summary, got ${summaries.length}: ${out}`);
+  const counts = summaries[0]!;
+  assert.ok(
+    "failed" in counts,
+    `test:summary counts has no \`failed\` key — run-tests.ts reads it to decide the suite verdict. Keys present: ${Object.keys(counts).sort().join(", ")}`,
+  );
+  assert.equal(
+    typeof counts.failed,
+    "number",
+    `test:summary \`failed\` is ${typeof counts.failed}, not a number — the oracle's \`failed > 0\` comparison would be meaningless`,
+  );
+  // ...and the other field the oracle reads, for the same reason.
+  assert.equal(typeof counts.tests, "number");
+  assert.ok((counts.tests as number) > 0, "the probe target reported zero tests, so this proves nothing");
+});

--- a/factory/run-tests.test.ts
+++ b/factory/run-tests.test.ts
@@ -25,6 +25,14 @@ const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
  * summary — attempted first, and it reported zero summaries rather than one. A child process is
  * also the honest shape: it observes what the real oracle observes, in the same conditions.
  *
+ * The probe target is a generated `.mjs` file, NOT one of this repository's own `.ts` test files,
+ * and that is the fix for a real portability failure rather than a stylistic choice. Pointing it at
+ * `factory/ids.test.ts` passed locally on Node 24 and FAILED on the declared floor 22.6.0 in CI with
+ * "expected one per-file summary, got 0": `run()` spawns its own child per file, and whether
+ * `--experimental-strip-types` reaches that grandchild differs by version. So the probe would have
+ * been reporting Node's flag propagation, not the property under test. Plain JavaScript needs no
+ * flag and the question becomes version-independent.
+ *
  * The probe is written to a FILE rather than passed with `--eval`, and that is not incidental.
  * Under `--input-type=module --eval`, `run({ files: [...] })` emits no per-file summary at all —
  * confirmed against a working file-based probe side by side. Two false negatives came out of that
@@ -43,18 +51,20 @@ stream.on("end", () => { process.stdout.write(JSON.stringify(counts)); });
 `;
 
 test("node:test's per-file summary really carries a numeric `failed` count", () => {
-  // `ids.test.ts` is the probe target: fast, no scratch-dir dependency, and a file the oracle
-  // accounts for anyway.
-  const probePath = join(tmp("foundry-oracle-probe"), "probe.mjs");
+  const dir = tmp("foundry-oracle-probe");
+  const probePath = join(dir, "probe.mjs");
+  // A trivial, flag-free target with a known non-zero test count.
+  const targetPath = join(dir, "target.test.mjs");
+  writeFileSync(targetPath, 'import test from "node:test";\ntest("a", () => {});\ntest("b", () => {});\n');
   writeFileSync(probePath, PROBE);
   // `NODE_TEST_CONTEXT` must be DELETED, not blanked. Node keys "am I inside a test file?" on the
   // variable's presence, so an inherited one makes the child print `run() is being called
   // recursively within a test file. skipping running files.` and emit nothing — the third false
   // negative this test produced before the cause was found, and again indistinguishable from the
   // property being absent. Setting it to "" is still setting it.
-  const childEnv: Record<string, string | undefined> = { ...process.env, PROBE_FILE: "factory/ids.test.ts" };
+  const childEnv: Record<string, string | undefined> = { ...process.env, PROBE_FILE: targetPath };
   delete childEnv.NODE_TEST_CONTEXT;
-  const out = execFileSync(process.execPath, ["--experimental-strip-types", probePath], {
+  const out = execFileSync(process.execPath, [probePath], {
     cwd: REPO_ROOT,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "ignore"],

--- a/factory/run-tests.ts
+++ b/factory/run-tests.ts
@@ -42,7 +42,17 @@ async function main(): Promise<void> {
   stream.on("test:summary", (event) => {
     // The run-wide summary carries no `file`; only the per-file ones do.
     if (typeof event.file !== "string") return;
-    perFile.set(event.file, { tests: event.counts.tests, failed: event.counts.failed });
+    /**
+     * `counts.failed` is real and this cast is a TYPES gap, not a guess. `@types/node` (checked
+     * through 24.9.2) omits `failed` from the `test:summary` counts while the runtime emits it —
+     * verified directly: the event carries
+     * `{tests,failed,passed,cancelled,skipped,todo,topLevel,suites}`. Casting rather than reaching
+     * for `any` keeps the other seven fields checked, and `run-tests.test.ts` pins the runtime
+     * property so that if Node ever DOES drop it, a test says so instead of this file silently
+     * reading `undefined` and reporting every file as having zero failures.
+     */
+    const counts = event.counts as typeof event.counts & { failed: number };
+    perFile.set(event.file, { tests: counts.tests, failed: counts.failed });
   });
 
   // `pipe()` returns the destination, not a promise — await the transfer itself, or the checks

--- a/factory/state.test.ts
+++ b/factory/state.test.ts
@@ -138,7 +138,7 @@ test("v6 ledger missing later-required fields is migrated, not stranded", () => 
   const scout = { ...(packet.scout as Record<string, unknown>) };
   delete scout.parts;
   packet.scout = scout;
-  const row = { ...(seed.scorecard[0] as Record<string, unknown>) };
+  const row = { ...(seed.scorecard[0] as unknown as Record<string, unknown>) };
   delete row.closedUnmerged;
   delete row.lastTouch;
   const path = join(tmp("foundry-"), "old-v6.json");

--- a/factory/terminal.test.ts
+++ b/factory/terminal.test.ts
@@ -395,8 +395,23 @@ test("every operator entry point installs the terminal boundary — driven, not 
   const scripts = Object.values(
     JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8")).scripts as Record<string, string>,
   );
+  /**
+   * YAML comments are stripped, for the same reason `factory/ci.test.ts` strips them before its
+   * own matching — except this guard fails in the OPPOSITE direction, which is how the omission
+   * was found. There, a comment could satisfy a check. Here, a comment could INVENT an entry
+   * point: a `ci.yml` note reading "`factory/ci.test.ts` asserts this" made a test file a
+   * "discovered entry point" and demanded a drive for something no workflow executes.
+   *
+   * Stripping cannot weaken detection. A real entry point is named on a `run:` line; a name that
+   * appears only inside a `#` comment is prose about a file, not an invocation of it.
+   */
+  const stripYamlComments = (text: string) =>
+    text
+      .split("\n")
+      .filter((line) => !/^\s*#/.test(line))
+      .join("\n");
   const workflows = readdirSync(join(REPO_ROOT, ".github/workflows")).map((f) =>
-    readFileSync(join(REPO_ROOT, ".github/workflows", f), "utf8"),
+    stripYamlComments(readFileSync(join(REPO_ROOT, ".github/workflows", f), "utf8")),
   );
   /**
    * `_`, `.` and `/` are in the class because they were not, and the omission was the second hole
@@ -421,6 +436,22 @@ test("every operator entry point installs the terminal boundary — driven, not 
       `${shape} is invisible to entry-point discovery, so it could ship without the boundary`,
     );
   }
+
+  // ...and the comment stripping, pinned in BOTH directions. A `#` line must not invent an entry
+  // point, and a real `run:` line must still produce one — a stripper that ate everything would
+  // make this whole guard vacuous and the assertion above would not notice.
+  const commented = "jobs:\n  x:\n    steps:\n      # see factory/phantom.ts for why\n      - run: npm test\n";
+  assert.deepEqual(
+    [...stripYamlComments(commented).matchAll(ENTRY_POINT)].map((m) => m[1]),
+    [],
+    "a file named only inside a YAML comment must not be discovered as an entry point",
+  );
+  const real = "jobs:\n  x:\n    steps:\n      - run: node --experimental-strip-types factory/real.ts\n";
+  assert.deepEqual(
+    [...stripYamlComments(real).matchAll(ENTRY_POINT)].map((m) => m[1]),
+    ["real.ts"],
+    "stripping comments must not hide an entry point that a run: line actually invokes",
+  );
 
   /**
    * The one exemption, and it is not an operator surface. `run-tests.ts` pipes `node:test`'s own

--- a/factory/terminal.test.ts
+++ b/factory/terminal.test.ts
@@ -408,7 +408,13 @@ test("every operator entry point installs the terminal boundary — driven, not 
   const stripYamlComments = (text: string) =>
     text
       .split("\n")
-      .filter((line) => !/^\s*#/.test(line))
+      // Whole-line comments go, and so does the tail of an INLINE one — review round 1 caught that
+      // stripping only full lines left `- run: npm test  # see factory/phantom.ts` discoverable,
+      // which is the same false positive one character further along. `(^|\s)#` is YAML's own rule:
+      // a `#` starts a comment at line start or after whitespace, so a `#` inside a token (a URL
+      // fragment, a colour) is left alone.
+      .map((line) => line.replace(/(^|\s)#.*$/, ""))
+      .filter((line) => line.trim().length > 0)
       .join("\n");
   const workflows = readdirSync(join(REPO_ROOT, ".github/workflows")).map((f) =>
     stripYamlComments(readFileSync(join(REPO_ROOT, ".github/workflows", f), "utf8")),
@@ -441,6 +447,12 @@ test("every operator entry point installs the terminal boundary — driven, not 
   // point, and a real `run:` line must still produce one — a stripper that ate everything would
   // make this whole guard vacuous and the assertion above would not notice.
   const commented = "jobs:\n  x:\n    steps:\n      # see factory/phantom.ts for why\n      - run: npm test\n";
+  const inlineCommented = "jobs:\n  x:\n    steps:\n      - run: npm test  # see factory/phantom.ts for why\n";
+  assert.deepEqual(
+    [...stripYamlComments(inlineCommented).matchAll(ENTRY_POINT)].map((m) => m[1]),
+    [],
+    "a file named in an INLINE YAML comment must not be discovered either",
+  );
   assert.deepEqual(
     [...stripYamlComments(commented).matchAll(ENTRY_POINT)].map((m) => m[1]),
     [],

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=22"
+    "node": ">=22.6.0"
   },
   "scripts": {
     "test": "node --experimental-strip-types factory/run-tests.ts",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=22.6.0"
+    "node": ">=22.10.0"
   },
   "scripts": {
     "test": "node --experimental-strip-types factory/run-tests.ts",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "test": "node --experimental-strip-types factory/run-tests.ts",
     "validate": "node --experimental-strip-types factory/validate-allowlist.ts",
-    "foundry": "node --experimental-strip-types factory/cli.ts"
+    "foundry": "node --experimental-strip-types factory/cli.ts",
+    "typecheck": "npm install --no-save --no-package-lock typescript@5.9.3 @types/node@24.9.2 && ./node_modules/.bin/tsc --noEmit"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,47 @@
+{
+  // TYPE CHECKING ONLY. Nothing here emits: `node --experimental-strip-types` runs the `.ts` files
+  // directly and this config exists so that something, somewhere, actually reads the types it
+  // erases. Node's own docs are explicit that type stripping performs no checking and ignores
+  // tsconfig.json entirely, so before this file 9,639 lines of TypeScript were enforced by review
+  // alone — which is why `factory/state.ts` hand-writes ~200 lines of runtime validators to
+  // re-derive at runtime what a compiler proves statically.
+  //
+  // Run by CI via a pinned `npx typescript@<version> tsc --noEmit`, NOT as a dependency: this
+  // repository's zero-dependency property is deliberate and CI-documented, and typescript 7.x ships
+  // platform-specific native optional dependencies, so a devDependency would import a real supply
+  // chain and a platform-sensitive lockfile for a check that never ships.
+  "compilerOptions": {
+    "noEmit": true,
+    "strict": true,
+    "target": "ES2023",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "lib": ["ES2024"],  // Promise.withResolvers, used in factory/witness.ts
+    "types": ["node"],
+    "skipLibCheck": true,
+
+    // Imports here are written `./foo.ts`, with the extension, because that is what Node requires
+    // at runtime. Plain tsc rejects that without this flag.
+    "allowImportingTsExtensions": true,
+
+    // The two flags that make this gate earn its keep beyond ordinary type errors, both recommended
+    // by Node's own TypeScript documentation for exactly this setup:
+    //
+    // `erasableSyntaxOnly` rejects enums, runtime namespaces, parameter properties and import
+    // aliases — the syntax type stripping cannot handle. Node 26 REMOVED the
+    // `--experimental-transform-types` escape hatch that used to cover it, so this is now the only
+    // thing standing between a well-meaning `enum` and a runtime failure on current Node. The tree
+    // is clean today; this keeps it that way.
+    "erasableSyntaxOnly": true,
+    // `verbatimModuleSyntax` catches the import-elision hazard: a type imported without the `type`
+    // keyword is treated as a value import and throws at runtime under stripping.
+    "verbatimModuleSyntax": true,
+
+    // NOT enabled: `noUncheckedIndexedAccess`. It produces 300+ findings, almost all of them
+    // `arr[0]` in test fixtures, and turning it on is its own piece of work rather than a rider on
+    // installing the gate. Filed rather than silently skipped.
+    "noImplicitOverride": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["factory/**/*.ts", "scripts/**/*.ts"]
+}


### PR DESCRIPTION
**P1 — Green baseline.** `T-01`…`T-04`. First phase with write access to source.

## The Node floor was a claim, not a guard

`engines.node` read `>=22` while every documented command passes `--experimental-strip-types`, a flag that does not exist before **22.6.0**. A stranger on 22.4 satisfied the declared floor and got `node: bad option:`.

Floor is now `>=22.6.0` — the truthful minimum, not a round number. **The plan called for a runtime `process.versions.node` check and I did not add one**: Node rejects an unknown option *before* executing anything (verified — `node --experimental-bogus-flag -e 'console.log(1)'` runs no code), so on exactly the versions the floor excludes, no in-process check can run. It would have been unreachable dead code.

What is enforceable instead: CI **executes** the floor. `ci.yml` runs a matrix of `22.6.0` and `24`, each proving what the other cannot — the floor proves the manifest claim; 24 is Active LTS and the only line where type stripping is Stable rather than a release candidate. A test asserts the matrix contains the declared floor, and that every script still passes the flag (if one stopped, the real floor would jump to 22.18.0 and the manifest would be silently wrong).

## Nothing had ever read the types

Type stripping erases without checking and ignores `tsconfig.json`. The gate is **CI-only, installed transiently** — `npm install --no-save --no-package-lock`, both versions pinned — so `package.json` keeps zero dependencies and the repo keeps no lockfile. That property is deliberate and tested: a clone needs nothing to run `npm test`. `typescript@5.9.3` over 7.x because 7 ships platform-specific native optional deps.

Two options do real work beyond type errors, both recommended by Node's own docs for this setup: **`erasableSyntaxOnly`** rejects enums, runtime namespaces and parameter properties — the syntax Node 26 removed the escape hatch for — and **`verbatimModuleSyntax`** catches a type imported as a value, which throws at runtime under stripping.

### Six real findings in non-test source

| finding | why it mattered |
|---|---|
| `isBoundSha` returned `boolean`, narrowing nothing — so `applyAttachDraft` carried **two non-null assertions** standing where the guard above had already established the fact | a `!` tells the compiler to stop checking, and both sat on the path that binds an external PR to a packet. Now a type predicate; assertions gone |
| `refuseIfCapped` took `truncated?: boolean`, silently accepting a synthesised `{ok:true, urls:[]}` with **no flag at all** | `undefined` reads as not-truncated. Behaviour was right by accident (that path's verdict comes from `pulls`, which *is* checked) but the type permitted the "truncated success silently disables the FATAL" shape `docs/12-ledger.md` names. Required now; all three call sites say `truncated: false` out loud |
| `run-tests.ts` reads `counts.failed` to decide the **whole suite's verdict**; `@types/node` omits it through 24.9.2 | verified real and numeric at runtime; narrow cast + a new `run-tests.test.ts` that pins the runtime property, so if Node drops it a test reds instead of the oracle silently reading `undefined` and reporting every file as zero failures |
| `Promise.withResolvers` needed `lib: ES2024` | config |
| two fixture/cast smells in tests | typed properly, not silenced |

## Gate proven, not asserted

Five negative controls, each caught: a plain type error, an `enum`, a runtime `namespace`, a parameter property, and a value-import of a type. Tree clean either side.

**Worth recording: the first "0 errors" was fake.** `npx tsc` had resolved to a squatter package that prints *"This is not the tsc command you are looking for"*, because an earlier `--no-save` install had pruned typescript. The negative controls are what caught it — a gate reporting zero because it checked nothing is worse than no gate.

## Two self-inflicted findings, recorded

- My verification chain ended in `|| echo`, which swallowed a non-zero suite exit and let a **red commit** through. Fixed in the next commit; the mechanism is worth naming.
- The floor guard's `\bnode\b` matched `@types/node@24.9.2` (`/` and `@` are both word boundaries) and demanded a strip-types flag from an `npm install`. Now anchored to a command position and pinned in both directions.

## One unplanned fix this surfaced

The terminal-boundary guard discovers entry points by scanning workflow text and **did not strip YAML comments** — so a `ci.yml` comment naming `factory/ci.test.ts` turned a test file into a "discovered entry point". `ci.test.ts` already strips comments for the mirror-image reason; this guard failed in the opposite direction, *inventing* an entry point. Stripping cannot weaken it, and the pin now asserts both directions. **Negative control:** pointing a `run:` line at a real uninstalled entry point still reds the suite.

## How verified

- suite **383/383** across 20 files (was 379/19)
- type check **0 errors** over 50 files, five negative controls
- `npm run validate` green
- greptile: 1 round, confidence **5/5**, 0 findings
- evidence: `T-01-version-floor.txt`, `T-02-typecheck.txt`, `T-04-gitignore.txt`

## Note

`private: true` on a public MIT repo is **kept** — it is a correct npm-publish guard for a repo that should never be published. `T-25` documents it in the README rather than leaving it looking like a mistake.






<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR establishes a tested Node runtime floor and adds a transient CI type-check gate while tightening several TypeScript contracts.
- Runs CI on Node 22.10.0 and Node 24.
- Adds strict type-check configuration and negative controls.
- Refines truncation metadata, SHA narrowing, test-runner accounting, and terminal-entry-point discovery.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds the runtime matrix, timeout, and type-check step without introducing a blocking failure. |
| factory/ci.test.ts | Enforces the declared runtime floor and transient type-check setup. |
| factory/terminal.test.ts | Completes the reported inline-comment case; no blocking failure remains. |
| factory/run-tests.ts | Types and preserves the runtime failed-test count used by the suite oracle. |
| factory/cli.ts | Makes truncation state mandatory at competition-read call sites. |
| tsconfig.json | Defines a no-emit Node-oriented strict type-check configuration. |

</details>

<sub>Reviews (3): Last reviewed commit: ["build: the real Node floor is 22.10.0, s..."](https://github.com/ravidsrk/oss-foundry/commit/7deca78c73ec101afe59f4d27133f8993d345f2f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59056051)</sub>

**Context used:**

- Knowledge Base — [Quality gates and scorecards](https://app.greptile.com/heycmo/-/custom-context/knowledge-base/ravidsrk/oss-foundry/-/docs/quality-gates-and-scorecards.md)
- Knowledge Base — [Automation and maintenance workflows](https://app.greptile.com/heycmo/-/custom-context/knowledge-base/ravidsrk/oss-foundry/-/docs/automation-and-maintenance-workflows.md)

<!-- /greptile_comment -->