### PR TITLE
P2: allowlist the witness child environment and bound every hung child

### DIFF
--- a/docs/completion/evidence/T-08-env-allowlist.txt
+++ b/docs/completion/evidence/T-08-env-allowlist.txt
@@ -1,0 +1,54 @@
+T-08 — invert witnessChildEnv from a denylist to an allowlist (G-02)
+
+Allowlist (factory/witness.ts WITNESS_CHILD_ENV_KEYS):
+  PATH, HOME, TMPDIR, TEMP, TMP, LANG, LC_ALL, LC_CTYPE, TZ, GIT_CONFIG_GLOBAL
+
+Each entry is justified in-source. SHELL is omitted (bash -c is the contract).
+Windows SystemRoot/USERPROFILE omitted (host runner is POSIX: bash -c, rm -rf).
+
+--- child's observed env (planted secrets in the parent, then printenv in the child) ---
+
+Planted on the parent and absent from the child:
+  NPM_TOKEN=foundry_planted_npm_token
+  AWS_SECRET_ACCESS_KEY=foundry_planted_aws_secret
+  ANTHROPIC_API_KEY=foundry_planted_anthropic_key
+  OP_SERVICE_ACCOUNT_TOKEN=foundry_planted_op_token
+  FOUNDRY_PAT=foundry_planted_foundry_pat
+  NOT_A_TOOLCHAIN_VAR=foundry_planted_unrelated
+
+witnessChildEnv({ PATH, HOME, NPM_TOKEN, AWS_SECRET_ACCESS_KEY, ANTHROPIC_API_KEY, FOUNDRY_PAT })
+  keys: ["HOME","PATH"]
+
+hostRunner("run-tests@head", printenv) exit 0:
+  PATH_LEN=1122
+  HOME_SET=yes
+  printenv (bash also synthesises PWD/SHLVL/_):
+    HOME, LANG, PATH, TMPDIR, PWD, SHLVL, _
+  leaked planted values: (none)
+
+--- test (fix in place) ---
+
+node --experimental-strip-types --test --test-name-pattern 'G-02|#114' factory/witness-host.test.ts
+
+✔ #114 / G-02: the host runner allowlists the child env and drops planted secrets (15.91575ms)
+ℹ tests 1
+ℹ pass 1
+ℹ fail 0
+
+--- negative control ---
+
+Reverted witnessChildEnv to the four-name denylist
+(FOUNDRY_PAT, GITHUB_TOKEN, GH_TOKEN, E2B_API_KEY; copy everything else).
+
+node --experimental-strip-types --test --test-name-pattern 'G-02' factory/witness-host.test.ts
+
+✖ #114 / G-02: the host runner allowlists the child env and drops planted secrets (0.790208ms)
+  AssertionError [ERR_ASSERTION]: GIT_ASKPASS is a credential helper, not a toolchain need
+  + actual - expected
+  + '/tmp/askpass'
+  - undefined
+
+The denylist still passes FOUNDRY_PAT's cousins and every other parent var
+(NPM_TOKEN, AWS_SECRET_ACCESS_KEY, GIT_ASKPASS, …). Restore the allowlist; test green.
+
+Fix restored from the known-good copy; cmp matched; G-02 test pass 1 fail 0.

--- a/docs/completion/evidence/T-10-child-timeout.txt
+++ b/docs/completion/evidence/T-10-child-timeout.txt
@@ -1,0 +1,80 @@
+T-10 — bound witness children and the unwired scout fetch (G-14, G-26)
+
+Default: WITNESS_CHILD_TIMEOUT_MS = 900000 (15 minutes).
+  Why minutes: a cold npm ci plus an upstream suite is a multi-minute job; the 15s
+  GitHub-fetch bound would kill a healthy run. 15 minutes is long enough for that
+  job on a laptop and short enough that a hung registry / `while true` cannot pin
+  `evidence` until the operator SIGKILLs the factory.
+
+Override: FOUNDRY_WITNESS_TIMEOUT_MS, integer 1..WITNESS_CHILD_TIMEOUT_MAX_MS (1 hour).
+Invalid values (-1, Infinity, 15.5, 0, non-number) fall back to 15 minutes
+(matching githubFetchTimeoutMs). A 0/NaN timeout would disable the deadline.
+
+A timed-out child is SIGKILL'd. execFile's `timeout` + `killSignal` cover the
+spawned PID; a pgrep -P walk SIGKILLs descendants so `bash -c 'npm test'`
+cannot leave the suite running after bash dies.
+Refusal names the step:
+  witness step "<step>" exceeded the <n>ms deadline and was killed
+
+Scout fetch (factory/github-scout.ts) now goes through githubRequestInit
+(AbortSignal.timeout). fetchImpl is a test seam. Module remains unwired.
+
+--- hung child (fix in place) ---
+
+FOUNDRY_WITNESS_TIMEOUT_MS=250
+hostRunner("run-tests@head", ["sleep 10"])
+
+✔ G-14: a hung witness child is killed at the deadline and the refusal names the step (274.30625ms)
+  exit != 0
+  output matches: witness step "run-tests@head" exceeded the 250ms deadline and was killed
+  elapsed < 2000ms
+
+✔ G-14: a truthy invalid FOUNDRY_WITNESS_TIMEOUT_MS falls back to the shipped bound
+
+--- scout deadline (fix in place) ---
+
+✔ G-26: the unwired scout's fetch carries a deadline (10.550833ms)
+  every fetchImpl call received init.signal
+
+✔ G-26: a hung scout fetch fails closed within the deadline (246.986416ms)
+  FOUNDRY_GITHUB_TIMEOUT_MS=40; 6 Wave≤1 repos abort; errors match /abort|timeout/i
+  elapsed < 2000ms
+
+--- negative control: child timeout ---
+
+Removed execFile `timeout`/`killSignal` and the setTimeout that SIGKILLs the
+process tree (timer = undefined). Nothing then killed the child.
+
+node --experimental-strip-types --test --test-name-pattern 'hung witness child' factory/witness-host.test.ts
+
+✖ G-14: a hung witness child is killed at the deadline and the refusal names the step (2003.732583ms)
+  Error: hung witness child was not killed
+      at Timeout._onTimeout (factory/witness-host.test.ts:329:33)
+
+Watchdog fired at 2s; sleep 10 was still running. Restore the deadline; test green.
+
+--- negative control: scout fetch ---
+
+Reverted to `fetchImpl(url, { headers })` (no githubRequestInit).
+
+node --experimental-strip-types --test --test-name-pattern 'scout.s fetch carries a deadline' factory/witness-host.test.ts
+
+✖ G-26: the unwired scout's fetch carries a deadline (1.223292ms)
+  AssertionError: ravidsrk/orca-fleet: scout fetch received no AbortSignal — githubRequestInit must attach a deadline;
+  … (6 Wave≤1 repos) …
+  6 !== 0
+
+Restore githubRequestInit; test green.
+
+Fix restored; G-14 and G-26 tests pass.
+
+--- suite ---
+
+npm test
+  suite ok — 383 tests across 19 files, every file accounted for
+
+typecheck (origin/main has no `npm run typecheck` / tsconfig; P1 lands that gate)
+  npx -p typescript@5.9.3 -p @types/node@24.9.2 tsc --noEmit --strict \
+    --erasableSyntaxOnly --verbatimModuleSyntax \
+    factory/witness.ts factory/github-scout.ts factory/witness-host.test.ts
+  EXIT:0  (0 errors)

--- a/factory/github-scout.ts
+++ b/factory/github-scout.ts
@@ -1,5 +1,5 @@
 import { ALLOWLIST } from "./allowlist.ts";
-import { githubApiHeaders } from "./github-pr.ts";
+import { githubApiHeaders, githubRequestInit } from "./github-pr.ts";
 import { rankIssues } from "./scout.ts";
 import type { ScoutScore } from "./types.ts";
 
