### PR TITLE
P5: remove every doc claim the code does not support

### DIFF
--- a/docs/01-architecture.md
+++ b/docs/01-architecture.md
@@ -8,29 +8,60 @@ Foundry splits into a **control plane** (`factory/` in this repo) and a **data p
         ▼
  ┌─────────────┐   ┌─────────────┐   ┌─────────────┐   ┌─────────────┐
  │ 1 Scout     │ → │ 2 Policy    │ → │ 3 Freeze    │ → │ 4 Implement │
- │ heuristic   │   │ AGENTS.md   │   │ human only  │   │ sandboxed   │
+ │ roster order│   │ AGENTS.md   │   │ human only  │   │ dry-run     │
  └─────────────┘   └─────────────┘   └─────────────┘   └──────┬──────┘
                                                               │
                        ┌─────────────┐   ┌─────────────┐      │
-                       │ 7 Scorecard │ ← │ 6 Draft PR  │ ←  5 Review (blind)
-                       │ halt rules  │   │ never merge │      │
+                       │ 7 Scorecard │ ← │ 6 Draft PR  │ ←  5 Review
+                       │ halt rules  │   │ never merge │   evidence gate
                        └─────────────┘   └─────────────┘      │
 ```
 
+Station 1 picks the next named `firstIssues` row in roster order (`pickCandidate` in `factory/engine.ts`), not a heuristic rank. Stations 4 and 5 are status bumps on `applyAdvance`; the evidence protocol is the gate on that arc. See [04-stations.md](04-stations.md).
+
 ## Control plane
 
-TypeScript in `factory/`. Deterministic. No LLM required to refuse a banned repo.
+TypeScript in `factory/`. Deterministic. No LLM required to refuse a banned repo. There is no TanStack console in this repository. The clock **must not** open contribution PRs.
 
-- `allowlist.ts` loads `allowlist.yaml` — the only repos the factory may see.
+The inventory below was derived from `factory/*.ts` on this tree (29 non-`*.test.ts` modules). [`factory/README.md`](../factory/README.md) is the closer map of the operator-facing surface — the modules you actually run — and this page is the complete list so the two stay honest: README names a subset; nothing it names is described differently here.
+
+### Operator-facing (also in `factory/README.md`)
+
+- `allowlist.ts` — loaded roster. Canonical id fold, `repoById`, denylist. YAML parse lives in `load-allowlist.ts`.
 - `policy.ts` — phrase scanner + wave / CLA / scope caps. No canned welcome corpus.
-- `scout.ts` — heuristic rank.
-- `engine.ts` — tick / queue / approve / advance. Honors inflight, halt, promotion, deny.
-- `packet.ts` — the unit of work. Objective, non-goals, acceptance, abort.
-- `sandbox.ts` — dry-run plan; never auto-harvests as green.
-- `scorecard.ts` — merge rate, tone, reverts, the two review KPIs. `health()` can halt a repo; the engine consults it. `classifyRevert` decides what counts as a revert; `applyRevert` (engine) is the only writer of `reverts`.
+- `engine.ts` — tick / queue / approve / advance. Honors inflight, halt, promotion, deny. Owns `pickCandidate`, `applyAdvance`, `applyAttachEvidence`, `evidenceIsReady`.
+- `packet.ts` — `buildPacket` / `renderPrBody`. Stamps `scoreIssue` onto the packet as a record; that score does not pick the candidate.
 - `cli.ts` — operator freeze / tick / draft-body loop.
+- `github-pr.ts` — SPEC §6 moment of contact: draft-only `createDraftPull` (`FOUNDRY_PAT`), PR sync, issue/competing-work reads (`GITHUB_TOKEN` / `GH_TOKEN`). No merge helper.
+- `github-scout.ts` — live issue fetch + `rankIssues`. **Not wired**: `tick` walks named `firstIssues`. Public API; `GITHUB_TOKEN` raises the rate limit.
+- `sandbox.ts` — dry-run plan. Emits `# planned · not executed ·` commands with `exit: -1`. Does not stamp harvested/exit 0. Clone in the plan is **full**, not shallow.
+- `scorecard.ts` — SPEC §7 standing: merge rate, tone, reverts, the two review KPIs. `health()` can halt a repo; the engine consults it. `classifyRevert` decides what counts as a revert; `applyRevert` (engine) is the only writer of `reverts`.
+- `seed.ts` — committed ledger seed. Keep in sync with GitHub.
+- `run-tests.ts` — the suite's own oracle. Discovers every `factory/*.test.ts` and refuses a run where any file reported zero tests.
+- `witness.ts` — SPEC §5 evidence protocol. Owns `hostRunner` (Wave 0 host shell) and `witnessEvidence`; parses and re-checks ingested witnesses. E2B/Daytona execution is not in this tree.
 
-There is no TanStack console in this repository. The clock **must not** open contribution PRs.
+### SPEC §5 / §6 / §7 and supporting modules README omits
+
+- `state.ts` — fail-closed ledger loader (`loadFactoryState`). Refuses a non-v6 / unshaped / over-inflight file rather than overwriting it with seed.
+- `types.ts` — shared unions and `TaskPacket` / `FactoryState` shapes. `Lighting = "lit"` only.
+- `halt.ts` — SPEC §6 durable factory halt on a GitHub secondary rate limit. Written into the ledger; `clear-halt` is the only lift.
+- `verify-ledger.ts` — clock-side, read-only: committed seed vs live GitHub. Divergence fails the run; advisories do not.
+- `ledger-check.ts` — per-packet reconciliation (draft/head/disclosure/revert/stale evidence). Used by the clock and `reconcile`.
+- `competition-read.ts` — live competing-work verdict for one packet, plus the one reporter the clock / `sync` / `reconcile` share.
+- `policy-records.ts` — SPEC §3 committed policy-record loader (`policy-records.json`).
+- `load-allowlist.ts` — YAML subset parser + `assertAllowlist` (disjointness, uniqueness, noop-oracle guard).
+- `validate-allowlist.ts` — CLI entry: allowlist + policy-records consistency. `npm run validate`.
+- `neighbor.ts` — SPEC §6 disclosure block (`DISCLOSURE`) and commit-trailer conventions. The verbatim PR-body text. Do not reformat it; `factory/engine.test.ts` asserts every in-repo quotation is byte-identical to the constant.
+- `terminal.ts` — the sole third-party-text sanitisation boundary. Installed on stdout/stderr by every real entry point.
+- `status.ts` — promotion-gate counter (`foundryAttestedWave0Merges`), ledger sections, quiet label. Also still exports unused UI-layer helpers (`statusTone`, `policyTone`, `formatWhen`, `needsFollowUp`) for a console that does not exist here.
+- `ids.ts` — `mintLedgerId`: the only door for event / follow-up / halt ids.
+- `scout.ts` — `scoreIssue` / `rankIssues`. Rank is unwired (see `github-scout.ts`). Score is stamped on packets and not consulted by `pickCandidate`.
+
+### Test-support modules (not `*.test.ts`, not collected by `run-tests.ts`)
+
+- `fixture-counts.ts` — `assertDisjointCounts` for issue #77 count fixtures.
+- `seed-fixtures.ts` — Wave 1 packet helpers so reducer tests can rewind the absorbed close.
+- `tmp-dir.ts` — the only `mkdtempSync` in the suite; registers `$TMPDIR` cleanup on `process.exit`.
 
 ## Data plane
 
@@ -42,6 +73,8 @@ Unchanged from orca-fleet:
 - Independent verifier re-derives tests, ancestry, negative control.
 - `oss-contribute` never merges. `awaiting-maintainer-merge` is a success state.
 
+That worker is not in this repository. Wave 0 host witnessing is (`witness.ts`). Wave 1+ execution is the worker host described in [06-v2.md](06-v2.md), ingested here with `attach-witness`.
+
 ## Trust boundaries
 
 | Boundary | Rule |
@@ -49,9 +82,9 @@ Unchanged from orca-fleet:
 | Allowlist | If it is not listed, it does not exist. |
 | Policy | Forbidden phrases win over “but the issue is tiny.” No docs = deny. |
 | Freeze | Every packet, at every wave. Nothing auto-freezes; the first-20 counter is an odometer, not a gate that opens. |
-| Sandbox | Wave 1+ clones never hit the operator laptop. No secrets in the box. Dry-run is labeled dry-run. |
-| Reviewer | Does not see implementer traces. Reviews the diff + tests only. |
-| GitHub | Fork → upstream **draft** PR. No admin, no merge helper. |
+| Sandbox | Wave 1+ clones never hit the operator laptop. No secrets in the box. Dry-run is labeled dry-run. This CLI does not run the box. |
+| Reviewer | Doctrine: does not see implementer traces. In this tree the review *station* is a status bump; the machine gate is `evidenceIsReady`. |
+| GitHub | Fork → upstream **draft** PR via `FOUNDRY_PAT`. No admin, no merge helper. No GitHub App client. |
 
 ## Why not Temporal / Mastra / a new Python agent
 
@@ -59,4 +92,21 @@ Orca already is the orchestrator. Mastra already is HeyCMO. A third runtime woul
 
 ## v1 vs v2 in this repo
 
-v1 is enforced: tick → packet → freeze → draft body, with halt / promotion / inflight including `submitted`. v2 adapters (live scout, PR sync, draft-only create payload) are real modules; credentials stay out of git. Dry-run sandbox does not pretend a harvest succeeded. Grok scout overlay is not shipped.
+v1 is enforced: tick → packet → freeze → draft body, with halt / promotion / inflight including `submitted`. v2 adapters (unwired live scout, PR sync, draft-only create payload, dry-run sandbox plan) are real modules; credentials stay out of git. Dry-run sandbox does not pretend a harvest succeeded. Grok scout overlay is not shipped.
+
+## Environment variables
+
+Derived by grepping `process.env.[A-Z_]+` across `factory/` and cross-checking `env.NAME` parameters that default to or are passed `process.env` (`FOUNDRY_PAT`, `E2B_API_KEY`). `PATH` appears in tests only (toolchain prefix) and is not a Foundry setting. No other `FOUNDRY_*` names are read by shipping code on this tree.
+
+| Name | Read by | Default | Unset / invalid |
+|---|---|---|---|
+| `FOUNDRY_PAT` | `createDraftPull` (`factory/github-pr.ts`) via `env.FOUNDRY_PAT`, `env` defaulting to `process.env`. The only write credential. Also listed in `WITNESS_SECRET_KEYS` so a host-witness child never sees it (`factory/witness.ts`). | none | `POST /pulls` never leaves. Returns an error naming `scripts/machine-account-wizard.sh`. |
+| `GITHUB_TOKEN` | `githubApiHeaders` (`factory/github-pr.ts`): `process.env.GITHUB_TOKEN \|\| process.env.GH_TOKEN`. Read path only. Also a `WITNESS_SECRET_KEYS` strip. The 6-hour clock injects `secrets.GITHUB_TOKEN` into `verify-ledger` (`.github/workflows/oss-tick.yml`). | none | Unauthenticated public reads (60 req/hr anonymous vs 5,000 with a token). |
+| `GH_TOKEN` | Fallback for `GITHUB_TOKEN` in `githubApiHeaders`. Same secret strip. | none | Ignored if `GITHUB_TOKEN` is set; if both unset, unauthenticated reads. |
+| `FOUNDRY_GITHUB_TIMEOUT_MS` | `githubFetchTimeoutMs` (`factory/github-pr.ts`). Integer milliseconds, 1…`GITHUB_FETCH_TIMEOUT_MAX_MS` (1 hour). | `15000` (`GITHUB_FETCH_TIMEOUT_MS`) | Unset, empty, non-integer, `< 1`, or above the max → shipped 15s bound. Does not throw. |
+| `FOUNDRY_OPERATOR` | `factory/cli.ts` `approve` and `clear-halt` when `--by` is omitted. Attribution in the ledger, not a credential. | `"operator"` | Ledger events record `by: "operator"`. |
+| `E2B_API_KEY` | `witnessEvidence` (`factory/witness.ts`) via caller `env` (`cli.ts` passes `process.env`). Presence check only — this CLI never talks to E2B. Also a `WITNESS_SECRET_KEYS` strip. | none | Wave 1+ `evidence` refuses with “cannot witness evidence in dry-run”. **Set** still refuses: execution belongs to the worker host; ingest with `attach-witness`. |
+| `NODE_TEST_CONTEXT` | `factory/cli.ts` persist / logs-root guards. Set by `node:test` for spawned CLI children. Not an operator setting. | unset in a real operator shell | When set, and the CLI was not given `--state` / `--logs-root`, the process refuses to write the repo-root ledger or run logs. Unset: those writes are allowed. |
+| `FOUNDRY_LIVE` | **Not a `process.env` read.** GitHub Actions **repository variable** `vars.FOUNDRY_LIVE` in `.github/workflows/oss-tick.yml`. | unset (dry) | `!= 'true'` → clock prints “FOUNDRY_LIVE is not set — clock stays dry” and does not file a packet-request issue. `== 'true'` → files (or updates) that issue on `oss-foundry`. Still must not open contribution PRs. |
+
+Not secrets, not read, do not provision: `FOUNDRY_APP_ID`, `FOUNDRY_APP_PRIVATE_KEY`, `FOUNDRY_INSTALLATION_ID`. They appear in no `factory/` read. See [07-github-app.md](07-github-app.md).

--- a/docs/04-stations.md
+++ b/docs/04-stations.md
@@ -1,6 +1,6 @@
 # Stations
 
-Four working stations plus freeze, draft, and follow-up. Mapped onto `oss-contribute` so we do not invent a second pipeline.
+Seven named stations mapped onto `oss-contribute` so we do not invent a second pipeline. Scout and policy are live gates; freeze is the human attest; **implement and review are not working gates** — `applyAdvance` stores a dry-run plan, then bumps status; the evidence protocol (`applyAttachEvidence` / `evidenceIsReady`) is the real check on that arc; draft and follow-up are contact and standing.
 
 ## 1. Scout
 
@@ -27,7 +27,7 @@ Does:
   `attach-draft` — a competitor that appeared since gating refuses the approval, the open or the
   attach; an adjacent mention at freeze is surfaced to the human doing the freezing, who is the
   taste gate.
-- Heuristic score: wave, labels, size, freshness.
+- **Selection is roster order, not heuristic rank.** `pickCandidate` (`factory/engine.ts`) walks the `live` list, then `ALLOWLIST` / `firstIssues`, and returns the first policy-allowable unused non-blocked row. `rankIssues` (`factory/scout.ts`) has exactly one caller — `factory/github-scout.ts` — which is on no live path ([06-v2.md](06-v2.md)). `scoreIssue` still stamps wave / labels / size / freshness onto the packet in `buildPacket`; that score is a record, not the picker.
 - Never invent issue numbers. If every named `firstIssues` row is consumed or blocked, the tick **idles**.
 
 Output: at most one candidate. Clock / CLI skip if anything is in flight (`gated` … `submitted`).
@@ -121,13 +121,15 @@ The first 20 factory-wide approvals decrement a visible counter (`humanApprovals
 
 ## 4. Implementer
 
-Worker in a fresh worktree (Wave 0) or E2B box (else). One playbook pack. Failing-first. No coordinator chat in the trace that the reviewer will see.
+**Not a working gate.** `applyAdvance` (`factory/engine.ts`) on status `approved` requires `humanAttest`, calls `runSandboxDry` / `planSandbox`, stores that session on the packet, and bumps status to `implementing` / station `implement`. The stored session is a dry-run plan: commands are comment strings prefixed `# planned · not executed ·` with `exit: -1` (`factory/sandbox.ts`). No playbook pack runs, no worktree is created, no E2B box is booted. Wave 0 host / Wave 1+ E2B execution belongs to a worker host that is not in this tree ([06-v2.md](06-v2.md)).
 
 The CLI dry-run **plans** sandbox commands. It does not stamp `harvested` with exit 0.
 
 ## 5. Independent reviewer
 
-Build-blind. Sees the diff, the test command, the negative control. Does not see the implementer’s chain of thought. Reviewed SHA must equal head SHA at draft time.
+**Not a working gate.** `applyAdvance` on status `implementing` is a bare status bump to `reviewing` / station `review` — no reviewer identity is recorded. `lighting` is the constant `"lit"` (`factory/types.ts` `Lighting = "lit"`; `buildPacket` always writes `"lit"`). The historical `dark-eligible` value is not representable; the loader refuses anything else (`factory/state.ts`).
+
+The only real gate on this arc is attaching witnessed evidence. `applyAttachEvidence` requires status `reviewing` and refuses placeholder SHAs, illegal provenance, a non-fast-forward range, scope overflow, and an unbound commit range. `applyAdvance` from `reviewing` to `draft-ready` then requires `evidenceIsReady` (negative control, witnessed exits, bound SHAs, provenance). Building the independent-reviewer *enforcement* (a second identity, build-blind traces) is a new capability, not present here (gap G-36).
 
 Evidence is attached by the operator (`attachEvidence`), from a run the operator did not perform by
 hand: `evidence` witnesses on the host (Wave 0 only), and `attach-witness` ingests a manifest

--- a/docs/06-v2.md
+++ b/docs/06-v2.md
@@ -23,17 +23,29 @@ field, and the witness gate holds each repo to the one its entry names (`witness
 witness is refused everywhere on today's allowlist; making one legal means editing the entry, not
 the gate.
 
-Lifecycle: create → shallow clone → test command → harvest patch → destroy.
+There is **no E2B (or Daytona) executor in this tree.** `runSandboxDry` (`factory/sandbox.ts`)
+emits only comment strings prefixed `# planned · not executed ·` with `exit: -1`. It does not
+create a box, clone, run tests, harvest, or destroy. The lifecycle below is the **design for a
+worker host that is not in this repository**.
 
-Hard rules:
+Designed worker-host lifecycle: create → **full** clone → test command → harvest patch → destroy.
 
-- No GitHub App private key in the box.
+Clone depth is not shallow. The planned command in `factory/sandbox.ts` is
+`git clone …  # full clone — historical SHAs must be reachable`, and `SANDBOX_RULES` repeats
+"Clone is full (historical SHAs must be reachable)." A shallow clone would make the negative
+control's historical SHAs unreachable.
+
+Hard rules (design of that worker host; this CLI only prints them):
+
+- No GitHub App private key in the box. (This tree has no App private key at all — see [07-github-app.md](07-github-app.md).)
 - No SSH keys, npm tokens, or `.env`.
 - Network allowlist: git + package registries.
 - If tests cannot run, park. Do not skip the oracle.
 - Dry-run in this repo is labeled `dry-run`. It does not stamp `harvested` with exit 0.
 
-Wire `E2B_API_KEY` in the worker host (not this git tree) to make it live.
+`E2B_API_KEY` is a presence check in `witnessEvidence` (`factory/witness.ts`). Unset → “cannot
+witness evidence in dry-run.” Set → this CLI still refuses: execution belongs to the worker host;
+ingest the result with `attach-witness`. Wiring the key here does not make a sandbox live.
 
 ### Witnessed evidence (issue #6)
 
@@ -91,9 +103,14 @@ A `stop` repo is unselectable until a human edits the scorecard row that holds t
 `factory/seed.ts` for the published one) — not `allowlist.yaml`, whose roster is what the scorecard rows
 are built from.
 
-## GitHub App (operator host)
+## GitHub App (unimplemented)
 
-Permissions (least):
+There is no GitHub App client in this repository. Writes go through `FOUNDRY_PAT`; reads through
+`GITHUB_TOKEN` / `GH_TOKEN` ([07-github-app.md](07-github-app.md)). The permission floor below is
+aspirational — the intended least-privilege set if an App is ever built, not a description of
+today's auth.
+
+Intended permissions (least):
 
 - Contents: read on upstream, write on operator forks.
 - Pull requests: write (draft).
@@ -103,7 +120,9 @@ Permissions (least):
 
 No administration. No merge. No Actions write on upstream.
 
-The App is **not** installed on ColeMurray/background-agents. `POST /pulls` there is 403. The in-repo create helper still hard-codes `draft: true` and exposes no merge method.
+An App token `POST /pulls` on ColeMurray/background-agents is **403** (no installation). The
+in-repo create helper (`createDraftPull`) uses `FOUNDRY_PAT`, hard-codes `draft: true`, and
+exposes no merge method.
 
 ## Promotion rule
 

--- a/docs/07-github-app.md
+++ b/docs/07-github-app.md
@@ -1,12 +1,44 @@
-# GitHub App
+# GitHub credentials
 
-The factory authenticates as a GitHub App, never as a personal PAT.
+The factory does **not** authenticate as a GitHub App. The shipping write credential is a classic personal access token (`FOUNDRY_PAT`); the shipping read credential is `GITHUB_TOKEN` or `GH_TOKEN`. A previous version of this page led with “authenticates as a GitHub App, never as a personal PAT.” That sentence was false — contradicted by the machine-account section below and by the code — and a false security claim is worse than a missing one.
 
-## Why
+## What the code actually uses
 
-PATs inherit the operator’s social graph. A leaked PAT is a reputation incident. An App is scoped, rotatable, and named `foundry-bot` so maintainers can see who is calling.
+| Credential | Direction | Where it is read | Unset |
+|---|---|---|---|
+| `FOUNDRY_PAT` | **The only write.** Classic PAT, minted at `public_repo` scope by `scripts/machine-account-wizard.sh`. | `createDraftPull` reads `env.FOUNDRY_PAT` (`factory/github-pr.ts`). `env` defaults to `process.env`. Used on exactly one call: `POST /repos/{owner}/{repo}/pulls` with `draft: true` hard-coded via `draftPullPayload`. | The POST never leaves. The function returns an error naming the wizard. |
+| `GITHUB_TOKEN` / `GH_TOKEN` | **The only read.** | `githubApiHeaders` (`factory/github-pr.ts`): `process.env.GITHUB_TOKEN \|\| process.env.GH_TOKEN`. Attached as `Authorization: Bearer …` when present. `createDraftPull` constructs its own header with `FOUNDRY_PAT` inline, so a read token cannot be used for a write. | Unauthenticated public reads (GitHub’s 60 req/hr anonymous ceiling vs 5,000 with a token). |
+| `E2B_API_KEY` | Not a GitHub credential. Presence check only. | `witnessEvidence` (`factory/witness.ts`) reads `env.E2B_API_KEY`. With or without it, this CLI does not run an E2B sandbox — see [06-v2.md](06-v2.md). | Wave 1+ `evidence` refuses with “cannot witness evidence in dry-run”. |
 
-## Permissions
+There is no App client in this tree. `FOUNDRY_APP_ID`, `FOUNDRY_APP_PRIVATE_KEY`, and `FOUNDRY_INSTALLATION_ID` have **zero** reads under `factory/`. Provisioning them does nothing. Do not set them.
+
+The full environment-variable reference — including `FOUNDRY_GITHUB_TIMEOUT_MS`, `FOUNDRY_OPERATOR`, `NODE_TEST_CONTEXT`, and the `FOUNDRY_LIVE` repository variable, which is not a `process.env` read — lives in [01-architecture.md](01-architecture.md#environment-variables).
+
+## Why a PAT at the moment of contact
+
+PATs inherit the operator’s social graph. A leaked PAT is a reputation incident. An App would be scoped, rotatable, and named so maintainers can see who is calling. **That App is not implemented.** GitHub App user-to-server tokens 403 on `POST /pulls` against repos the App is not installed on (intersection of installations and user access). Fine-grained PATs are not the documented credential for fork→upstream PRs on unaffiliated public repos. The one documented credential for that write is a **classic PAT**.
+
+So the moment of contact is machine-enforced with the PAT, not with an App:
+
+- a dedicated, ToS-compliant **machine account** holds a classic PAT scoped to `public_repo` only (`FOUNDRY_PAT`, operator host env — never git, never the E2B box), used for exactly one call: `createDraftPull` → `POST /pulls` with `draft: true` hard-coded (`factory/github-pr.ts`);
+- this repository does not clone, push a branch, or otherwise write with an App token — those steps, when they happen, are operator / worker-host work outside this tree;
+- `open-draft <packetId> --head <fork:branch>` re-runs the competing-work check, refuses a body without the verbatim disclosure, opens the draft, and records it via the normal attach flow;
+- one create per CLI run; a secondary-rate-limit response is a **durable factory halt**, never a retry (AUP: excessive automated bulk activity): it is written into the state record, not just printed, so the next run refuses too until a human runs `clear-halt` ([08-operations.md](08-operations.md) §1);
+- setup is human-only: `scripts/machine-account-wizard.sh` walks account, 2FA, token, and verification. No agent creates accounts.
+
+Browser sessions are demoted to emergency-only. No contribution PR opens by hand again — and if one ever does, `attach-draft` refuses to bind it unless the body carries the verbatim disclosure block. That refusal lives in `applyAttachDraft` (`factory/engine.ts`), not in a verb, so both create paths run it; until issue #38 it existed only in `open-draft`, which is not the path that opened ColeMurray/background-agents#1652.
+
+## Draft discipline
+
+`factory/github-pr.ts` `draftPullPayload` sets `draft: true` unconditionally. There is no merge / `--admin` helper in that module. Marking ready-for-review is not in the method set; a human uses the browser.
+
+`POST /repos/ColeMurray/background-agents/pulls` with an App token is **403** (no installation). ColeMurray#1652 was opened in a browser session, ready rather than draft — the doctrine miss that motivated the machine account above. The in-repo create path would use `FOUNDRY_PAT`, not an App.
+
+## GitHub App (unimplemented / aspirational)
+
+Nothing below is wired. It is the permission floor to implement against if an App is ever built, not a description of today’s auth.
+
+Intended permissions (least):
 
 | Permission | Access | Why |
 |---|---|---|
@@ -19,50 +51,9 @@ PATs inherit the operator’s social graph. A leaked PAT is a reputation inciden
 | Administration | none | |
 | Merge queues | none | |
 
-## Installations
+Intended installations, if that App exists:
 
 - Installation 1: `ravidsrk` — Wave 0 + `oss-foundry`.
 - Installation 2 (later): only after a Wave 1 maintainer invites the App. Do not send unsolicited App installs.
 
-## Draft discipline
-
-`factory/github-pr.ts` `draftPullPayload` sets `draft: true` unconditionally. There is no merge / `--admin` helper in that module. Marking ready-for-review is not in the method set; a human uses the browser.
-
-The App is installed on `ravidsrk` only. `POST /repos/ColeMurray/background-agents/pulls` is **403**. ColeMurray#1652 was opened in a browser session, ready rather than draft — the doctrine miss that motivated the machine account below.
-
-## Machine account — the moment of contact (issue #5)
-
-The App's 403 on non-installed repos is GitHub's security model (user tokens act on the
-intersection of app installations and user access), and the roadmap item that would fix
-fine-grained PATs is paused. The one documented credential for fork→upstream PRs on unaffiliated
-public repos is a **classic PAT**. So the moment of contact is machine-enforced with a hybrid:
-
-- the App keeps doing everything it can (clone, push the branch to the operator fork);
-- a dedicated, ToS-compliant **machine account** holds a classic PAT scoped to `public_repo`
-  only (`FOUNDRY_PAT`, operator host env — never git, never the E2B box), used for exactly one
-  call: `createDraftPull` → `POST /pulls` with `draft: true` hard-coded;
-- `open-draft <packetId> --head <fork:branch>` re-runs the competing-work check, refuses a body
-  without the verbatim disclosure, opens the draft, and records it via the normal attach flow;
-- one create per CLI run; a secondary-rate-limit response is a **durable factory halt**, never a
-  retry (AUP: excessive automated bulk activity): it is written into the state record, not just
-  printed, so the next run refuses too until a human runs `clear-halt`
-  ([08-operations.md](08-operations.md) §1);
-- setup is human-only: `scripts/machine-account-wizard.sh` walks account, 2FA, token, and
-  verification. No agent creates accounts.
-
-Browser sessions are demoted to emergency-only. No contribution PR opens by hand again — and if
-one ever does, `attach-draft` refuses to bind it unless the body carries the verbatim disclosure
-block. That refusal lives in `applyAttachDraft` (`factory/engine.ts`), not in a verb, so both
-create paths run it; until issue #38 it existed only in `open-draft`, which is not the path that
-opened #1652.
-
-## Secrets
-
-Live in the operator host / GHA environment:
-
-- `FOUNDRY_APP_ID`
-- `FOUNDRY_APP_PRIVATE_KEY`
-- `FOUNDRY_INSTALLATION_ID`
-- `E2B_API_KEY` (v2)
-
-Never in `allowlist.yaml`, never in the E2B box, never in a packet.
+Do not put App private keys — or `FOUNDRY_PAT` — in `allowlist.yaml`, in the E2B box, or in a packet.

--- a/docs/10-schemas.md
+++ b/docs/10-schemas.md
@@ -26,10 +26,14 @@ policyDocs        [{ name: AGENTS.md | CONTRIBUTING, chars, excerpt, truncated }
                   `excerpt.length < chars`. Absent when nothing was fetched, which is a different
                   fact from a document fetched and empty (`chars: 0`) and is displayed as one.
 scout             ScoutScore
-createdAt         ISO timestamp. Required string on `TaskPacket` (`factory/types.ts`). `isPacket`
-                  (`factory/state.ts`) requires `typeof === "string"`. `migrateV6` fills a missing
-                  key from `updatedAt` or `"—"` before that check; a non-string is refused.
-updatedAt         ISO timestamp. Required the same way. Written on every status bump.
+createdAt         Required STRING, ISO 8601 by convention but not by enforcement. `isPacket`
+                  (`factory/state.ts:265`) checks `typeof === "string"` and nothing more, so the
+                  format is not validated on load — and `migrateV6` (`factory/state.ts:356`) fills a
+                  missing key from `updatedAt` or, failing that, the literal `"—"`. So a loadable
+                  packet's timestamp may not be a timestamp at all. Do not parse these without
+                  checking; a non-string IS refused.
+updatedAt         Required the same way, with the same caveat (`factory/state.ts:357`). Written on
+                  every status bump.
 humanAttest       { by, at, note }  required before implement on Wave 1+
 evidence          EvidenceManifest
 prBody

--- a/docs/10-schemas.md
+++ b/docs/10-schemas.md
@@ -26,6 +26,10 @@ policyDocs        [{ name: AGENTS.md | CONTRIBUTING, chars, excerpt, truncated }
                   `excerpt.length < chars`. Absent when nothing was fetched, which is a different
                   fact from a document fetched and empty (`chars: 0`) and is displayed as one.
 scout             ScoutScore
+createdAt         ISO timestamp. Required string on `TaskPacket` (`factory/types.ts`). `isPacket`
+                  (`factory/state.ts`) requires `typeof === "string"`. `migrateV6` fills a missing
+                  key from `updatedAt` or `"—"` before that check; a non-string is refused.
+updatedAt         ISO timestamp. Required the same way. Written on every status bump.
 humanAttest       { by, at, note }  required before implement on Wave 1+
 evidence          EvidenceManifest
 prBody
@@ -35,6 +39,8 @@ prMeta            { url, title, draft, state, merged, mergeable, commits, review
                   `humanReview` ABSENT means the review endpoints were not read — never "nobody reviewed it".
                   `reviewComments` is GitHub's own total: it counts bots, so it is a record, not the KPI.
 followUps         [{ id, at, kind: review-reply|bot-reconcile|quiet|ci|note, body, url? }]
+parkReason        optional string. Why the engine parked the packet (policy denial, scope overflow,
+                  …). `isPacket` accepts a string or absence.
 sandboxSession
 ```
 

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -72,12 +72,12 @@ The factory does not merge. Maintainers own the merge.
         ▼
  ┌─────────────┐   ┌─────────────┐   ┌─────────────┐   ┌─────────────┐
  │ 1 Scout     │ → │ 2 Policy    │ → │ 3 Freeze    │ → │ 4 Implement │
- │ heuristic   │   │ AGENTS.md   │   │ human only  │   │ sandboxed   │
+ │ roster order│   │ AGENTS.md   │   │ human only  │   │ dry-run     │
  └─────────────┘   └─────────────┘   └─────────────┘   └──────┬──────┘
                                                               │
                        ┌─────────────┐   ┌─────────────┐      │
-                       │ 7 Scorecard │ ← │ 6 Draft PR  │ ←  5 Review (blind)
-                       │ halt rules  │   │ never merge │      │
+                       │ 7 Scorecard │ ← │ 6 Draft PR  │ ←  5 Review
+                       │ halt rules  │   │ never merge │   evidence gate
                        └─────────────┘   └─────────────┘      │
 ```
 
@@ -108,11 +108,11 @@ There is **no** TanStack operator console in this repository. The freeze/tick/dr
 
 | # | Station | Does |
 |---|---|---|
-| 1 | Scout | Allowlist issues only. Drop denylist, RFC/meta, issues with an in-flight maintainer PR. Heuristic rank. Clock / CLI never invent issue numbers |
+| 1 | Scout | Allowlist issues only. Drop denylist, RFC/meta, issues with an in-flight maintainer PR. Next candidate is roster order (`pickCandidate` in `factory/engine.ts`), not heuristic rank — `rankIssues` (`factory/scout.ts`) has one caller, unwired `github-scout.ts`. Clock / CLI never invent issue numbers |
 | 2 | Policy | Deterministic. Grok has no vote |
 | 3 | Freeze | Operator `approve` (attest) or `reject` (park). Denied / halted packets cannot be approved. `merged` packets cannot be rejected — terminal, and a late reject desyncs the promotion-gate counters. Rejecting a `submitted` packet is the halt-everything path, but it never closes the PR: the CLI names the one left open |
-| 4 | Implement | One playbook pack. Failing-first. Wave 0 host / Wave 1+ E2B. Console/CLI dry-run does not fake a green harvest |
-| 5 | Review | Independent, lit. Negative control: revert goes red. Evidence attached by the operator, not invented |
+| 4 | Implement | Not a working gate. `applyAdvance` on `approved` stores a dry-run sandbox plan (`factory/engine.ts`) and bumps status to `implementing`. No playbook pack runs here. Wave 0 host / Wave 1+ E2B belong to a worker host that is not in this tree. CLI dry-run does not fake a green harvest |
+| 5 | Review | Not a working gate. `applyAdvance` on `implementing` is a bare status bump to `reviewing`. `lighting` is the constant `"lit"` (`factory/types.ts`) — no reviewer identity exists. The only real gate on this arc is `applyAttachEvidence` / `evidenceIsReady` (negative control, witnessed exits, provenance) before `reviewing` → `draft-ready` |
 | 6 | Draft | Fork → upstream draft. Body from `renderPrBody`. Create helper sets `draft: true` |
 | 7 | Follow-up | Sync live PR. Answer threads. Mark quiet. **Never merge.** Scorecard on merged / closed-unmerged |
 

--- a/docs/completion/evidence/T-23-doc-truth.txt
+++ b/docs/completion/evidence/T-23-doc-truth.txt
@@ -1,0 +1,132 @@
+T-23 / G-15 — each corrected claim beside the code that decides it.
+
+Negative control: `git show origin/main:<file>` still carries the false sentence;
+this branch does not. Docs-only; no production behaviour changed.
+
+================================================================
+1. docs/07-github-app.md:3 "never as a personal PAT"
+================================================================
+
+BEFORE (origin/main docs/07-github-app.md:3):
+  The factory authenticates as a GitHub App, never as a personal PAT.
+
+CODE THAT DECIDES IT:
+  factory/github-pr.ts createDraftPull — the only write:
+    env: Record<string, string | undefined> = process.env
+    const pat = env.FOUNDRY_PAT;
+    if (!pat) return { ok: false, error: "FOUNDRY_PAT is not set — …" };
+    Authorization: `Bearer ${pat}` on POST /repos/{owner}/{repo}/pulls
+  factory/github-pr.ts githubApiHeaders — the only read:
+    const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  grep FOUNDRY_APP_ID / FOUNDRY_APP_PRIVATE_KEY / FOUNDRY_INSTALLATION_ID
+  over factory/ → zero hits.
+
+AFTER (docs/07-github-app.md:3):
+  The factory does **not** authenticate as a GitHub App. The shipping write
+  credential is a classic personal access token (`FOUNDRY_PAT`); the shipping
+  read credential is `GITHUB_TOKEN` or `GH_TOKEN`. …
+  App discussion is under "GitHub App (unimplemented / aspirational)".
+
+================================================================
+2. Three secrets mandated and read by nothing
+================================================================
+
+BEFORE (origin/main docs/07-github-app.md:63-65):
+  - FOUNDRY_APP_ID
+  - FOUNDRY_APP_PRIVATE_KEY
+  - FOUNDRY_INSTALLATION_ID
+
+CODE THAT DECIDES IT:
+  grep over factory/ for those three names → no matches.
+  (Confirmed again on this tree after the doc rewrite.)
+
+AFTER (docs/07-github-app.md):
+  "There is no App client in this tree. FOUNDRY_APP_ID,
+  FOUNDRY_APP_PRIVATE_KEY, and FOUNDRY_INSTALLATION_ID have **zero** reads
+  under factory/. Provisioning them does nothing. Do not set them."
+  Secrets table lists only FOUNDRY_PAT, GITHUB_TOKEN/GH_TOKEN, E2B_API_KEY.
+
+================================================================
+3. docs/06-v2.md E2B lifecycle + clone depth
+================================================================
+
+BEFORE (origin/main docs/06-v2.md:26):
+  Lifecycle: create → shallow clone → test command → harvest patch → destroy.
+
+CODE THAT DECIDES IT:
+  factory/sandbox.ts runSandboxDry:
+    commands are `# planned · not executed · ${cmd}` with exit: -1
+    clone line: `git clone …  # full clone — historical SHAs must be reachable`
+  factory/sandbox.ts SANDBOX_RULES:
+    "Clone is full (historical SHAs must be reachable)."
+  No E2B SDK / client / worker host in this tree.
+  factory/witness.ts witnessEvidence: E2B_API_KEY is a presence check;
+  with or without it the CLI refuses to run a non-host sandbox.
+
+AFTER (docs/06-v2.md):
+  No executor in this tree. Lifecycle is the design for a worker host that
+  is not in this repository. Clone is **full**, not shallow. E2B_API_KEY
+  does not make a sandbox live here.
+
+================================================================
+4. Stations 4 and 5 described as working gates
+================================================================
+
+BEFORE:
+  docs/PRODUCT.md §5 row 4: "One playbook pack. Failing-first. …"
+  docs/PRODUCT.md §5 row 5: "Independent, lit. Negative control: revert goes red."
+  docs/04-stations.md intro: "Four working stations plus freeze, draft, and follow-up."
+  docs/04-stations.md §4: "Worker in a fresh worktree … One playbook pack."
+  docs/04-stations.md §5: "Build-blind. … Does not see the implementer's chain of thought."
+
+CODE THAT DECIDES IT:
+  factory/engine.ts applyAdvance:
+    approved → implementing: runSandboxDry + planSandbox stored, status bump
+    implementing → reviewing: bare status/station bump, no reviewer identity
+    reviewing → draft-ready: gated on evidenceIsReady
+  factory/engine.ts applyAttachEvidence: the attach gate (status must be reviewing)
+  factory/types.ts: export type Lighting = "lit";
+  factory/packet.ts buildPacket: lighting: "lit"
+  factory/state.ts LIGHTING = new Set(["lit"]); loader refuses anything else
+
+AFTER:
+  Both docs state stations 4/5 are not working gates; applyAdvance stores a
+  dry-run plan then bumps status; lighting is the constant "lit" with no
+  reviewer identity; the only real gate on that arc is applyAttachEvidence /
+  evidenceIsReady.
+
+================================================================
+5. "Heuristic rank" as live station-1 behaviour
+================================================================
+
+BEFORE:
+  docs/PRODUCT.md §5 row 1: "Heuristic rank."
+  docs/PRODUCT.md diagram: "heuristic"
+  docs/04-stations.md §1: "Heuristic score: wave, labels, size, freshness."
+  docs/01-architecture.md (origin/main): "scout.ts — heuristic rank."
+
+CODE THAT DECIDES IT:
+  factory/scout.ts rankIssues — sole caller factory/github-scout.ts
+    (docs/06-v2.md: "Not wired into cli.ts, and on no live path.")
+  factory/engine.ts pickCandidate: walks `live` then ALLOWLIST/firstIssues
+    in roster order; returns the first policy-allowable unused non-blocked row.
+    Does not consult scout.total.
+  factory/packet.ts buildPacket still calls scoreIssue and stores the score
+    on the packet — a record, not the picker.
+
+AFTER:
+  Selection is roster order (pickCandidate). rankIssues is unwired.
+  scoreIssue still stamps a score onto the packet; it does not pick the candidate.
+
+================================================================
+Negative control
+================================================================
+
+  git show origin/main:docs/07-github-app.md | sed -n '3p'
+    → The factory authenticates as a GitHub App, never as a personal PAT.
+  git show origin/main:docs/06-v2.md | sed -n '26p'
+    → Lifecycle: create → shallow clone → test command → harvest patch → destroy.
+  This branch's corresponding lines do not contain those sentences.
+  Restoring origin/main versions of the four files would restore the lies;
+  that is the guard. No production test was added because no production
+  behaviour changed.

--- a/docs/completion/evidence/T-24-reference.txt
+++ b/docs/completion/evidence/T-24-reference.txt
@@ -1,0 +1,128 @@
+T-24 / G-22 — derived module list, env-var reference, packet fields.
+
+Derivation timestamp: this branch, factory/*.ts glob + process.env grep.
+
+================================================================
+1. Module inventory (docs/01-architecture.md)
+================================================================
+
+BEFORE (origin/main docs/01-architecture.md): 8 modules
+  allowlist.ts, policy.ts, scout.ts, engine.ts, packet.ts,
+  sandbox.ts, scorecard.ts, cli.ts
+
+DERIVATION: glob factory/*.ts, drop *.test.ts → 29 files.
+
+  Non-test modules (29):
+    allowlist.ts
+    cli.ts
+    competition-read.ts
+    engine.ts
+    fixture-counts.ts          (test-support; not collected by run-tests.ts)
+    github-pr.ts               (SPEC §6 moment of contact)
+    github-scout.ts
+    halt.ts                    (SPEC §6 factory halt)
+    ids.ts
+    ledger-check.ts            (SPEC §7 reconcile)
+    load-allowlist.ts
+    neighbor.ts                (SPEC §6 DISCLOSURE)
+    packet.ts
+    policy-records.ts
+    policy.ts
+    run-tests.ts
+    sandbox.ts
+    scorecard.ts               (SPEC §7 standing)
+    scout.ts
+    seed-fixtures.ts           (test-support)
+    seed.ts
+    state.ts                   (fail-closed ledger loader)
+    status.ts
+    terminal.ts                (sole third-party-text sanitisation boundary)
+    tmp-dir.ts                 (test-support)
+    types.ts
+    validate-allowlist.ts
+    verify-ledger.ts           (SPEC §7 clock vs GitHub)
+    witness.ts                 (SPEC §5 evidence protocol)
+
+  factory/README.md is the closer map of the operator-facing subset
+  (allowlist, policy, engine, packet, cli, github-pr, github-scout,
+  sandbox, scorecard, seed, run-tests, witness). Architecture names
+  every module; README's descriptions of the overlapping set are not
+  contradicted.
+
+AFTER: docs/01-architecture.md lists all 29, grouped as operator-facing /
+SPEC §5–§7 supporting / test-support.
+
+================================================================
+2. Environment-variable reference
+================================================================
+
+BEFORE: zero markdown files documented FOUNDRY_GITHUB_TIMEOUT_MS.
+  grep FOUNDRY_GITHUB_TIMEOUT_MS over **/*.md on origin/main → empty.
+
+DERIVATION: grep process.env.[A-Z_]+ across factory/:
+
+  process.env.FOUNDRY_GITHUB_TIMEOUT_MS  github-pr.ts (shipping), github-pr.test.ts
+  process.env.FOUNDRY_OPERATOR           cli.ts
+  process.env.FOUNDRY_PAT                witness-host.test.ts only (planted leak probe)
+  process.env.GH_TOKEN                   github-pr.ts
+  process.env.GITHUB_TOKEN               github-pr.ts
+  process.env.NODE_TEST_CONTEXT          cli.ts
+  process.env.PATH                       engine.test.ts, witness-host.test.ts (test PATH prefix)
+
+Cross-check env.NAME (parameters defaulting to / passed process.env):
+
+  env.FOUNDRY_PAT      github-pr.ts createDraftPull  ← shipping write
+  env.E2B_API_KEY      witness.ts witnessEvidence    ← presence check
+  env.NODE_TEST_CONTEXT engine.test.ts (test)
+
+Not a process.env read:
+
+  FOUNDRY_LIVE = vars.FOUNDRY_LIVE in .github/workflows/oss-tick.yml
+
+PATH is test plumbing, not a Foundry setting — listed as such in the
+architecture note, not in the operator table.
+
+No FOUNDRY_WITNESS_* timeout name exists on this tree (sibling T-10
+may add one later; grep found none).
+
+AFTER: docs/01-architecture.md "## Environment variables" table covers
+every shipping name above. docs/07-github-app.md points at it.
+FOUNDRY_APP_* explicitly called out as unread.
+
+Reconcile: every process.env.NAME in factory/ is either in that table
+or identified as test-only PATH / the FOUNDRY_PAT leak-probe write.
+Zero shipping reads unlisted.
+
+================================================================
+3. Packet fields omitted from docs/10-schemas.md
+================================================================
+
+BEFORE packet block ended:
+  scout, humanAttest, evidence, prBody, prUrl, prMeta, followUps, sandboxSession
+  (no createdAt, updatedAt, parkReason)
+
+CODE THAT DECIDES IT:
+  factory/types.ts TaskPacket:
+    createdAt: string;          // required
+    updatedAt: string;          // required
+    parkReason?: string;        // optional
+  factory/state.ts isPacket:
+    typeof o.createdAt === "string" &&
+    typeof o.updatedAt === "string" &&
+    optional(o.parkReason, (v) => typeof v === "string")
+  factory/state.ts migratePacket fills a missing createdAt/updatedAt from
+  the other or "—" before isPacket; a non-string is still refused.
+
+AFTER: both required timestamps and optional parkReason are in the packet
+block, citing types.ts and state.ts.
+
+================================================================
+Negative control
+================================================================
+
+  git show origin/main:docs/01-architecture.md | grep -c 'witness.ts\|github-pr.ts\|halt.ts\|state.ts\|terminal.ts'
+    → 0 (those SPEC §5/§6/§7 modules were unnamed)
+  git show origin/main:docs/10-schemas.md | grep -c createdAt
+    → 0 in the packet block (the field was absent)
+  This branch names them. Restoring origin/main docs would drop the
+  inventory and the three packet fields; that is the guard.


