### PR TITLE
P2: pin the GitHub API version and surface the primary rate limit

### DIFF
--- a/docs/completion/evidence/T-09-api-version.txt
+++ b/docs/completion/evidence/T-09-api-version.txt
@@ -1,0 +1,59 @@
+### T-09 — pin X-GitHub-Api-Version: 2022-11-28 (G-04)
+
+Pinned in `githubApiHeaders` as `GITHUB_API_VERSION`, after the extra-header spread so a
+caller cannot drop it. `createDraftPull` builds headers inline (FOUNDRY_PAT must win over
+GITHUB_TOKEN) so it sets the same named constant itself.
+
+Why this version: `2026-03-10` removes `merge_commit_sha` from every PR payload. This code
+copies that field at `syncGithubPr` onto `PrMeta.mergeCommitSha`, the sole input to
+`classifyRevert`. When the unversioned default rolls forward, revert detection stops
+silently and `reverts > 0` stops forcing `health=stop`. `2022-11-28` is supported until
+2028-03-10.
+
+--- header the client now sends ---
+
+  "X-GitHub-Api-Version": GITHUB_API_VERSION   // "2022-11-28"
+
+--- 11 call sites, each observed carrying the pin ---
+
+  listOpenPulls
+  listCrossReferencingOpenPulls
+  fetchIssueState
+  fetchIssueClosingRef
+  fetchRepoFile
+  compareCommits
+  fetchHumanReview
+  listCommitsSince
+  revertCheck
+  syncGithubPr
+  createDraftPull
+
+Test: "every GitHub fetch carries X-GitHub-Api-Version 2022-11-28"
+  enumerates the 11 sites through the injected fetchImpl seam; asserts every request's
+  X-GitHub-Api-Version is the literal "2022-11-28" (not read out of the constant);
+  also asserts extra headers cannot override the pin.
+
+$ node --experimental-strip-types --test --test-name-pattern 'every GitHub fetch carries X-GitHub-Api-Version' factory/github-pr.test.ts
+  ✔ every GitHub fetch carries X-GitHub-Api-Version 2022-11-28
+  tests 1 / pass 1 / fail 0
+
+--- NEGATIVE CONTROL 1: drop both pin sites (githubApiHeaders + createDraftPull) ---
+
+  removed 2 pin lines
+  ✖ every GitHub fetch carries X-GitHub-Api-Version 2022-11-28
+  AssertionError: a caller must not be able to drop the pin via extra headers
+    actual: '2026-03-10'
+    expected: '2022-11-28'
+  EXIT:1
+  restored
+
+--- NEGATIVE CONTROL 2: drop only the createDraftPull pin (proves enumeration, not just githubApiHeaders) ---
+
+  T-09b: dropped createDraftPull pin only
+  ✖ every GitHub fetch carries X-GitHub-Api-Version 2022-11-28
+  AssertionError: requests missing the pin: [{"name":"createDraftPull","version":null}]
+  EXIT:1
+  restored
+
+$ npm test
+  suite ok — 382 tests across 19 files, every file accounted for