@@ -27,7 +27,10 @@ export interface LiveIssue {
  * classifies every candidate first and splits the verdict into `competingKeys` (stand down) and
  * `adjacentKeys` (hold for human triage) before anything is queued (issue #44 item 8).
  */
-export async function scoutGithub(data: { maxPerRepo?: number } = {}) {
+export async function scoutGithub(
+  data: { maxPerRepo?: number } = {},
+  fetchImpl: typeof fetch = fetch,
+) {
   const maxPerRepo = Math.min(Math.max(data.maxPerRepo ?? 5, 1), 8);
   const found: Omit<LiveIssue, "scout">[] = [];
   const errors: string[] = [];
@@ -36,7 +39,10 @@ export async function scoutGithub(data: { maxPerRepo?: number } = {}) {
   for (const repo of ALLOWLIST.filter((r) => r.wave <= 1)) {
     const url = `https://api.github.com/repos/${repo.owner}/${repo.name}/issues?state=open&per_page=${maxPerRepo}&sort=updated`;
     try {
-      const res = await fetch(url, { headers });
+      // Deadline via githubRequestInit (G-26). Wiring this module is out of scope; the
+      // fetch still must not hang the process if someone calls it. `fetchImpl` is a test
+      // seam so the deadline is asserted without a network.
+      const res = await fetchImpl(url, githubRequestInit({ headers }));
       if (!res.ok) {
         errors.push(
           res.status === 403

--- a/factory/witness-host.test.ts
+++ b/factory/witness-host.test.ts
@@ -417,6 +417,46 @@ test("G-14: a hung grandchild is dead after the deadline, not reparented", async
   }
 });
 
+test("G-14: a daemonized grandchild is dead after the deadline", async () => {
+  // Real clock. The intermediate subshell exits immediately so `sleep` is
+  // reparented to init — `pgrep -P` on the witness shell cannot see it.
+  // Process-group membership survives that; a group SIGKILL must reap it.
+  const pidFile = join(tmp("foundry-daemon-"), "pid");
+  const prev = process.env.FOUNDRY_WITNESS_TIMEOUT_MS;
+  process.env.FOUNDRY_WITNESS_TIMEOUT_MS = "400";
+  let daemonPid: number | undefined;
+  try {
+    const run = await Promise.race([
+      hostRunner("run-tests@head", [
+        `(sleep 20 >/dev/null 2>&1 & echo $! > ${JSON.stringify(pidFile)}); sleep 20`,
+      ]),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("hung daemon parent was not killed")), 2000),
+      ),
+    ]);
+    assert.notEqual(run.exit, 0, run.output);
+    assert.match(run.output, /exceeded the 400ms deadline/, run.output);
+    daemonPid = Number(readFileSync(pidFile, "utf8").trim());
+    assert.ok(Number.isInteger(daemonPid) && daemonPid > 1, `pid file held ${daemonPid}`);
+    const listed = spawnSync("ps", ["-p", String(daemonPid), "-o", "state="], { encoding: "utf8" });
+    const state = listed.stdout.trim();
+    assert.ok(
+      state === "" || state.startsWith("Z"),
+      `daemonized grandchild ${daemonPid} still running (ps state=${JSON.stringify(state)}) — escaped the process group`,
+    );
+  } finally {
+    if (daemonPid !== undefined) {
+      try {
+        process.kill(daemonPid, "SIGKILL");
+      } catch {
+        // already dead
+      }
+    }
+    if (prev === undefined) delete process.env.FOUNDRY_WITNESS_TIMEOUT_MS;
+    else process.env.FOUNDRY_WITNESS_TIMEOUT_MS = prev;
+  }
+});
+
 test("G-14: a self-SIGKILL is not reported as a deadline", async () => {
   const run = await hostRunner("run-tests@head", ["kill -KILL $$"]);
   assert.notEqual(run.exit, 0, run.output);

--- a/factory/witness-host.test.ts
+++ b/factory/witness-host.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { chmodSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
@@ -244,6 +245,15 @@ test("#114 / G-02: the host runner allowlists the child env and drops planted se
     LANG: "C.UTF-8",
     TZ: "UTC",
     GIT_CONFIG_GLOBAL: "/tmp/gitconfig",
+    HTTPS_PROXY: "http://user:foundry_planted_proxy_pass@proxy.example:8080",
+    HTTP_PROXY: "http://proxy.example:3128",
+    NO_PROXY: "localhost,127.0.0.1",
+    NVM_DIR: "/opt/nvm",
+    NODE_EXTRA_CA_CERTS: "/etc/ssl/corp.pem",
+    GIT_SSL_CAINFO: "/etc/ssl/git.pem",
+    MISE_DATA_DIR: "/opt/mise",
+    MISE_GITHUB_TOKEN: "foundry_planted_mise_token",
+    ASDF_GITHUB_API_TOKEN: "foundry_planted_asdf_token",
     GIT_ASKPASS: "/tmp/askpass",
     SHELL: "/bin/zsh",
     FOUNDRY_PAT: "ghp_should_never_leak",
@@ -262,6 +272,15 @@ test("#114 / G-02: the host runner allowlists the child env and drops planted se
   assert.equal(isolated.LANG, "C.UTF-8");
   assert.equal(isolated.TZ, "UTC");
   assert.equal(isolated.GIT_CONFIG_GLOBAL, "/tmp/gitconfig");
+  assert.equal(isolated.HTTPS_PROXY, "http://proxy.example:8080");
+  assert.equal(isolated.HTTP_PROXY, "http://proxy.example:3128");
+  assert.equal(isolated.NO_PROXY, "localhost,127.0.0.1");
+  assert.equal(isolated.NVM_DIR, "/opt/nvm");
+  assert.equal(isolated.NODE_EXTRA_CA_CERTS, "/etc/ssl/corp.pem");
+  assert.equal(isolated.GIT_SSL_CAINFO, "/etc/ssl/git.pem");
+  assert.equal(isolated.MISE_DATA_DIR, "/opt/mise");
+  assert.equal(isolated.MISE_GITHUB_TOKEN, undefined, "MISE_GITHUB_TOKEN is a credential; no MISE_* glob");
+  assert.equal(isolated.ASDF_GITHUB_API_TOKEN, undefined, "ASDF_GITHUB_API_TOKEN is a credential; no ASDF_* glob");
   assert.equal(isolated.GIT_ASKPASS, undefined, "GIT_ASKPASS is a credential helper, not a toolchain need");
   assert.equal(isolated.SHELL, undefined, "SHELL is not a toolchain need; bash -c is the contract");
   assert.equal(isolated.FOUNDRY_PAT, undefined);
@@ -273,7 +292,24 @@ test("#114 / G-02: the host runner allowlists the child env and drops planted se
   assert.equal(isolated.ANTHROPIC_API_KEY, undefined);
   assert.equal(isolated.OP_SERVICE_ACCOUNT_TOKEN, undefined);
   assert.equal(isolated.NOT_A_TOOLCHAIN_VAR, undefined);
-  assert.deepEqual(Object.keys(isolated).sort(), ["GIT_CONFIG_GLOBAL", "HOME", "LANG", "PATH", "TMPDIR", "TZ"]);
+  assert.deepEqual(
+    Object.keys(isolated).sort(),
+    [
+      "GIT_CONFIG_GLOBAL",
+      "GIT_SSL_CAINFO",
+      "HOME",
+      "HTTPS_PROXY",
+      "HTTP_PROXY",
+      "LANG",
+      "MISE_DATA_DIR",
+      "NODE_EXTRA_CA_CERTS",
+      "NO_PROXY",
+      "NVM_DIR",
+      "PATH",
+      "TMPDIR",
+      "TZ",
+    ].sort(),
+  );
 
   const planted: Record<string, string> = {
     NPM_TOKEN: "foundry_planted_npm_token",
@@ -282,6 +318,9 @@ test("#114 / G-02: the host runner allowlists the child env and drops planted se
     OP_SERVICE_ACCOUNT_TOKEN: "foundry_planted_op_token",
     FOUNDRY_PAT: "foundry_planted_foundry_pat",
     NOT_A_TOOLCHAIN_VAR: "foundry_planted_unrelated",
+    MISE_GITHUB_TOKEN: "foundry_planted_mise_token",
+    HTTPS_PROXY: "http://user:foundry_planted_proxy_pass@127.0.0.1:9",
+    NVM_DIR: "/tmp/foundry-nvm-dir",
   };
   const saved: Record<string, string | undefined> = {};
   for (const key of Object.keys(planted)) saved[key] = process.env[key];
@@ -297,7 +336,14 @@ test("#114 / G-02: the host runner allowlists the child env and drops planted se
     assert.equal(run.exit, 0, run.output);
     assert.match(run.output, /PATH_LEN=[1-9]/, `child PATH was empty — over-aggressive allowlist: ${run.output}`);
     assert.match(run.output, /HOME_SET=yes/, `child HOME was missing: ${run.output}`);
+    assert.match(run.output, /^NVM_DIR=\/tmp\/foundry-nvm-dir$/m, `NVM_DIR did not reach the child: ${run.output}`);
+    assert.match(run.output, /^HTTPS_PROXY=http:\/\/127\.0\.0\.1:9\/?$/m, `stripped proxy URL missing: ${run.output}`);
     for (const [key, value] of Object.entries(planted)) {
+      if (key === "NVM_DIR") continue;
+      if (key === "HTTPS_PROXY") {
+        assert.doesNotMatch(run.output, /foundry_planted_proxy_pass/, `proxy userinfo reached the child: ${run.output}`);
+        continue;
+      }
       assert.doesNotMatch(run.output, new RegExp(value), `${key} reached the child: ${run.output}`);
     }
   } finally {
@@ -340,6 +386,46 @@ test("G-14: a hung witness child is killed at the deadline and the refusal names
     if (prev === undefined) delete process.env.FOUNDRY_WITNESS_TIMEOUT_MS;
     else process.env.FOUNDRY_WITNESS_TIMEOUT_MS = prev;
   }
+});
+
+test("G-14: a hung grandchild is dead after the deadline, not reparented", async () => {
+  // Real clock: we have to observe a live grandchild PID and then that it is gone.
+  // Fake timers cannot tell a reparented `sleep` from a reaped one.
+  const pidFile = join(tmp("foundry-grandchild-"), "pid");
+  const prev = process.env.FOUNDRY_WITNESS_TIMEOUT_MS;
+  process.env.FOUNDRY_WITNESS_TIMEOUT_MS = "400";
+  try {
+    const run = await Promise.race([
+      hostRunner("run-tests@head", [`(sleep 20 & echo $! > ${JSON.stringify(pidFile)}; wait)`]),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("hung grandchild parent was not killed")), 2000),
+      ),
+    ]);
+    assert.notEqual(run.exit, 0, run.output);
+    assert.match(run.output, /exceeded the 400ms deadline/, run.output);
+    const pid = Number(readFileSync(pidFile, "utf8").trim());
+    assert.ok(Number.isInteger(pid) && pid > 1, `pid file held ${pid}`);
+    const listed = spawnSync("ps", ["-p", String(pid), "-o", "state="], { encoding: "utf8" });
+    const state = listed.stdout.trim();
+    assert.ok(
+      state === "" || state.startsWith("Z"),
+      `grandchild ${pid} still running (ps state=${JSON.stringify(state)}) — reparented after the shell died`,
+    );
+  } finally {
+    if (prev === undefined) delete process.env.FOUNDRY_WITNESS_TIMEOUT_MS;
+    else process.env.FOUNDRY_WITNESS_TIMEOUT_MS = prev;
+  }
+});
+
+test("G-14: a self-SIGKILL is not reported as a deadline", async () => {
+  const run = await hostRunner("run-tests@head", ["kill -KILL $$"]);
+  assert.notEqual(run.exit, 0, run.output);
+  assert.doesNotMatch(
+    run.output,
+    /exceeded the .* deadline/,
+    `SIGKILL was mislabeled as a timeout: ${run.output}`,
+  );
+  assert.match(run.output, /killed by SIGKILL/, run.output);
 });
 
 test("G-14: a truthy invalid FOUNDRY_WITNESS_TIMEOUT_MS falls back to the shipped bound", () => {

--- a/factory/witness-host.test.ts
+++ b/factory/witness-host.test.ts
@@ -457,6 +457,67 @@ test("G-14: a daemonized grandchild is dead after the deadline", async () => {
   }
 });
 
+test("G-14: a setsid grandchild is not reached — that is the sandbox boundary", async () => {
+  // Pins the documented limit, not a bug. A process that calls setsid() leaves
+  // the group we signal and is not a pgrep -P child after the intermediate
+  // parent exits. Defeating it would need a cgroup/jail/VM (ADR 0003); a
+  // best-effort pid scan that sometimes kills the wrong process is worse.
+  // This test fails if the limit silently changes shape (we start reaching it,
+  // or we stop spawning a group at all and start claiming we do).
+  const dir = tmp("foundry-setsid-");
+  const pidFile = join(dir, "pid");
+  const script = join(dir, "escape.py");
+  writeFileSync(
+    script,
+    [
+      "import os, sys, time",
+      "pid = os.fork()",
+      "if pid > 0:",
+      "    sys.stdout.write(str(pid))",
+      "    sys.exit(0)",
+      "os.setsid()",
+      "devnull = os.open(os.devnull, os.O_RDWR)",
+      "os.dup2(devnull, 0)",
+      "os.dup2(devnull, 1)",
+      "os.dup2(devnull, 2)",
+      "time.sleep(20)",
+    ].join("\n"),
+  );
+  const prev = process.env.FOUNDRY_WITNESS_TIMEOUT_MS;
+  process.env.FOUNDRY_WITNESS_TIMEOUT_MS = "400";
+  let escapedPid: number | undefined;
+  try {
+    const run = await Promise.race([
+      hostRunner("run-tests@head", [
+        `python3 ${JSON.stringify(script)} > ${JSON.stringify(pidFile)} 2>/dev/null; sleep 20`,
+      ]),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("setsid parent was not killed")), 2000),
+      ),
+    ]);
+    assert.notEqual(run.exit, 0, run.output);
+    assert.match(run.output, /exceeded the 400ms deadline/, run.output);
+    escapedPid = Number(readFileSync(pidFile, "utf8").trim());
+    assert.ok(Number.isInteger(escapedPid) && escapedPid > 1, `pid file held ${escapedPid}`);
+    const listed = spawnSync("ps", ["-p", String(escapedPid), "-o", "state="], { encoding: "utf8" });
+    const state = listed.stdout.trim();
+    assert.ok(
+      state.length > 0 && !state.startsWith("Z"),
+      `setsid grandchild ${escapedPid} was reached (ps state=${JSON.stringify(state)}) — the session-escape boundary moved`,
+    );
+  } finally {
+    if (escapedPid !== undefined) {
+      try {
+        process.kill(escapedPid, "SIGKILL");
+      } catch {
+        // already dead
+      }
+    }
+    if (prev === undefined) delete process.env.FOUNDRY_WITNESS_TIMEOUT_MS;
+    else process.env.FOUNDRY_WITNESS_TIMEOUT_MS = prev;
+  }
+});
+
 test("G-14: a self-SIGKILL is not reported as a deadline", async () => {
   const run = await hostRunner("run-tests@head", ["kill -KILL $$"]);
   assert.notEqual(run.exit, 0, run.output);

--- a/factory/witness-host.test.ts
+++ b/factory/witness-host.test.ts
@@ -4,7 +4,16 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 import { tmp } from "./tmp-dir.ts";
-import { hostRunner, resolveToolchain, witnessChildEnv, witnessEvidence } from "./witness.ts";
+import { scoutGithub } from "./github-scout.ts";
+import {
+  hostRunner,
+  resolveToolchain,
+  witnessChildEnv,
+  witnessChildTimeoutMs,
+  witnessEvidence,
+  WITNESS_CHILD_TIMEOUT_MS,
+  WITNESS_CHILD_TIMEOUT_MAX_MS,
+} from "./witness.ts";
 
 /**
  * `hostRunner` driven against a real shell — the only assertions in the repo that a fake runner
@@ -227,30 +236,75 @@ test("two witness runs for the same repo under one frozen millisecond both succe
  * #80 was filed for, one layer down. Refused here as well as sanitised by the caller, because a
  * guard that only exists at the call site is one call site away from not existing.
  */
-test("#114: the host runner does not pass FOUNDRY_PAT into the child", async () => {
+test("#114 / G-02: the host runner allowlists the child env and drops planted secrets", async () => {
   const isolated = witnessChildEnv({
     PATH: "/usr/bin",
+    HOME: "/tmp",
+    TMPDIR: "/tmp",
+    LANG: "C.UTF-8",
+    TZ: "UTC",
+    GIT_CONFIG_GLOBAL: "/tmp/gitconfig",
+    GIT_ASKPASS: "/tmp/askpass",
+    SHELL: "/bin/zsh",
     FOUNDRY_PAT: "ghp_should_never_leak",
     GITHUB_TOKEN: "ghs_also_secret",
     GH_TOKEN: "ghp_gh",
     E2B_API_KEY: "e2b_secret",
-    HOME: "/tmp",
+    NPM_TOKEN: "foundry_planted_npm_token",
+    AWS_SECRET_ACCESS_KEY: "foundry_planted_aws_secret",
+    ANTHROPIC_API_KEY: "foundry_planted_anthropic_key",
+    OP_SERVICE_ACCOUNT_TOKEN: "foundry_planted_op_token",
+    NOT_A_TOOLCHAIN_VAR: "foundry_planted_unrelated",
   });
+  assert.equal(isolated.PATH, "/usr/bin");
+  assert.equal(isolated.HOME, "/tmp");
+  assert.equal(isolated.TMPDIR, "/tmp");
+  assert.equal(isolated.LANG, "C.UTF-8");
+  assert.equal(isolated.TZ, "UTC");
+  assert.equal(isolated.GIT_CONFIG_GLOBAL, "/tmp/gitconfig");
+  assert.equal(isolated.GIT_ASKPASS, undefined, "GIT_ASKPASS is a credential helper, not a toolchain need");
+  assert.equal(isolated.SHELL, undefined, "SHELL is not a toolchain need; bash -c is the contract");
   assert.equal(isolated.FOUNDRY_PAT, undefined);
   assert.equal(isolated.GITHUB_TOKEN, undefined);
   assert.equal(isolated.GH_TOKEN, undefined);
   assert.equal(isolated.E2B_API_KEY, undefined);
-  assert.equal(isolated.PATH, "/usr/bin");
-  assert.equal(isolated.HOME, "/tmp");
+  assert.equal(isolated.NPM_TOKEN, undefined);
+  assert.equal(isolated.AWS_SECRET_ACCESS_KEY, undefined);
+  assert.equal(isolated.ANTHROPIC_API_KEY, undefined);
+  assert.equal(isolated.OP_SERVICE_ACCOUNT_TOKEN, undefined);
+  assert.equal(isolated.NOT_A_TOOLCHAIN_VAR, undefined);
+  assert.deepEqual(Object.keys(isolated).sort(), ["GIT_CONFIG_GLOBAL", "HOME", "LANG", "PATH", "TMPDIR", "TZ"]);
 
-  const saved = process.env.FOUNDRY_PAT;
-  process.env.FOUNDRY_PAT = "ghp_should_never_leak";
+  const planted: Record<string, string> = {
+    NPM_TOKEN: "foundry_planted_npm_token",
+    AWS_SECRET_ACCESS_KEY: "foundry_planted_aws_secret",
+    ANTHROPIC_API_KEY: "foundry_planted_anthropic_key",
+    OP_SERVICE_ACCOUNT_TOKEN: "foundry_planted_op_token",
+    FOUNDRY_PAT: "foundry_planted_foundry_pat",
+    NOT_A_TOOLCHAIN_VAR: "foundry_planted_unrelated",
+  };
+  const saved: Record<string, string | undefined> = {};
+  for (const key of Object.keys(planted)) saved[key] = process.env[key];
   try {
-    const run = await hostRunner("run-tests@head", ["printenv FOUNDRY_PAT || true"]);
-    assert.doesNotMatch(run.output, /ghp_should_never_leak/);
+    Object.assign(process.env, planted);
+    const run = await hostRunner("run-tests@head", [
+      [
+        'echo PATH_LEN=${#PATH}',
+        'echo HOME_SET=$(if [ -n "$HOME" ]; then echo yes; else echo no; fi)',
+        "printenv",
+      ].join("; "),
+    ]);
+    assert.equal(run.exit, 0, run.output);
+    assert.match(run.output, /PATH_LEN=[1-9]/, `child PATH was empty — over-aggressive allowlist: ${run.output}`);
+    assert.match(run.output, /HOME_SET=yes/, `child HOME was missing: ${run.output}`);
+    for (const [key, value] of Object.entries(planted)) {
+      assert.doesNotMatch(run.output, new RegExp(value), `${key} reached the child: ${run.output}`);
+    }
   } finally {
-    if (saved === undefined) delete process.env.FOUNDRY_PAT;
-    else process.env.FOUNDRY_PAT = saved;
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
   }
 });
 
@@ -259,5 +313,110 @@ test("the host runner refuses a scratch prefix that would escape the tmpdir", as
     const result = await hostRunner("mkdtemp", [bad]);
     assert.equal(result.exit, 1, `${bad} was accepted: ${result.output}`);
     assert.match(result.output, /path separator/, result.output);
+  }
+});
+
+test("G-14: a hung witness child is killed at the deadline and the refusal names the step", async () => {
+  // Real clock on purpose: the production deadline is `setTimeout` + SIGKILL of a live
+  // `sleep` process group. Fake timers cannot observe whether the grandchild actually died.
+  const prev = process.env.FOUNDRY_WITNESS_TIMEOUT_MS;
+  process.env.FOUNDRY_WITNESS_TIMEOUT_MS = "250";
+  const started = Date.now();
+  try {
+    const run = await Promise.race([
+      hostRunner("run-tests@head", ["sleep 10"]),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("hung witness child was not killed")), 2000),
+      ),
+    ]);
+    assert.notEqual(run.exit, 0, run.output);
+    assert.match(
+      run.output,
+      /witness step "run-tests@head" exceeded the 250ms deadline and was killed/,
+      run.output,
+    );
+    assert.ok(Date.now() - started < 2000, `hung child took ${Date.now() - started}ms`);
+  } finally {
+    if (prev === undefined) delete process.env.FOUNDRY_WITNESS_TIMEOUT_MS;
+    else process.env.FOUNDRY_WITNESS_TIMEOUT_MS = prev;
+  }
+});
+
+test("G-14: a truthy invalid FOUNDRY_WITNESS_TIMEOUT_MS falls back to the shipped bound", () => {
+  assert.equal(witnessChildTimeoutMs(undefined), WITNESS_CHILD_TIMEOUT_MS);
+  assert.equal(witnessChildTimeoutMs(""), WITNESS_CHILD_TIMEOUT_MS);
+  assert.equal(witnessChildTimeoutMs("nope"), WITNESS_CHILD_TIMEOUT_MS);
+  assert.equal(witnessChildTimeoutMs("0"), WITNESS_CHILD_TIMEOUT_MS);
+  assert.equal(witnessChildTimeoutMs("-1"), WITNESS_CHILD_TIMEOUT_MS);
+  assert.equal(witnessChildTimeoutMs("Infinity"), WITNESS_CHILD_TIMEOUT_MS);
+  assert.equal(witnessChildTimeoutMs("15.5"), WITNESS_CHILD_TIMEOUT_MS);
+  assert.equal(witnessChildTimeoutMs(WITNESS_CHILD_TIMEOUT_MAX_MS + 1), WITNESS_CHILD_TIMEOUT_MS);
+  assert.equal(witnessChildTimeoutMs(-1), WITNESS_CHILD_TIMEOUT_MS);
+  assert.equal(witnessChildTimeoutMs(Number.POSITIVE_INFINITY), WITNESS_CHILD_TIMEOUT_MS);
+  assert.equal(witnessChildTimeoutMs("250"), 250);
+  assert.equal(witnessChildTimeoutMs(250), 250);
+  assert.equal(witnessChildTimeoutMs(WITNESS_CHILD_TIMEOUT_MAX_MS), WITNESS_CHILD_TIMEOUT_MAX_MS);
+
+  const prev = process.env.FOUNDRY_WITNESS_TIMEOUT_MS;
+  process.env.FOUNDRY_WITNESS_TIMEOUT_MS = "-1";
+  try {
+    assert.equal(witnessChildTimeoutMs(), WITNESS_CHILD_TIMEOUT_MS);
+  } finally {
+    if (prev === undefined) delete process.env.FOUNDRY_WITNESS_TIMEOUT_MS;
+    else process.env.FOUNDRY_WITNESS_TIMEOUT_MS = prev;
+  }
+});
+
+test("G-26: the unwired scout's fetch carries a deadline", async () => {
+  let fetches = 0;
+  const fetchImpl: typeof fetch = async (_url, init) => {
+    fetches += 1;
+    assert.ok(init?.signal, "scout fetch received no AbortSignal — githubRequestInit must attach a deadline");
+    return new Response(JSON.stringify([]), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+  const result = await scoutGithub({ maxPerRepo: 1 }, fetchImpl);
+  assert.equal(result.ok, true);
+  assert.ok(fetches > 0, "scout never called fetch");
+  assert.equal(result.errors.length, 0, result.errors.join("; "));
+});
+
+test("G-26: a hung scout fetch fails closed within the deadline", async () => {
+  // Real clock: `AbortSignal.timeout` is what production attaches, and fake timers do not
+  // fire it. The watchdog holds node:test's event loop until the abort (or 2s, the failure).
+  const hung: typeof fetch = (_url, init) =>
+    new Promise((_resolve, reject) => {
+      const signal = init?.signal;
+      if (!signal) {
+        reject(new Error("hung fetch received no AbortSignal — scoutGithub must attach a deadline"));
+        return;
+      }
+      const fail = () =>
+        reject(signal.reason ?? new DOMException("The operation was aborted due to timeout", "TimeoutError"));
+      if (signal.aborted) {
+        fail();
+        return;
+      }
+      signal.addEventListener("abort", fail, { once: true });
+    });
+  const prev = process.env.FOUNDRY_GITHUB_TIMEOUT_MS;
+  process.env.FOUNDRY_GITHUB_TIMEOUT_MS = "40";
+  const started = Date.now();
+  try {
+    const result = await Promise.race([
+      scoutGithub({ maxPerRepo: 1 }, hung),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("hung scout fetch was not aborted")), 2000),
+      ),
+    ]);
+    assert.equal(result.ok, true);
+    assert.ok(result.errors.length > 0, "hung scout produced no errors");
+    assert.match(result.errors.join("\n"), /abort|timeout|This operation was aborted/i);
+    assert.ok(Date.now() - started < 2000, `hung scout fetch took ${Date.now() - started}ms`);
+  } finally {
+    if (prev === undefined) delete process.env.FOUNDRY_GITHUB_TIMEOUT_MS;
+    else process.env.FOUNDRY_GITHUB_TIMEOUT_MS = prev;
   }
 });

--- a/factory/witness.ts
+++ b/factory/witness.ts
@@ -1,4 +1,4 @@
-import { execFile, spawnSync, type ChildProcess } from "node:child_process";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdtempSync } from "node:fs";
 import { join } from "node:path";
@@ -207,10 +207,22 @@ export function witnessChildTimeoutMs(
 }
 
 /**
- * SIGKILL the child and every descendant. The deadline is ours, not `execFile`'s
- * `timeout`: that option kills only the spawned PID, reparents `bash -c 'npm test'`
- * grandchildren to init, and then `pgrep -P` on the dead shell sees nothing. Walking
- * the tree while the shell is still alive, children first, is the whole fix.
+ * SIGKILL the child and every descendant, including ones that daemonized.
+ *
+ * `pgrep -P` only sees current children. A setup command that double-forks (the
+ * intermediate parent exits, the worker is reparented to init) is invisible to
+ * that walk — and then the factory reports the step killed, deletes the scratch
+ * dir, and leaves repository code running on the operator host.
+ *
+ * The child is spawned `detached` so it is a process-group leader. Group
+ * membership is inherited and survives reparenting, so `process.kill(-pid)`
+ * reaches those workers. Negative-pid signalling is POSIX; Wave 0 host
+ * witnessing is `bash -c` / `rm -rf` and does not run on stock Windows.
+ *
+ * The `pgrep -P` walk stays as a second pass for anything that was not in the
+ * group. `detached` also means the child no longer dies with this process's
+ * terminal, so every settlement (deadline *and* a normal exit) reaps the group
+ * — otherwise a green `npm test` that daemonized a helper would leak it.
  */
 function killWitnessProcessTree(child: ChildProcess): void {
   const pid = child.pid;
@@ -218,11 +230,12 @@ function killWitnessProcessTree(child: ChildProcess): void {
     child.kill("SIGKILL");
     return;
   }
-  try {
-    process.kill(-pid, "SIGKILL");
-    return;
-  } catch {
-    // Not a process-group leader — expected for execFile.
+  if (process.platform !== "win32") {
+    try {
+      process.kill(-pid, "SIGKILL");
+    } catch {
+      // group already gone, or this pid was never a leader
+    }
   }
   killPidTree(pid);
 }
@@ -284,39 +297,57 @@ export const hostRunner: WitnessRunner = (step, args, opts) => {
   let timedOut = false;
   let settled = false;
   let timer: NodeJS.Timeout | undefined;
-  const child = execFile(
-    cmd,
-    cmdArgs,
-    {
-      cwd: opts?.cwd,
-      env: witnessChildEnv(),
-      maxBuffer: 16 * 1024 * 1024,
-      encoding: "utf8",
-    },
-    (err, stdout, stderr) => {
-      settled = true;
-      clearTimeout(timer);
-      // `ExecException.code` is already typed `number | undefined`, so the shape needs narrowing, not
-      // an assertion: a signal-killed child reports `signal` with no numeric code and must read as 1.
-      const output = `${stdout}${stderr}`;
-      if (timedOut) {
-        resolveRun({
-          exit: 1,
-          output: `witness step "${step}" exceeded the ${timeoutMs}ms deadline and was killed\n${output}`,
-        });
-        return;
-      }
-      if (err?.signal) {
-        resolveRun({
-          exit: 1,
-          output: `witness step "${step}" was killed by ${err.signal}\n${output}`,
-        });
-        return;
-      }
-      const exit = !err ? 0 : typeof err.code === "number" ? err.code : 1;
-      resolveRun({ exit, output });
-    },
-  );
+  // `execFile` silently drops `detached` — the child keeps this process's
+  // group, so `kill(-pid)` is ESRCH. `spawn` actually creates the group.
+  const child = spawn(cmd, cmdArgs, {
+    cwd: opts?.cwd,
+    env: witnessChildEnv(),
+    // Own process group so a double-forked descendant is still reachable after
+    // it is reparented to init. Off on Windows: `kill(-pid)` is POSIX, and this
+    // runner is Wave-0-host (`bash -c`) only.
+    detached: process.platform !== "win32",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  const maxBuffer = 16 * 1024 * 1024;
+  const take = (chunk: string, which: "out" | "err"): void => {
+    if (stdout.length + stderr.length > maxBuffer) return;
+    if (which === "out") stdout += chunk;
+    else stderr += chunk;
+    if (stdout.length + stderr.length > maxBuffer) killWitnessProcessTree(child);
+  };
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => take(chunk, "out"));
+  child.stderr.on("data", (chunk: string) => take(chunk, "err"));
+  const finish = (code: number | null, signal: NodeJS.Signals | null): void => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(timer);
+    // Reap the group on every settlement. `detached` children outlive this
+    // process's terminal; a successful command that daemonized a helper would
+    // otherwise leave that helper running after we delete the scratch dir.
+    if (!timedOut) killWitnessProcessTree(child);
+    const output = `${stdout}${stderr}`;
+    if (timedOut) {
+      resolveRun({
+        exit: 1,
+        output: `witness step "${step}" exceeded the ${timeoutMs}ms deadline and was killed\n${output}`,
+      });
+      return;
+    }
+    if (signal) {
+      resolveRun({
+        exit: 1,
+        output: `witness step "${step}" was killed by ${signal}\n${output}`,
+      });
+      return;
+    }
+    resolveRun({ exit: code ?? 1, output });
+  };
+  child.on("error", () => finish(1, null));
+  child.on("close", (code, signal) => finish(code, signal));
   timer = setTimeout(() => {
     if (settled) return;
     timedOut = true;

--- a/factory/witness.ts
+++ b/factory/witness.ts
@@ -1,4 +1,4 @@
-import { execFile } from "node:child_process";
+import { execFile, spawnSync, type ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdtempSync } from "node:fs";
 import { join } from "node:path";
@@ -42,7 +42,7 @@ export type WitnessRunner = (
  * exit code we then publish as evidence. It is also the one part of the protocol a fake runner
  * cannot cover, so it needs to be importable without dragging the CLI in (`witness-host.test.ts`).
  *
- * **The shell is `bash -c`: non-login, non-interactive, with secrets stripped from the child env.**
+ * **The shell is `bash -c`: non-login, non-interactive, with an allowlisted child env.**
  * That is the whole of the contract, and each half of it was chosen against a failure:
  *
  * - **Non-login.** `bash -lc` sources `/etc/profile`, and on macOS that runs `path_helper`, which
@@ -52,42 +52,137 @@ export type WitnessRunner = (
  *   and the repo's suite died on `str | None` at head with no output. Issue #41.
  * - **Non-interactive, and no `$SHELL`.** The operator's login shell is not a stable contract: it
  *   may be zsh, fish, or nushell, whose `-c` semantics differ, and whose rc files are theirs to
- *   change. `bash -c` is the same shell everywhere the factory runs, including CI.
+ *   change. `bash -c` is the same shell everywhere the factory runs, including CI. `$SHELL` is
+ *   therefore not on the child allowlist — passing it would reintroduce the operator's shell as
+ *   a side channel without changing which interpreter we invoke.
  * - **Isolated environment.** `execFile` used to inherit `process.env` wholesale, so a Wave 0
  *   `setupCommand` (`npm ci` on frontguard) ran lifecycle scripts with `FOUNDRY_PAT` in the
- *   child's environment (issue #114). The child now gets `witnessChildEnv()`: PATH and toolchain
- *   vars pass through; machine-account and platform secrets do not. `witness-check` reports the
- *   isolation, not inheritance.
+ *   child's environment (issue #114). A four-name denylist closed that one leak and left
+ *   `NPM_TOKEN`, `AWS_SECRET_ACCESS_KEY`, `ANTHROPIC_API_KEY` — every other secret in the
+ *   operator shell — still reaching third-party `preinstall` scripts (G-02). The child now
+ *   gets `witnessChildEnv()`: an allowlist of what `git clone` / `npm ci` / a test command
+ *   actually need. Presence of `E2B_API_KEY` is still read by `witnessEvidence` from the
+ *   *caller* env — that check never reaches this child.
  *
  * A repo needing anything more than this declares it as `setupCommand` in `allowlist.yaml`, where
  * it is visible, rather than relying on a profile nobody reads.
  */
 
-/** Names a host-witness child must never see. The operator shell still holds them for `open-draft`. */
-export const WITNESS_SECRET_KEYS = [
-  "FOUNDRY_PAT",
-  "GITHUB_TOKEN",
-  "GH_TOKEN",
-  "E2B_API_KEY",
+/**
+ * Names copied into a host-witness child. Anything not listed is dropped — including
+ * `NPM_TOKEN`, `AWS_SECRET_ACCESS_KEY`, `ANTHROPIC_API_KEY`, `OP_SERVICE_ACCOUNT_TOKEN`,
+ * `FOUNDRY_PAT`, and every other operator secret. A denylist cannot stay complete; this
+ * list is the whole contract (G-02).
+ *
+ * `SHELL` is absent on purpose (see the host-runner contract above). Windows `SystemRoot` /
+ * `USERPROFILE` are absent because the host runner is POSIX (`bash -c`, `rm -rf`); Wave 0
+ * witnessing does not run on stock Windows.
+ */
+export const WITNESS_CHILD_ENV_KEYS = [
+  "PATH", // git, npm, node, python, bash — a child with no PATH cannot clone or test
+  "HOME", // npm cache (~/.npm); git/python user-level files the toolchain actually reads
+  "TMPDIR", // npm extract + test temp files; Node's os.tmpdir() honours this
+  "TEMP", // Windows-style alias some tools read even on POSIX when the operator set it
+  "TMP", // Windows-style alias of TMPDIR
+  "LANG", // UTF-8 / locale-sensitive tools (git, python) without a C locale surprise
+  "LC_ALL", // overrides LANG when the operator set a full locale
+  "LC_CTYPE", // character type / UTF-8 without a full locale override
+  "TZ", // timestamps in logs and time-sensitive tests
+  // git's documented override for ~/.gitconfig. The evidence fixtures rewrite the clone URL
+  // through `url.insteadOf` here so a local origin is cloned instead of GitHub; dropping it
+  // sends `git clone` at the real network and the fixture SHAs are not reachable. An operator
+  // isolating git config the same way needs the same pass-through. Not a secret.
+  "GIT_CONFIG_GLOBAL",
 ] as const;
 
 /**
- * The env a clone's `setupCommand` / `testCommand` runs under (issue #114).
+ * The env a clone's `setupCommand` / `testCommand` runs under (issue #114, G-02).
  *
- * Copies the parent environment and strips the secrets the factory holds for GitHub writes and
- * the E2B worker. Presence of `E2B_API_KEY` is still read by `witnessEvidence` from the *caller*
- * env — that check never reaches this child.
+ * Allowlist, not denylist: copies only {@link WITNESS_CHILD_ENV_KEYS} from the parent.
+ * Presence of `E2B_API_KEY` is still read by `witnessEvidence` from the *caller* env —
+ * that check never reaches this child.
  */
 export function witnessChildEnv(
   from: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env,
 ): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {};
-  for (const [key, value] of Object.entries(from)) {
+  for (const key of WITNESS_CHILD_ENV_KEYS) {
+    const value = from[key];
     if (value === undefined) continue;
-    if ((WITNESS_SECRET_KEYS as readonly string[]).includes(key)) continue;
     env[key] = value;
   }
   return env;
+}
+
+/**
+ * Default deadline for one host-witness child (`git clone`, `setupCommand`, `testCommand`).
+ *
+ * Minutes, not seconds: a cold `npm ci` plus an upstream suite is a multi-minute job, and
+ * the 15s GitHub-fetch bound would kill a healthy run. Fifteen minutes is long enough for
+ * that job on a laptop and short enough that a hung registry or an upstream `while true`
+ * cannot pin the `evidence` verb until the operator SIGKILLs the factory.
+ */
+export const WITNESS_CHILD_TIMEOUT_MS = 15 * 60 * 1000;
+
+/** Inclusive ceiling on `FOUNDRY_WITNESS_TIMEOUT_MS`. Above this the shipped 15-minute bound is used. */
+export const WITNESS_CHILD_TIMEOUT_MAX_MS = 60 * 60 * 1000;
+
+/**
+ * Deadline for one host-witness `execFile` (G-14).
+ *
+ * `FOUNDRY_WITNESS_TIMEOUT_MS` is an integer millisecond override. A truthy invalid value
+ * (`-1`, `Infinity`, `15.5`, a non-number) must not reach the timer as `NaN` / `0` (which
+ * would disable the deadline) — those values fall back to the shipped 15-minute bound,
+ * matching `githubFetchTimeoutMs`.
+ */
+export function witnessChildTimeoutMs(
+  raw: string | number | undefined = process.env.FOUNDRY_WITNESS_TIMEOUT_MS,
+): number {
+  const n = typeof raw === "number" ? raw : raw == null || raw === "" ? Number.NaN : Number(raw);
+  if (Number.isInteger(n) && n >= 1 && n <= WITNESS_CHILD_TIMEOUT_MAX_MS) return n;
+  return WITNESS_CHILD_TIMEOUT_MS;
+}
+
+/**
+ * SIGKILL the child and every descendant. `execFile`'s own `timeout` only signals the
+ * spawned PID, so `bash -c 'npm test'` would leave the suite running after bash died.
+ * `execFile` options do not include `detached`, so the child is not a group leader and
+ * `kill(-pid)` is refused; walk `pgrep -P` instead and SIGKILL from the leaves up.
+ */
+function killWitnessProcessTree(child: ChildProcess): void {
+  const pid = child.pid;
+  if (pid === undefined) {
+    child.kill("SIGKILL");
+    return;
+  }
+  try {
+    process.kill(-pid, "SIGKILL");
+    return;
+  } catch {
+    // Not a process-group leader — expected for execFile.
+  }
+  killPidTree(pid);
+}
+
+function killPidTree(pid: number): void {
+  let children: string[] = [];
+  try {
+    const listed = spawnSync("pgrep", ["-P", String(pid)], { encoding: "utf8" });
+    if (listed.status === 0) {
+      children = listed.stdout.split("\n").map((line) => line.trim()).filter(Boolean);
+    }
+  } catch {
+    // pgrep is absent; fall through and kill this pid alone.
+  }
+  for (const childPid of children) {
+    const n = Number(childPid);
+    if (Number.isInteger(n) && n > 1) killPidTree(n);
+  }
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {
+    // already exited
+  }
 }
 
 export const hostRunner: WitnessRunner = (step, args, opts) => {
@@ -116,22 +211,54 @@ export const hostRunner: WitnessRunner = (step, args, opts) => {
     }
   }
   const { promise, resolve: resolveRun } = Promise.withResolvers<{ exit: number; output: string }>();
+  const timeoutMs = witnessChildTimeoutMs();
   const [cmd, cmdArgs] =
     step === "git"
       ? ["git", args]
       : step === "cleanup"
         ? ["rm", ["-rf", ...args]]
         : ["bash", ["-c", args[0] ?? "false"]]; // run-setup, probe and both run-tests phases execute the repo's own commands
-  execFile(
+  let timedOut = false;
+  let settled = false;
+  let timer: NodeJS.Timeout | undefined;
+  const child = execFile(
     cmd,
     cmdArgs,
-    { cwd: opts?.cwd, env: witnessChildEnv(), maxBuffer: 16 * 1024 * 1024 },
+    {
+      cwd: opts?.cwd,
+      env: witnessChildEnv(),
+      maxBuffer: 16 * 1024 * 1024,
+      encoding: "utf8",
+      timeout: timeoutMs,
+      killSignal: "SIGKILL",
+    },
     (err, stdout, stderr) => {
-    // `ExecException.code` is already typed `number | undefined`, so the shape needs narrowing, not
-    // an assertion: a signal-killed child reports `signal` with no numeric code and must read as 1.
-    const exit = !err ? 0 : typeof err.code === "number" ? err.code : 1;
-    resolveRun({ exit, output: `${stdout}${stderr}` });
-  });
+      settled = true;
+      clearTimeout(timer);
+      // `ExecException.code` is already typed `number | undefined`, so the shape needs narrowing, not
+      // an assertion: a signal-killed child reports `signal` with no numeric code and must read as 1.
+      // `execFile`'s own `timeout` and our tree-walk can win the race; either one is the deadline.
+      const deadlineHit =
+        timedOut ||
+        (err != null &&
+          err.signal === "SIGKILL" &&
+          err.code !== "ERR_CHILD_PROCESS_STDIO_MAXBUFFER");
+      if (deadlineHit) {
+        resolveRun({
+          exit: 1,
+          output: `witness step "${step}" exceeded the ${timeoutMs}ms deadline and was killed\n${stdout}${stderr}`,
+        });
+        return;
+      }
+      const exit = !err ? 0 : typeof err.code === "number" ? err.code : 1;
+      resolveRun({ exit, output: `${stdout}${stderr}` });
+    },
+  );
+  timer = setTimeout(() => {
+    if (settled) return;
+    timedOut = true;
+    killWitnessProcessTree(child);
+  }, timeoutMs);
   return promise;
 };
 

--- a/factory/witness.ts
+++ b/factory/witness.ts
@@ -207,22 +207,26 @@ export function witnessChildTimeoutMs(
 }
 
 /**
- * SIGKILL the child and every descendant, including ones that daemonized.
+ * SIGKILL the child and every descendant that stayed in its process group.
  *
- * `pgrep -P` only sees current children. A setup command that double-forks (the
- * intermediate parent exits, the worker is reparented to init) is invisible to
- * that walk — and then the factory reports the step killed, deletes the scratch
- * dir, and leaves repository code running on the operator host.
+ * Reach: ordinary children, `&` background jobs, and double-forked workers that
+ * were reparented to init but kept the group (membership is inherited and
+ * survives reparenting). `pgrep -P` cannot see those reparented workers; the
+ * group signal can. Negative-pid signalling is POSIX; Wave 0 host witnessing
+ * is `bash -c` / `rm -rf` and does not run on stock Windows.
  *
- * The child is spawned `detached` so it is a process-group leader. Group
- * membership is inherited and survives reparenting, so `process.kill(-pid)`
- * reaches those workers. Negative-pid signalling is POSIX; Wave 0 host
- * witnessing is `bash -c` / `rm -rf` and does not run on stock Windows.
+ * Do not reach: a process that called `setsid()` / `setpgid()` and left the
+ * session. Containing that needs a cgroup, a jail, or a VM. A best-effort pid
+ * scan that sometimes kills the wrong process is worse than this limit, so
+ * we do not try. ADR 0003 puts untrusted execution in a sandbox; Wave 0 host
+ * witnessing is only repos the operator owns (`load-allowlist.ts` refuses
+ * `wave >= 1 && sandbox === "host"`). The process group is a courtesy on top
+ * of that doctrine, not a substitute for it.
  *
- * The `pgrep -P` walk stays as a second pass for anything that was not in the
- * group. `detached` also means the child no longer dies with this process's
- * terminal, so every settlement (deadline *and* a normal exit) reaps the group
- * — otherwise a green `npm test` that daemonized a helper would leak it.
+ * `spawn({ detached: true })` makes the child a group leader (`execFile`
+ * silently drops `detached`, so `kill(-pid)` was ESRCH). The group is reaped
+ * on every settlement — deadline *and* a normal exit — because a detached
+ * child no longer dies with this process's terminal.
  */
 function killWitnessProcessTree(child: ChildProcess): void {
   const pid = child.pid;
@@ -263,7 +267,7 @@ function killPidTree(pid: number): void {
 
 export const hostRunner: WitnessRunner = (step, args, opts) => {
   /**
-   * Handled before the `execFile` shapes below because it is the one step with no command: the OS
+   * Handled before the `spawn` shapes below because it is the one step with no command: the OS
    * allocates the name, which is the entire point. `mkdtempSync` appends its own random suffix to
    * the prefix and fails if the result already exists, so two witness runs starting in the same
    * millisecond cannot collide — the defect in issue #56, where the directory was named from

--- a/factory/witness.ts
+++ b/factory/witness.ts
@@ -77,6 +77,17 @@ export type WitnessRunner = (
  * `SHELL` is absent on purpose (see the host-runner contract above). Windows `SystemRoot` /
  * `USERPROFILE` are absent because the host runner is POSIX (`bash -c`, `rm -rf`); Wave 0
  * witnessing does not run on stock Windows.
+ *
+ * Version-manager *directories* are listed, never a `MISE_*` / `ASDF_*` glob:
+ * `MISE_GITHUB_TOKEN` and `ASDF_GITHUB_API_TOKEN` are credentials, and a prefix match
+ * would put them in the child. PATH already carries the shims; these dirs are what
+ * `nvm` / `mise` / `asdf` / `volta` / `fnm` / `pyenv` consult to resolve a pin.
+ *
+ * Proxy URLs (`HTTP_PROXY` and friends) can embed `user:password@`. Copied verbatim,
+ * that password reaches third-party `preinstall` scripts. The *names* still pass —
+ * git/npm cannot reach a corporate proxy without them — but {@link witnessChildEnv}
+ * strips userinfo from the value. A proxy that required that password then fails
+ * closed, without leaking it. `NO_PROXY` is a host list, not a URL, and is copied as-is.
  */
 export const WITNESS_CHILD_ENV_KEYS = [
   "PATH", // git, npm, node, python, bash — a child with no PATH cannot clone or test
@@ -93,14 +104,64 @@ export const WITNESS_CHILD_ENV_KEYS = [
   // sends `git clone` at the real network and the fixture SHAs are not reachable. An operator
   // isolating git config the same way needs the same pass-through. Not a secret.
   "GIT_CONFIG_GLOBAL",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "ALL_PROXY",
+  "NO_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "all_proxy",
+  "no_proxy",
+  "SSL_CERT_FILE", // OpenSSL / git / python custom CA file
+  "SSL_CERT_DIR", // OpenSSL hashed CA directory
+  "NODE_EXTRA_CA_CERTS", // Node's extra CA bundle (npm ci on a corp intercepting proxy)
+  "GIT_SSL_CAINFO", // git's own CA override; SSL_CERT_FILE is not always consulted
+  "CURL_CA_BUNDLE",
+  "REQUESTS_CA_BUNDLE", // Python requests; the clone's tests may need the same corp CA
+  "ASDF_DIR",
+  "ASDF_DATA_DIR",
+  "NVM_DIR",
+  "VOLTA_HOME",
+  "FNM_DIR",
+  "FNM_MULTISHELL_PATH",
+  "PYENV_ROOT",
+  "MISE_DATA_DIR",
+  "MISE_CONFIG_DIR",
+  "MISE_CACHE_DIR",
 ] as const;
+
+/** Proxy vars whose value is a URL and may embed `user:password@`. Not `NO_PROXY`. */
+const PROXY_URL_KEYS: readonly string[] = [
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "ALL_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "all_proxy",
+];
+
+/**
+ * Drop `user:password@` from a proxy URL. Unparseable values that contain `@` are
+ * treated as credential-shaped and discarded rather than guessed at.
+ */
+function stripProxyUserinfo(value: string): string {
+  try {
+    const url = new URL(value);
+    if (url.username === "" && url.password === "") return value;
+    const path = url.pathname === "/" ? "" : url.pathname;
+    return `${url.protocol}//${url.host}${path}${url.search}${url.hash}`;
+  } catch {
+    return value.includes("@") ? "" : value;
+  }
+}
 
 /**
  * The env a clone's `setupCommand` / `testCommand` runs under (issue #114, G-02).
  *
  * Allowlist, not denylist: copies only {@link WITNESS_CHILD_ENV_KEYS} from the parent.
- * Presence of `E2B_API_KEY` is still read by `witnessEvidence` from the *caller* env —
- * that check never reaches this child.
+ * Proxy URL values have userinfo stripped (see the allowlist comment). Presence of
+ * `E2B_API_KEY` is still read by `witnessEvidence` from the *caller* env — that check
+ * never reaches this child.
  */
 export function witnessChildEnv(
   from: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env,
@@ -109,7 +170,9 @@ export function witnessChildEnv(
   for (const key of WITNESS_CHILD_ENV_KEYS) {
     const value = from[key];
     if (value === undefined) continue;
-    env[key] = value;
+    const copied = PROXY_URL_KEYS.includes(key) ? stripProxyUserinfo(value) : value;
+    if (copied === "") continue;
+    env[key] = copied;
   }
   return env;
 }
@@ -144,10 +207,10 @@ export function witnessChildTimeoutMs(
 }
 
 /**
- * SIGKILL the child and every descendant. `execFile`'s own `timeout` only signals the
- * spawned PID, so `bash -c 'npm test'` would leave the suite running after bash died.
- * `execFile` options do not include `detached`, so the child is not a group leader and
- * `kill(-pid)` is refused; walk `pgrep -P` instead and SIGKILL from the leaves up.
+ * SIGKILL the child and every descendant. The deadline is ours, not `execFile`'s
+ * `timeout`: that option kills only the spawned PID, reparents `bash -c 'npm test'`
+ * grandchildren to init, and then `pgrep -P` on the dead shell sees nothing. Walking
+ * the tree while the shell is still alive, children first, is the whole fix.
  */
 function killWitnessProcessTree(child: ChildProcess): void {
   const pid = child.pid;
@@ -229,29 +292,29 @@ export const hostRunner: WitnessRunner = (step, args, opts) => {
       env: witnessChildEnv(),
       maxBuffer: 16 * 1024 * 1024,
       encoding: "utf8",
-      timeout: timeoutMs,
-      killSignal: "SIGKILL",
     },
     (err, stdout, stderr) => {
       settled = true;
       clearTimeout(timer);
       // `ExecException.code` is already typed `number | undefined`, so the shape needs narrowing, not
       // an assertion: a signal-killed child reports `signal` with no numeric code and must read as 1.
-      // `execFile`'s own `timeout` and our tree-walk can win the race; either one is the deadline.
-      const deadlineHit =
-        timedOut ||
-        (err != null &&
-          err.signal === "SIGKILL" &&
-          err.code !== "ERR_CHILD_PROCESS_STDIO_MAXBUFFER");
-      if (deadlineHit) {
+      const output = `${stdout}${stderr}`;
+      if (timedOut) {
         resolveRun({
           exit: 1,
-          output: `witness step "${step}" exceeded the ${timeoutMs}ms deadline and was killed\n${stdout}${stderr}`,
+          output: `witness step "${step}" exceeded the ${timeoutMs}ms deadline and was killed\n${output}`,
+        });
+        return;
+      }
+      if (err?.signal) {
+        resolveRun({
+          exit: 1,
+          output: `witness step "${step}" was killed by ${err.signal}\n${output}`,
         });
         return;
       }
       const exit = !err ? 0 : typeof err.code === "number" ? err.code : 1;
-      resolveRun({ exit, output: `${stdout}${stderr}` });
+      resolveRun({ exit, output });
     },
   );
   timer = setTimeout(() => {


### PR DESCRIPTION
**T-08** (gap G-02, severity **S0**) and **T-10** (gaps G-14, G-26).

## T-08 — the operator's whole environment reached third-party code

`witnessChildEnv` stripped **four** secret names and passed everything else through. The child then runs an allowlisted repository's `setupCommand` and `testCommand` through `bash -c` — `npm ci`, which executes that repo's `preinstall`/`postinstall` scripts. So an operator's `NPM_TOKEN`, `AWS_SECRET_ACCESS_KEY`, `ANTHROPIC_API_KEY`, `OP_SERVICE_ACCOUNT_TOKEN` — everything not on a list of four — reached arbitrary third-party code on the one path that executes it.

Now an explicit **allowlist**, every entry justified in a comment. Review round 1 correctly pushed back that the first cut was too narrow — it dropped proxy, custom-CA and version-manager settings, so commands that work in the operator's shell would fail during evidence generation. Those are admitted now, with one non-obvious consequence handled: **a proxy URL can carry credentials**, so `user:password@` is stripped before the value is passed.

## T-10 — nothing bounded the child processes

`hostRunner` called `execFile` with **no timeout**, behind which sit `git clone`, `git fetch`, `bash -c <setupCommand>` and `bash -c <testCommand>` twice. A hung clone, a hung registry or an upstream suite that never exits blocked `evidence` forever.

Now a range-clamped deadline (15 min default, `FOUNDRY_WITNESS_TIMEOUT_MS` override, 1 h max, invalid values falling back rather than disabling it) following the pattern `FOUNDRY_GITHUB_TIMEOUT_MS` already established — plus a process-tree kill, because killing `bash` does not kill what `bash` started.

Review round 1 found the first version raced itself: `execFile`'s own timeout could kill the shell before the `pgrep -P` walk discovered its children, which were then reparented and survived. `execFile`'s timeout is dropped; the walk now happens while the shell is still alive, and the test asserts the **grandchild** is dead rather than that the parent returned.

It also found that a child SIGKILLed for any other reason — OOM killer, self-kill — was reported as exceeding the deadline. Only a fired timer reports a deadline now.

`github-scout.ts`'s bare `fetch` gains the `AbortSignal` deadline every other GitHub fetch carries. **The module is still unwired** — wiring it is a feature and out of scope; this is safety only.

## Negative controls
Unstripped proxy userinfo → G-02 test fails. Racing `execFile`'s timeout → grandchild left in state `S`. SIGKILL-labelled-as-deadline → `doesNotMatch /exceeded the .* deadline/` fails. Reverted allowlist → `GIT_ASKPASS` leaks as `/tmp/askpass`. Reverted scout → 6 repos report `scout fetch received no AbortSignal`.

## Verified
suite **389/389** · typecheck **0** · validate green · greptile 2 rounds, **5/5**, 3 findings fixed, 0 rebutted · evidence `T-08-env-allowlist.txt`, `T-10-child-timeout.txt`





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR restricts the environment inherited by witness children and adds bounded execution for host witness commands and GitHub scouting requests.
- Replaces secret denylisting with an explicit child-environment allowlist and strips proxy credentials.
- Runs host witness commands in dedicated process groups with configurable deadlines and descendant cleanup.
- Adds an abort deadline to GitHub scouting requests.
- Adds host-level tests and completion evidence for the new boundaries.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; reparented descendants are covered by process-group cleanup, while new-session escape is explicitly documented and tested as the accepted host-sandbox boundary.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| factory/witness.ts | Replaces inherited child environments with an allowlist and introduces bounded process-group execution and cleanup. |
| factory/witness-host.test.ts | Adds host-level coverage for environment isolation, deadlines, descendant cleanup, and scout abort signals. |
| factory/github-scout.ts | Routes scouting requests through the shared GitHub request initializer so each request carries an abort deadline. |
| docs/completion/evidence/T-08-env-allowlist.txt | Records verification and negative-control evidence for child-environment isolation. |
| docs/completion/evidence/T-10-child-timeout.txt | Records verification and negative-control evidence for witness and scouting deadlines. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Witness step] --> B[Build allowlisted environment]
  B --> C[Spawn detached process group]
  C --> D{Settles before deadline?}
  D -- Yes --> E[Reap remaining process group]
  D -- No --> F[SIGKILL process group and descendants]
  E --> G[Return exit and output]
  F --> H[Return deadline failure]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Pin setsid session-escape as a Wave-0 sa..."](https://github.com/ravidsrk/oss-foundry/commit/fa9250c2f0cc220831a27138b2a998007f3b64ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59072274)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Factory workspace isolation](https://app.greptile.com/heycmo/-/custom-context/knowledge-base/ravidsrk/oss-foundry/-/docs/factory-workspace-isolation.md)
- Knowledge Base — [Witness and ledger verification](https://app.greptile.com/heycmo/-/custom-context/knowledge-base/ravidsrk/oss-foundry/-/docs/witness-and-ledger-verification.md)
- Knowledge Base — [Repository scouting and neighbor analysis](https://app.greptile.com/heycmo/-/custom-context/knowledge-base/ravidsrk/oss-foundry/-/docs/repository-scouting-and-neighbor-analysis.md)
</details>


<!-- /greptile_comment -->