### PR DESCRIPTION
**T-23** (gap G-15) and **T-24** (gap G-22). Docs only — no source file changed.

## T-23 — five false or aspirational claims, each corrected beside the code that decides it

| doc | claimed | actually |
|---|---|---|
| `07-github-app.md:3` | "The factory authenticates as a GitHub App, **never** as a personal PAT" | **false**, and contradicted 30 lines below by its own file. The only write credential is `FOUNDRY_PAT`, a classic PAT (`github-pr.ts:741`); the only read credential is `GITHUB_TOKEN`/`GH_TOKEN` (`github-pr.ts:71`). A false security claim is worse than a missing one |
| `07-github-app.md:63-65` | three secrets to provision | `FOUNDRY_APP_ID`, `FOUNDRY_APP_PRIVATE_KEY`, `FOUNDRY_INSTALLATION_ID` are read by **no code**. An operator following it provisioned three secrets that do nothing |
| `06-v2.md` | E2B lifecycle with a **shallow** clone | no executor exists in this tree; `sandbox.ts` emits `# planned · not executed` strings, and its clone line says **full** clone |
| `PRODUCT.md` §5 / `04-stations.md` | stations 4/5 are gates | `applyAdvance` stores a dry-run plan then does a bare status bump; `lighting: "lit"` is a constant with no reviewer identity. The only real gate on that arc is `evidenceIsReady` |
| `PRODUCT.md` §5 / `04-stations.md` | "heuristic rank" is live station-1 behaviour | `rankIssues` has one caller, in the module `06-v2.md` itself says is on no live path. The live `pickCandidate` uses roster order |