--- a/docs/completion/evidence/T-21-rate-limit.txt
+++ b/docs/completion/evidence/T-21-rate-limit.txt
@@ -1,0 +1,56 @@
+### T-21 — detect primary rate limit; warn when unauthenticated (G-10)
+
+Primary quota exhaustion is now a distinct error: a 403 or 429 with
+`x-ratelimit-remaining: 0` reports the resource, the ceiling, remaining 0, and the reset
+as ISO-8601 (unix-seconds `x-ratelimit-reset`). `retry-after` is named when present.
+No retries are added.
+
+Ceilings documented in `factory/github-pr.ts` (they appeared nowhere in the repo):
+  authenticated PAT: 5,000 requests/hour
+  unauthenticated:      60 requests/hour
+  measured spend:     ~19 requests/tick
+  so an unauthenticated hour fails on the fourth tick.
+
+Secondary-limit handling is unchanged: a 403/429 whose body matches /secondary rate limit/i
+still returns `{halt: true}` and is checked BEFORE the primary remaining-0 path, including
+when primary headers are also present.
+
+Unauthenticated reads (neither GITHUB_TOKEN nor GH_TOKEN): warn once via console.error.
+The token is not mandatory; GITHUB_TOKEN or GH_TOKEN suppresses the warning.
+
+--- simulated exhausted quota (listOpenPulls, x-ratelimit-remaining: 0, reset 1770000000) ---
+
+  GitHub primary rate limit exhausted (core: 5000 requests/hour, remaining 0, resets 2026-02-02T02:40:00.000Z) listing pulls on ravidsrk/orca-fleet
+
+  Ordinary 403 without remaining-0 stays:
+  GitHub 403 listing pulls on ravidsrk/orca-fleet
+
+Tests (driven through fetchImpl):
+  ✔ primary rate limit exhaustion is distinguishable from an ordinary 403
+  ✔ unauthenticated GitHub reads warn once, and stay quiet when a token is set
+
+$ node --experimental-strip-types --test --test-name-pattern 'primary rate limit|unauthenticated GitHub reads' factory/github-pr.test.ts
+  ✔ primary rate limit exhaustion is distinguishable from an ordinary 403
+  ✔ unauthenticated GitHub reads warn once, and stay quiet when a token is set
+  tests 2 / pass 2 / fail 0
+
+--- NEGATIVE CONTROL 1: primaryRateLimitMessage always returns undefined ---
+
+  T-21a: primaryRateLimitMessage always undefined
+  ✖ primary rate limit exhaustion is distinguishable from an ordinary 403
+  AssertionError: The input did not match /primary rate limit exhausted/i
+  Input: 'GitHub 403 listing pulls on ravidsrk/orca-fleet'
+  EXIT:1
+  restored
+
+--- NEGATIVE CONTROL 2: skip the unauthenticated warning ---
+
+  T-21b: unauthenticated warning skipped
+  ✖ unauthenticated GitHub reads warn once, and stay quiet when a token is set
+  AssertionError: the warning must fire once per process, not once per request
+  0 !== 1
+  EXIT:1
+  restored
+
+$ npm test
+  suite ok — 382 tests across 19 files, every file accounted for

--- a/factory/github-pr.test.ts
+++ b/factory/github-pr.test.ts
@@ -16,11 +16,16 @@ import {
   nextPageUrl,
   revertCheck,
   syncGithubPr,
+  githubApiHeaders,
   githubRequestInit,
   githubFetchTimeoutMs,
+  GITHUB_API_VERSION,
+  GITHUB_AUTHENTICATED_RATE_LIMIT_PER_HOUR,
+  GITHUB_UNAUTHENTICATED_RATE_LIMIT_PER_HOUR,
   GITHUB_FETCH_TIMEOUT_MS,
   GITHUB_FETCH_TIMEOUT_MAX_MS,
   MAX_LIST_PAGES,
+  resetUnauthenticatedGithubWarning,
 } from "./github-pr.ts";
 import { REVERT_WINDOW_DAYS } from "./scorecard.ts";
 
@@ -1072,4 +1077,235 @@ test("#113: a truthy invalid FOUNDRY_GITHUB_TIMEOUT_MS falls back to the shipped
     else process.env.FOUNDRY_GITHUB_TIMEOUT_MS = prev;
   }
   assert.doesNotThrow(() => githubRequestInit({}, Number.POSITIVE_INFINITY));
+});
+
+/**
+ * G-04 / T-09. The pin is the whole fix: without `X-GitHub-Api-Version` every request inherits
+ * GitHub's rolling default, and version `2026-03-10` removes `merge_commit_sha` — the field
+ * `syncGithubPr` copies onto `PrMeta.mergeCommitSha` and the sole input to `classifyRevert`.
+ * A test that only inspects `githubApiHeaders()` would miss `createDraftPull`, which builds
+ * its headers inline, so this enumerates every shipped GitHub call site and asserts the header
+ * on the request that actually left. The version string is written here, not read out of the
+ * constant, for the same reason the page-cap test writes `10`.
+ */
+test("every GitHub fetch carries X-GitHub-Api-Version 2022-11-28", async () => {
+  assert.equal(GITHUB_API_VERSION, "2022-11-28");
+  assert.equal(
+    githubApiHeaders({ "X-GitHub-Api-Version": "2026-03-10" })["X-GitHub-Api-Version"],
+    "2022-11-28",
+    "a caller must not be able to drop the pin via extra headers",
+  );
+
+  const seen: { name: string; version: string | null }[] = [];
+  const tracking =
+    (name: string): typeof fetch =>
+    async (_url, init) => {
+      seen.push({ name, version: new Headers(init?.headers).get("X-GitHub-Api-Version") });
+      return jsonResponse(200, []);
+    };
+
+  const sites: { name: string; run: (f: typeof fetch) => Promise<unknown> }[] = [
+    { name: "listOpenPulls", run: (f) => listOpenPulls("ravidsrk/orca-fleet", f) },
+    {
+      name: "listCrossReferencingOpenPulls",
+      run: (f) => listCrossReferencingOpenPulls("ravidsrk/orca-fleet", 71, f),
+    },
+    { name: "fetchIssueState", run: (f) => fetchIssueState("ravidsrk/orca-fleet", 71, f) },
+    { name: "fetchIssueClosingRef", run: (f) => fetchIssueClosingRef("ravidsrk/orca-fleet", 71, f) },
+    { name: "fetchRepoFile", run: (f) => fetchRepoFile("ravidsrk/orca-fleet", "AGENTS.md", f) },
+    { name: "compareCommits", run: (f) => compareCommits("ravidsrk/orca-fleet", BASE, HEAD, f) },
+    { name: "fetchHumanReview", run: (f) => fetchHumanReview("ravidsrk/orca-fleet", 70, f) },
+    {
+      name: "listCommitsSince",
+      run: (f) => listCommitsSince("ravidsrk/orca-fleet", { since: "2026-08-27T07:04:52Z" }, f),
+    },
+    {
+      name: "revertCheck",
+      run: (f) =>
+        revertCheck(
+          "ravidsrk/orca-fleet",
+          { mergeCommitSha: HEAD, mergedAt: "2026-08-27T07:04:52Z", baseRef: "main" },
+          f,
+        ),
+    },
+    {
+      name: "syncGithubPr",
+      run: (f) => syncGithubPr({ url: "https://github.com/ravidsrk/orca-fleet/pull/70" }, f),
+    },
+    {
+      name: "createDraftPull",
+      run: (f) =>
+        createDraftPull(
+          "ColeMurray/background-agents",
+          { title: "t", head: "ravidsrk:b", body: "Fixes #1" },
+          f,
+          { FOUNDRY_PAT: "ghp_x" },
+        ),
+    },
+  ];
+  assert.equal(
+    sites.length,
+    11,
+    "the shipped GitHub call-site count; a new site must be added here so the pin cannot go missing on it",
+  );
+
+  for (const site of sites) await site.run(tracking(site.name));
+
+  assert.ok(seen.length >= sites.length, `expected at least one fetch per call site, got ${seen.length}`);
+  const missing = seen.filter((row) => row.version !== "2022-11-28");
+  assert.deepEqual(missing, [], `requests missing the pin: ${JSON.stringify(missing)}`);
+  const names = [...new Set(seen.map((row) => row.name))].sort();
+  assert.deepEqual(
+    names,
+    sites.map((s) => s.name).sort(),
+    "a listed call site made no request — it cannot prove it carries the pin",
+  );
+});
+
+const PRIMARY_RESET_UNIX = 1_770_000_000;
+
+function primaryLimitResponse(status: number, extra: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify({ message: "API rate limit exceeded" }), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "x-ratelimit-limit": "5000",
+      "x-ratelimit-remaining": "0",
+      "x-ratelimit-used": "5000",
+      "x-ratelimit-reset": String(PRIMARY_RESET_UNIX),
+      "x-ratelimit-resource": "core",
+      ...extra,
+    },
+  });
+}
+
+/**
+ * G-10 / T-21. A quota-exhausted 403 used to be byte-identical to any other 403 (`GitHub 403
+ * listing pulls on …`). Primary state lives in `x-ratelimit-*`; secondary limits already halt
+ * on a body match and must keep doing that — GitHub's own guidance is to back off, not retry,
+ * and this product goes further with a durable factory halt. No retries are added here.
+ */
+test("primary rate limit exhaustion is distinguishable from an ordinary 403", async () => {
+  assert.equal(GITHUB_AUTHENTICATED_RATE_LIMIT_PER_HOUR, 5_000);
+  assert.equal(GITHUB_UNAUTHENTICATED_RATE_LIMIT_PER_HOUR, 60);
+  const resetIso = new Date(PRIMARY_RESET_UNIX * 1000).toISOString();
+
+  const exhausted = await listOpenPulls("ravidsrk/orca-fleet", async () => primaryLimitResponse(403));
+  assert.equal(exhausted.ok, false);
+  if (!exhausted.ok) {
+    assert.match(exhausted.error, /primary rate limit exhausted/i);
+    assert.match(exhausted.error, /core/);
+    assert.match(exhausted.error, /5000 requests\/hour/);
+    assert.match(exhausted.error, new RegExp(resetIso.replaceAll(".", "\\.")));
+    assert.doesNotMatch(exhausted.error, /^GitHub 403 listing pulls/);
+  }
+
+  const exhausted429 = await listOpenPulls("ravidsrk/orca-fleet", async () => primaryLimitResponse(429));
+  assert.equal(exhausted429.ok, false);
+  if (!exhausted429.ok) assert.match(exhausted429.error, /primary rate limit exhausted/i);
+
+  const ordinary = await listOpenPulls("ravidsrk/orca-fleet", async () => jsonResponse(403, { message: "nope" }));
+  assert.equal(ordinary.ok, false);
+  if (!ordinary.ok) {
+    assert.match(ordinary.error, /GitHub 403 listing pulls/);
+    assert.doesNotMatch(ordinary.error, /primary rate limit/i);
+  }
+
+  const secondary = await createDraftPull(
+    "ColeMurray/background-agents",
+    { title: "t", head: "ravidsrk:b", body: "Fixes #1" },
+    async () => jsonResponse(403, { message: "You have exceeded a secondary rate limit. Please wait." }),
+    { FOUNDRY_PAT: "ghp_x" },
+  );
+  assert.equal(secondary.ok, false);
+  if (!secondary.ok) {
+    assert.equal(secondary.halt, true);
+    assert.match(secondary.error, /secondary rate limit/i);
+    assert.doesNotMatch(secondary.error, /primary rate limit/i);
+  }
+
+  // Secondary wins even when primary headers are also present — the halt path must not be
+  // reclassified as quota exhaustion.
+  const secondaryWithPrimaryHeaders = await createDraftPull(
+    "ColeMurray/background-agents",
+    { title: "t", head: "ravidsrk:b", body: "Fixes #1" },
+    async () =>
+      new Response(JSON.stringify({ message: "You have exceeded a secondary rate limit. Please wait." }), {
+        status: 403,
+        headers: {
+          "Content-Type": "application/json",
+          "x-ratelimit-remaining": "0",
+          "x-ratelimit-reset": String(PRIMARY_RESET_UNIX),
+          "x-ratelimit-resource": "core",
+        },
+      }),
+    { FOUNDRY_PAT: "ghp_x" },
+  );
+  assert.equal(secondaryWithPrimaryHeaders.ok, false);
+  if (!secondaryWithPrimaryHeaders.ok) {
+    assert.equal(secondaryWithPrimaryHeaders.halt, true);
+    assert.match(secondaryWithPrimaryHeaders.error, /HALT/i);
+  }
+
+  const quotaOnCreate = await createDraftPull(
+    "ColeMurray/background-agents",
+    { title: "t", head: "ravidsrk:b", body: "Fixes #1" },
+    async () => primaryLimitResponse(403),
+    { FOUNDRY_PAT: "ghp_x" },
+  );
+  assert.equal(quotaOnCreate.ok, false);
+  if (!quotaOnCreate.ok) {
+    assert.equal(quotaOnCreate.halt, undefined);
+    assert.match(quotaOnCreate.error, /primary rate limit exhausted/i);
+    assert.match(quotaOnCreate.error, /creating the draft/);
+  }
+});
+
+/**
+ * G-10 / T-21. Reads are silently unauthenticated when neither `GITHUB_TOKEN` nor `GH_TOKEN`
+ * is set, which drops the ceiling from 5,000/hr to 60/hr against a ~19-requests-per-tick spend.
+ * Warn once, clearly; do not make the token mandatory.
+ */
+test("unauthenticated GitHub reads warn once, and stay quiet when a token is set", async () => {
+  const prevGithub = process.env.GITHUB_TOKEN;
+  const prevGh = process.env.GH_TOKEN;
+  const origError = console.error;
+  const lines: string[] = [];
+  console.error = ((...args: unknown[]) => {
+    lines.push(args.map(String).join(" "));
+  }) as typeof console.error;
+  const unauthWarnings = () => lines.filter((l) => /unauthenticated/i.test(l));
+
+  try {
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.GH_TOKEN;
+    resetUnauthenticatedGithubWarning();
+    lines.length = 0;
+    await listOpenPulls("ravidsrk/orca-fleet", async () => jsonResponse(200, []));
+    await listOpenPulls("ravidsrk/orca-fleet", async () => jsonResponse(200, []));
+    assert.equal(unauthWarnings().length, 1, "the warning must fire once per process, not once per request");
+    assert.match(unauthWarnings()[0] ?? "", /60 requests\/hour/);
+    assert.match(unauthWarnings()[0] ?? "", /5,?000/);
+    assert.match(unauthWarnings()[0] ?? "", /GITHUB_TOKEN|GH_TOKEN/);
+
+    resetUnauthenticatedGithubWarning();
+    lines.length = 0;
+    process.env.GITHUB_TOKEN = "ghp_test";
+    await listOpenPulls("ravidsrk/orca-fleet", async () => jsonResponse(200, []));
+    assert.deepEqual(unauthWarnings(), [], "GITHUB_TOKEN must suppress the unauthenticated warning");
+
+    delete process.env.GITHUB_TOKEN;
+    process.env.GH_TOKEN = "ghp_test";
+    resetUnauthenticatedGithubWarning();
+    lines.length = 0;
+    await listOpenPulls("ravidsrk/orca-fleet", async () => jsonResponse(200, []));
+    assert.deepEqual(unauthWarnings(), [], "GH_TOKEN must suppress the unauthenticated warning");
+  } finally {
+    console.error = origError;
+    if (prevGithub === undefined) delete process.env.GITHUB_TOKEN;
+    else process.env.GITHUB_TOKEN = prevGithub;
+    if (prevGh === undefined) delete process.env.GH_TOKEN;
+    else process.env.GH_TOKEN = prevGh;
+    resetUnauthenticatedGithubWarning();
+  }
 });