## T-24 — the reference material was incomplete

- **`01-architecture.md` listed 8 of 29 non-test modules**, omitting every module implementing SPEC §5/§6/§7 — `witness.ts`, `github-pr.ts`, `halt.ts`, `verify-ledger.ts`, `ledger-check.ts`, `state.ts`, `terminal.ts` and ten more. Now inventories all 29, **glob-derived** rather than hand-listed, with the three test-support modules identified as such and `factory/README.md` named as the closer operator-facing map.
- **There was no environment-variable reference anywhere.** Built one, derived by grepping `process.env.[A-Z_]+` plus the `env.NAME` forms, then cross-checked. `FOUNDRY_GITHUB_TIMEOUT_MS` is read by shipping code and had appeared in **zero** markdown files. `FOUNDRY_LIVE` is documented as a GitHub Actions repository variable (`vars.FOUNDRY_LIVE`), not a `process.env` read. Zero shipping reads are unlisted.
- **`10-schemas.md`'s packet block omitted `createdAt`, `updatedAt`, `parkReason`** — all three real, all validated on load, and the first two non-optional, so a reader building a ledger from the doc produced a file the loader refuses.

## Verified
suite **383/383** · typecheck **0** · evidence `T-23-doc-truth.txt`, `T-24-reference.txt`, each showing the claim before, the code that decides it, and the claim after.



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR aligns the documentation with the currently implemented factory behavior and expands previously incomplete reference material.
- Reclassifies GitHub App, sandbox execution, heuristic ranking, and stations 4–5 behavior according to the shipping code.
- Adds a complete factory-module inventory and environment-variable reference.
- Documents all packet timestamp and parking fields, including the actual timestamp validation limitations.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/01-architecture.md | Expands the architecture inventory and documents the implemented credential, environment, selection, and station behavior. |
| docs/04-stations.md | Corrects the station model to distinguish status transitions from implemented execution and review gates. |
| docs/06-v2.md | Clarifies that sandbox execution is external and that the local implementation produces a full-clone dry-run plan. |
| docs/07-github-app.md | Replaces the unsupported GitHub App authentication claim with the currently implemented PAT and read-token model. |
| docs/10-schemas.md | Adds the omitted packet fields and explicitly documents that timestamp format is not enforced, resolving the prior review finding. |
| docs/PRODUCT.md | Updates the product-level station descriptions to match the current engine behavior. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs: say what the packet timestamps enf..."](https://github.com/ravidsrk/oss-foundry/commit/72684b220532d65a2e62ba4c891ceead973035a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59068213)</sub>

<!-- /greptile_comment -->