--- a/factory/github-pr.ts
+++ b/factory/github-pr.ts
@@ -62,14 +62,103 @@ export function githubRequestInit(
   return { ...extra, signal: AbortSignal.timeout(githubFetchTimeoutMs(timeoutMs)) };
 }
 
+/**
+ * REST API version this client pins on every request.
+ *
+ * Unversioned requests inherit GitHub's rolling default. Version `2026-03-10`
+ * removes `merge_commit_sha` from every PR payload. This module copies that
+ * field onto `PrMeta.mergeCommitSha` in `syncGithubPr`, and that value is the
+ * sole input to `classifyRevert` — the entire revert-detection path. When the
+ * unversioned default rolls forward the field is `undefined`, `revertCheck`
+ * short-circuits on `if (!meta.mergeCommitSha)`, and revert detection stops
+ * **silently**. `reverts > 0` is what forces `health=stop`, so the failure
+ * mode is a governance gate that quietly stops firing. `2022-11-28` is
+ * supported until 2028-03-10.
+ */
+export const GITHUB_API_VERSION = "2022-11-28";
+
+/**
+ * GitHub REST **primary** (core) rate-limit ceilings. They appeared nowhere in
+ * the repo, so headroom against a measured ~19-requests-per-tick spend could
+ * not be computed (G-10 / R-05).
+ *
+ * Authenticated PAT: 5,000 requests/hour. Unauthenticated: 60/hour — the
+ * fourth tick of an hour then fails with an unexplained 403 if reads run
+ * without `GITHUB_TOKEN`/`GH_TOKEN`. Secondary limits are a different class
+ * (body matching `/secondary rate limit/i`) and already halt-and-never-retry;
+ * this module does not add retries for either class.
+ */
+export const GITHUB_AUTHENTICATED_RATE_LIMIT_PER_HOUR = 5_000;
+export const GITHUB_UNAUTHENTICATED_RATE_LIMIT_PER_HOUR = 60;
+
+let unauthenticatedGithubWarningEmitted = false;
+
+/**
+ * The unauthenticated warning is process-wide and once-only so a tick does not
+ * print 19 copies of the same ceiling. Tests reset it so they do not depend on
+ * suite order.
+ */
+export function resetUnauthenticatedGithubWarning(): void {
+  unauthenticatedGithubWarningEmitted = false;
+}
+
+function warnUnauthenticatedGithubReads(): void {
+  if (unauthenticatedGithubWarningEmitted) return;
+  unauthenticatedGithubWarningEmitted = true;
+  console.error(
+    `warning: GitHub reads are unauthenticated (neither GITHUB_TOKEN nor GH_TOKEN is set). Anonymous ceiling is ${GITHUB_UNAUTHENTICATED_RATE_LIMIT_PER_HOUR} requests/hour against a documented ~19-requests-per-tick spend, so the fourth tick of an hour fails with 403. Authenticated PAT ceiling is ${GITHUB_AUTHENTICATED_RATE_LIMIT_PER_HOUR}/hour. The token is not required; set GITHUB_TOKEN or GH_TOKEN to raise the ceiling.`,
+  );
+}
+
+/** `x-ratelimit-reset` is unix seconds; ISO is the operator-readable form. */
+function formatRateLimitReset(raw: string | null | undefined): string {
+  const n = raw == null || raw === "" ? Number.NaN : Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return "at an unknown time";
+  const ms = n < 1e12 ? n * 1000 : n;
+  const d = new Date(ms);
+  if (Number.isNaN(d.getTime())) return "at an unknown time";
+  return d.toISOString();
+}
+
+/**
+ * Primary quota exhaustion only: 403/429 with `x-ratelimit-remaining: 0`.
+ * Absent remaining is not a match — that is how an ordinary 403 stays an
+ * ordinary 403, and how a secondary-limit body is left to its own handler.
+ */
+function primaryRateLimitMessage(res: Response): string | undefined {
+  if (res.status !== 403 && res.status !== 429) return undefined;
+  const remaining = res.headers?.get("x-ratelimit-remaining");
+  if (remaining !== "0") return undefined;
+  const resource = res.headers?.get("x-ratelimit-resource") ?? "core";
+  const limit = res.headers?.get("x-ratelimit-limit");
+  const resetAt = formatRateLimitReset(res.headers?.get("x-ratelimit-reset"));
+  const retryAfter = res.headers?.get("retry-after");
+  const retry = retryAfter ? `; retry-after ${retryAfter}s` : "";
+  const ceiling =
+    limit != null && limit !== ""
+      ? `${limit} requests/hour`
+      : `${GITHUB_AUTHENTICATED_RATE_LIMIT_PER_HOUR}/hour authenticated, ${GITHUB_UNAUTHENTICATED_RATE_LIMIT_PER_HOUR}/hour unauthenticated`;
+  return `GitHub primary rate limit exhausted (${resource}: ${ceiling}, remaining 0, resets ${resetAt}${retry})`;
+}
+
+function githubHttpError(res: Response, what: string): string {
+  const primary = primaryRateLimitMessage(res);
+  if (primary) return what ? `${primary} ${what}` : primary;
+  return what ? `GitHub ${res.status} ${what}` : `GitHub ${res.status}`;
+}
+
 export function githubApiHeaders(extra: Record<string, string> = {}): Record<string, string> {
   const headers: Record<string, string> = {
     Accept: "application/vnd.github+json",
     "User-Agent": "oss-foundry",
     ...extra,
+    // Spread extra first so a caller cannot drop the pin. `Accept` may still
+    // be overridden (raw-file reads); the version may not.
+    "X-GitHub-Api-Version": GITHUB_API_VERSION,
   };
   const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
   if (token) headers.Authorization = `Bearer ${token}`;
+  else if (!headers.Authorization) warnUnauthenticatedGithubReads();
   return headers;
 }
 
@@ -195,7 +284,7 @@ export async function fetchIssueState(
       githubRequestInit({ headers: githubApiHeaders() }),
     );
     if (!res.ok) {
-      return { ok: false, error: `GitHub ${res.status} reading ${repoId}#${issueNumber}` };
+      return { ok: false, error: githubHttpError(res, `reading ${repoId}#${issueNumber}`) };
     }
     const body = (await res.json()) as {
       number?: number;
@@ -313,7 +402,10 @@ export async function compareCommits(
     if (!res.ok) {
       return {
         ok: false,
-        error: `GitHub ${res.status} comparing ${baseSha.slice(0, 7)}...${headSha.slice(0, 7)} on ${repoId}`,
+        error: githubHttpError(
+          res,
+          `comparing ${baseSha.slice(0, 7)}...${headSha.slice(0, 7)} on ${repoId}`,
+        ),
       };
     }
     const body = (await res.json()) as {
@@ -501,7 +593,7 @@ async function listAllPages<T>(
   const items: T[] = [];
   for (let page = 0; page < cap; page += 1) {
     const res = await fetchImpl(url, githubRequestInit({ headers: githubApiHeaders() }));
-    if (!res.ok) return { ok: false, error: `GitHub ${res.status} ${what}` };
+    if (!res.ok) return { ok: false, error: githubHttpError(res, what) };
     const body = await res.json();
     if (!Array.isArray(body)) return { ok: false, error: `GitHub returned a non-list ${what}` };
     items.push(...(body as T[]));
@@ -657,7 +749,7 @@ export async function syncGithubPr(data: { url: string }, fetchImpl: typeof fetc
       `https://api.github.com/repos/${parsed.owner}/${parsed.repo}/pulls/${parsed.number}`,
       githubRequestInit({ headers: githubApiHeaders() }),
     );
-    if (!res.ok) return { ok: false as const, error: `GitHub ${res.status}` };
+    if (!res.ok) return { ok: false as const, error: githubHttpError(res, "") };
     const pr = (await res.json()) as {
       html_url: string;
       title: string;
@@ -760,6 +852,7 @@ export async function createDraftPull(
           "User-Agent": "oss-foundry",
           Authorization: `Bearer ${pat}`,
           "Content-Type": "application/json",
+          "X-GitHub-Api-Version": GITHUB_API_VERSION,
         },
         body: JSON.stringify(payload),
       }),
@@ -777,6 +870,10 @@ export async function createDraftPull(
         error:
           "GitHub secondary rate limit on content creation — HALT the factory (AUP: excessive automated bulk activity). Do not retry; investigate before any further create.",
       };
+    }
+    const primary = primaryRateLimitMessage(res);
+    if (primary) {
+      return { ok: false, error: `${primary} creating the draft on ${repoId}` };
     }
     if (res.status === 403) {
       return {


### PR DESCRIPTION
**T-09** (gap G-04) and **T-21** (gap G-10).

## T-09 — an unpinned API version was a silent time bomb

`githubApiHeaders()` sent `Accept` and `User-Agent` and **no `X-GitHub-Api-Version`**, so every request inherited GitHub's rolling default.

REST API version **`2026-03-10`** removes `merge_commit_sha` from all PR payloads. This code consumes it (`github-pr.ts:695`) and it is the sole input to `classifyRevert` — the entire revert-detection path. When the default rolls forward, `merge_commit_sha` becomes `undefined`, the guard short-circuits, and **revert detection stops without a word**. `reverts > 0` is what forces a repo to `health=stop`, so the failure mode is a governance gate that quietly stops firing. `2022-11-28` is supported until 2028-03-10.

Pinned as a named constant, set **after** `extra` so a caller cannot drop it, and set again on `createDraftPull`'s inline headers (which must let `FOUNDRY_PAT` win over `GITHUB_TOKEN`). A test enumerates all 11 call sites through the `fetchImpl` seam and asserts every request carries it.

**Negative controls:** dropping both pin sites → test fails with `actual 2026-03-10, expected 2022-11-28`. Dropping only the `createDraftPull` pin → fails with `[{"name":"createDraftPull","version":null}]`.

## T-21 — the primary rate limit was invisible

A 403 from quota exhaustion was indistinguishable from any other 403, and nothing read `x-ratelimit-*` anywhere.

A 403/429 carrying `x-ratelimit-remaining: 0` now names the resource, the ceiling, the remaining count and the ISO reset (plus `retry-after` when present). Reads that are silently unauthenticated — 60/hr against a documented ~19-per-tick spend, so the fourth tick of an hour fails unexplained — now warn once. The token is **not** made mandatory.

**Secondary-limit handling is untouched**, deliberately: a body matching `/secondary rate limit/i` still returns `{halt: true}` and writes a durable factory halt, which is more conservative than GitHub's own back-off guidance. **No retries were added anywhere.**

**Negative controls:** stubbing the primary-limit message → the old bare `GitHub 403 listing pulls on …` returns. Skipping the unauthenticated warning → `0 !== 1`. Secondary halt still fires even when `remaining` is also 0.

## Verified
suite **386/386** · typecheck **0** · validate green · evidence `T-09-api-version.txt`, `T-21-rate-limit.txt`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR pins factory GitHub REST requests to API version `2022-11-28` and enriches primary-rate-limit diagnostics while preserving the existing secondary-limit halt behavior.
- Adds a shared API-version constant and applies it to read and draft-creation requests.
- Reports primary quota metadata and warns once when reads are unauthenticated.
- Adds request-coverage and rate-limit tests plus completion evidence.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with one non-blocking gap in the test that claims exhaustive GitHub request-site coverage.

The production request paths reviewed carry the version pin and preserve secondary-limit handling; only the completeness assertion in the new regression test needs refinement.

**Files Needing Attention:** factory/github-pr.test.ts
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| factory/github-pr.ts | Adds the API-version pin, unauthenticated-read warning, and centralized primary-rate-limit error formatting without an identified runtime defect. |
| factory/github-pr.test.ts | Thoroughly tests the new behavior, but the purported exhaustive request-site table omits `scoutGithub`. |
| docs/completion/evidence/T-09-api-version.txt | Records the API-version rationale, coverage test, and negative controls. |
| docs/completion/evidence/T-21-rate-limit.txt | Records the rate-limit diagnostics, unauthenticated warning, and negative controls. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20ravidsrk%2Foss-foundry%20PR%20%23125%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=ravidsrk%2Foss-foundry&pr=125&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Afactory%2Fgithub-pr.test.ts%3A1147-1151%0A**Call-site%20enumeration%20omits%20scout**%0A%0AThe%20test%20labels%20these%2011%20entries%20as%20every%20shipped%20GitHub%20call%20site%2C%20but%20%60scoutGithub%60%20also%20sends%20a%20request%20using%20%60githubApiHeaders%60.%20Omitting%20it%20leaves%20the%20regression%20test%20incomplete%20and%20allows%20that%20request%20to%20lose%20the%20version%20pin%20without%20failing%20this%20coverage%20assertion.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ravidsrk%2Foss-foundry&pr=125&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
factory/github-pr.test.ts:1147-1151
**Call-site enumeration omits scout**

The test labels these 11 entries as every shipped GitHub call site, but `scoutGithub` also sends a request using `githubApiHeaders`. Omitting it leaves the regression test incomplete and allows that request to lose the version pin without failing this coverage assertion.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Pin GitHub API version and surface prima..."](https://github.com/ravidsrk/oss-foundry/commit/1b092ad4cd0ccc2a3fdeb2ca4fb411be9d33d39a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59068118)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [GitHub pull request integration](https://app.greptile.com/heycmo/-/custom-context/knowledge-base/ravidsrk/oss-foundry/-/docs/github-pull-request-integration.md)

<!-- /greptile_comment -->