### PR TITLE
P2: make the ledger survivable — atomic write, backup, restore, id guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 # `docs/12-ledger.md` are the durable, reviewable record, and `verify-ledger.ts` reconciles the
 # COMMITTED seed against live GitHub rather than reading this file (docs/08-operations.md).
 .foundry-state.json
+.foundry-state.json.bak
 
 # Secrets, none of which this repo needs at rest but all of which an operator's shell may carry:
 # FOUNDRY_PAT, GITHUB_TOKEN/GH_TOKEN, E2B_API_KEY. There is no `.env` in the documented workflow —

--- a/docs/08-operations.md
+++ b/docs/08-operations.md
@@ -284,6 +284,8 @@ node --experimental-strip-types factory/cli.ts witness-check
 
 **The expiry is 90 days and nothing in this repository reminds you.** That is a known gap, filed rather than fixed: the scope is checked at mint time by the wizard and never re-checked at runtime, so a token that is broadened later is accepted silently. Note the expiry date somewhere you will see it.
 
-**What is safe to do while the PAT is missing.** Everything except `open-draft`. `tick`, `approve`, `evidence`, `attach-witness`, `sync`, `reconcile`, `ledger` and `status` need no write credential. A packet can sit at `draft-ready` indefinitely; the in-flight cap is not consumed by a missing token.
+**What is safe to do while the PAT is missing.** Everything except `open-draft`. `tick`, `approve`, `evidence`, `attach-witness`, `sync`, `reconcile`, `ledger` and `status` need no write credential.
+
+**But the factory is stalled, not merely narrowed, and that is worth being exact about.** `draft-ready` is one of the `INFLIGHT_STATUSES` (`factory/types.ts`), so a packet waiting on a token holds the single in-flight slot and `tick` will select nothing new until it moves. There is no way to work around this by starting other work: the cap is one, deliberately. Either restore the PAT, or `reject` the packet to free the slot and accept that the evidence must be regenerated later.
 
 **What must NOT be done.** Do not substitute your own personal token for `FOUNDRY_PAT`. The separation is the point: the machine account is what makes a draft attributable to the factory rather than to the maintainer, and `docs/07-github-app.md` is the design.

--- a/docs/08-operations.md
+++ b/docs/08-operations.md
@@ -229,3 +229,61 @@ PR volume is a vanity metric and is not shown as a success KPI.
 3. Move the repo to denylist.
 4. Write a scorecard event with tone `banned`.
 5. Do not open another external PR for 14 days.
+
+## Incident: the ledger will not load
+
+**Symptom.** Every verb dies with the same line, including `status`:
+
+```
+refusing to load <path>: <parser message>. Fix or remove it; will not overwrite with seed.
+```
+
+That refusal is correct and deliberate — the loader will not silently overwrite a damaged ledger with the seed — but it takes out the diagnostic command too, which is why this runbook exists. Three different causes produce it, and the message tells you which:
+
+| message contains | cause | fix |
+|---|---|---|
+| a JSON parser error (`Unexpected end of JSON input`, `Unterminated string…`) | truncated or hand-mangled file | restore, below |
+| `not a Foundry v6 state file` | a ledger from an older schema | restore, or hand-edit `version` only if you know the shape matches |
+| `the one-packet-in-flight invariant is violated` | more packets in flight than `CAPS.in_flight` | restore, or hand-edit the extra packets to a terminal status |
+
+**Restore.** Every mutating run copies the previous ledger to `<path>.bak` before writing, so the backup is the last state that *loaded*:
+
+```
+cp .foundry-state.json.bak .foundry-state.json
+node --experimental-strip-types factory/cli.ts status
+```
+
+**What restoring costs, stated plainly.** One generation. Anything recorded between the backup being taken and the damage is gone — in practice, the single most recent mutating command. That is the trade the backup makes deliberately: two files to reason about under pressure is worse than one, and the durable record is `factory/seed.ts` plus the generated block in `docs/12-ledger.md`, not this file.
+
+**If there is no backup** (a first run, or the backup is damaged too): delete the ledger. `status` then reads the committed seed and says so, and the next mutating command creates a fresh one. Everything not yet promoted into `factory/seed.ts` is lost, which is the argument for promoting rather than accumulating — see the promotion note above.
+
+**Why a torn write is now unlikely rather than merely unlucky.** `saveFactoryState` writes a temp file in the same directory, fsyncs it, and renames over the target. POSIX rename is atomic, so a reader sees the whole old file or the whole new one. Measured before the change, a concurrent reader saw a half-written ledger in 29 of 187 samples; after, 0 of 186.
+
+## Incident: the machine-account PAT is revoked or expired
+
+**Symptom.** `open-draft` fails and nothing else does — the PAT is the only write credential, so reads keep working and the failure looks narrower than it is:
+
+```
+GitHub 401 creating the draft on <owner>/<repo>: Bad credentials
+```
+
+A 403 with a scope complaint means the token exists but is too narrow (or was broadened and then restricted); a 401 means it is gone, expired, or mistyped.
+
+**Fix.**
+
+```
+bash scripts/machine-account-wizard.sh
+```
+
+It walks the five steps and, at step 4, verifies the token by reading `x-oauth-scopes` from `HEAD /user` — it exits non-zero unless the scope set is exactly `public_repo`. Then re-export it in the operator shell:
+
+```
+export FOUNDRY_PAT=<new token>
+node --experimental-strip-types factory/cli.ts witness-check
+```
+
+**The expiry is 90 days and nothing in this repository reminds you.** That is a known gap, filed rather than fixed: the scope is checked at mint time by the wizard and never re-checked at runtime, so a token that is broadened later is accepted silently. Note the expiry date somewhere you will see it.
+
+**What is safe to do while the PAT is missing.** Everything except `open-draft`. `tick`, `approve`, `evidence`, `attach-witness`, `sync`, `reconcile`, `ledger` and `status` need no write credential. A packet can sit at `draft-ready` indefinitely; the in-flight cap is not consumed by a missing token.
+
+**What must NOT be done.** Do not substitute your own personal token for `FOUNDRY_PAT`. The separation is the point: the machine account is what makes a draft attributable to the factory rather than to the maintainer, and `docs/07-github-app.md` is the design.

--- a/docs/completion/evidence/T-11-id-validation.txt
+++ b/docs/completion/evidence/T-11-id-validation.txt
@@ -1,0 +1,16 @@
+### T-11 — packet id format enforced at the load boundary
+
+--- NEGATIVE CONTROL: remove the guard, plant a traversal id ---
+    AssertionError [ERR_ASSERTION]: a ledger containing a traversal packet id must not load
+  suite refused:
+
+--- restored ---
+  suite ok — 386 tests across 20 files, every file accounted for
+
+--- and the real ids still load ---
+  ok pkt_ColeMurray_background-agents_1476 -> true
+  ok pkt_ravidsrk_orca-fleet_71 -> true
+  ok pkt_ravidsrk_frontguard_195 -> true
+  ok pkt_ravidsrk_orca-fleet_42 -> true
+  ok pkt_matplotlib_matplotlib_0 -> true
+  ok pkt_OpenHands_OpenHands_16907 -> true

--- a/docs/completion/evidence/T-22-runbooks.txt
+++ b/docs/completion/evidence/T-22-runbooks.txt
@@ -1,0 +1,18 @@
+### T-22 — runbooks, verified by following them
+
+## Runbook 1: the ledger will not load
+
+  setup: ledger + backup exist -> 
+
+  SYMPTOM (as the runbook says, every verb including status):
+    exit=1
+    refusing to load /var/folders/65/nfjkpf196n5_xrwbkyrrgqrc0000gn/T/tmp.HXEpFybPEB/.foundry-state.json
+
+  FIX, the runbook's two commands verbatim:
+    $ cp .foundry-state.json.bak .foundry-state.json
+    $ foundry status
+      exit=0  -> recovered
+
+  NO-BACKUP path, also as written:
+      no state file at /var/folders/65/nfjkpf196n5_xrwbkyrrgqrc0000gn/T/tmp.HXEpFybPEB/.foundry-state.json — showing the committed seed ledger, not live state. Mutating commands will create it.
+      exit=0 -> reads the committed seed and says so

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -53,7 +53,7 @@ import { DISCLOSURE } from "./neighbor.ts";
 import { renderEvidencePage, renderFreezeEvidence, renderPrBody } from "./packet.ts";
 import { health, scorecardRow } from "./scorecard.ts";
 import { seedState } from "./seed.ts";
-import { loadFactoryState, saveFactoryState } from "./state.ts";
+import { backupFactoryState, loadFactoryState, saveFactoryState } from "./state.ts";
 import { foundryAttestedWave0Merges, ledgerSections, quietLabel } from "./status.ts";
 import { installTerminalBoundary } from "./terminal.ts";
 import { INFLIGHT_STATUSES, type EvidenceManifest, type EvidenceWitness, type FactoryState } from "./types.ts";
@@ -248,6 +248,22 @@ function persist(state: FactoryState): void {
       `refusing to write the repo-root ledger ${STATE_FILE} from a test run — pass \`--state <tmpfile>\` to every spawned CLI so the test cannot mutate real state.`,
     );
     process.exit(1);
+  }
+  /**
+   * One generation of backup, taken BEFORE the write, so `<state>.bak` is always the last ledger
+   * that loaded rather than the one we are about to replace it with.
+   *
+   * `saveFactoryState` makes a torn write essentially impossible; this covers the failures it
+   * cannot — a bad hand-edit, an `rm`, or a state the loader legitimately refuses because the
+   * invariants really are violated. Recovery is written up in `docs/08-operations.md`.
+   *
+   * A failed backup is a WARNING, not a refusal, and the direction matters: refusing to work
+   * because a convenience copy could not be made would turn a full disk into a dead factory, while
+   * a missing `.bak` costs only the seatbelt. The operator is told either way.
+   */
+  const backup = backupFactoryState(STATE_FILE);
+  if (!backup.ok) {
+    console.error(`could not back up ${STATE_FILE} before writing: ${backup.error} — continuing without a backup`);
   }
   saveFactoryState(STATE_FILE, state);
 }

--- a/factory/state.test.ts
+++ b/factory/state.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { test } from "node:test";
 import { tmp } from "./tmp-dir.ts";
@@ -7,8 +8,9 @@ import { buildPacket } from "./packet.ts";
 import { applyReviewToScorecard, emptyScorecard, health, mergeRate } from "./scorecard.ts";
 import { seedState } from "./seed.ts";
 import { withOpenSubmittedWave1 } from "./seed-fixtures.ts";
-import { loadFactoryState, saveFactoryState } from "./state.ts";
+import { isValidPacketId, loadFactoryState, saveFactoryState } from "./state.ts";
 import { evaluatePolicy } from "./policy.ts";
+import type { FactoryState } from "./types.ts";
 
 test("missing state file loads seed and does not invent a file", () => {
   const path = join(tmp("foundry-"), "missing.json");
@@ -441,4 +443,214 @@ test("an owner repo with nothing fetched is ALLOW, not DENY_UNKNOWN_POLICY", () 
   const v = evaluatePolicy({ repoId: "ravidsrk/frontguard", issueTitle: "docs typo" });
   assert.equal(v.record?.stance, "silent");
   assert.equal(v.code, "ALLOW");
+});
+
+/**
+ * ISSUE G-01, severity S0 — the ledger write used to be one line: `writeFileSync(path, json)`.
+ *
+ * That is a TRUNCATING write in place. `open(O_TRUNC)` empties the file before the first byte of new
+ * content lands, so anything that stops the process in between — a crash, `SIGKILL`, a full disk, a
+ * closed laptop — leaves a prefix of valid JSON, or nothing at all. `loadFactoryState` then does the
+ * right thing and refuses it, and that is where the cost lands: every verb goes through `mustLoad`,
+ * so a half-written ledger takes out `status` as well, the one command an operator would reach for
+ * to find out what just happened. There was no backup and no documented recovery.
+ *
+ * WHY A CONCURRENT READER AND NOT A SIGKILL LOOP. A kill loop is the obvious test and it is a bad
+ * one: measured here, an 8 MB payload torn by `SIGKILL` produced an unparseable file roughly once in
+ * twelve attempts, so the test would pass most runs with a broken implementation and fail
+ * intermittently for timing reasons — a flake, in a repository that treats flakes as defects. A
+ * reader sampling the same file continuously observes the whole write window instead of racing one
+ * instant of it, and the measured discrimination is unambiguous:
+ *
+ *   truncate-in-place : complete=158  partial=29
+ *   temp+flush+rename : complete=186  partial=0
+ *
+ * So the assertion is `partial === 0`, which cannot fail spuriously: a partial read is only possible
+ * if the target is observable in a half-written state, which is exactly the property under test.
+ */
+test("a concurrent reader never observes a half-written ledger", () => {
+  const dir = tmp("foundry-atomic");
+  const path = join(dir, "state.json");
+
+  // Large enough that the write spans many syscalls and the window is worth sampling. A small
+  // ledger is nearly atomic by accident — one `write(2)` — which would make this prove nothing.
+  const seed = seedState();
+  const padded: FactoryState = {
+    ...seed,
+    events: Array.from({ length: 20000 }, (_, i) => ({
+      id: `ev_${i}_${"x".repeat(40)}`,
+      kind: "tick" as const,
+      message: `padding so the write is not a single syscall ${i}`,
+      at: new Date().toISOString(),
+    })),
+  };
+
+  const writerSource = `
+import { readFileSync } from "node:fs";
+import { saveFactoryState } from ${JSON.stringify(new URL("./state.ts", import.meta.url).href)};
+const state = JSON.parse(readFileSync(process.env.PAYLOAD, "utf8"));
+for (;;) saveFactoryState(process.env.TARGET, state);
+`;
+  const payload = join(dir, "payload.json");
+  const writerPath = join(dir, "writer.mjs");
+  writeFileSync(payload, JSON.stringify(padded));
+  writeFileSync(writerPath, writerSource);
+
+  const childEnv: Record<string, string | undefined> = {
+    ...process.env,
+    TARGET: path,
+    PAYLOAD: payload,
+  };
+  // Deleted, not blanked: an inherited NODE_TEST_CONTEXT changes how a child node behaves.
+  delete childEnv.NODE_TEST_CONTEXT;
+  const writer = spawn(process.execPath, ["--experimental-strip-types", writerPath], {
+    env: childEnv,
+    stdio: "ignore",
+  });
+
+  try {
+    let complete = 0;
+    let partial = 0;
+    const deadline = Date.now() + 800;
+    while (Date.now() < deadline) {
+      let raw: string;
+      try {
+        raw = readFileSync(path, "utf8");
+      } catch {
+        continue; // not created yet; absence is not a torn file
+      }
+      if (raw.length === 0) {
+        partial += 1;
+        continue;
+      }
+      try {
+        JSON.parse(raw);
+        complete += 1;
+      } catch {
+        partial += 1;
+      }
+    }
+    assert.ok(complete > 0, `sampled ${complete} complete reads — the writer never produced a ledger, so this proves nothing`);
+    assert.equal(
+      partial,
+      0,
+      `${partial} of ${complete + partial} reads saw a half-written ledger. The write is not atomic: a reader (or the next run's loader) can observe a truncated file.`,
+    );
+  } finally {
+    writer.kill("SIGKILL");
+  }
+});
+
+/**
+ * The other half of the same guarantee, and the one the launch gate names: after the process is
+ * killed outright, the ledger is either absent or LOADABLE — never present-and-refused.
+ *
+ * This is the weaker discriminator of the two (see above: the tear rate under `SIGKILL` is low), so
+ * it is not carrying the proof. It is here because "survives a kill" is the property an operator
+ * actually cares about, and stating it as a test means a future change that reintroduces an
+ * in-place write has two chances to be caught rather than one.
+ */
+test("a ledger killed mid-write is absent or loadable, never present and unreadable", () => {
+  const dir = tmp("foundry-kill");
+  const payload = join(dir, "payload.json");
+  const writerPath = join(dir, "writer.mjs");
+  const seed = seedState();
+  const padded: FactoryState = {
+    ...seed,
+    events: Array.from({ length: 20000 }, (_, i) => ({
+      id: `ev_${i}_${"x".repeat(40)}`,
+      kind: "tick" as const,
+      message: `padding ${i}`,
+      at: new Date().toISOString(),
+    })),
+  };
+  writeFileSync(payload, JSON.stringify(padded));
+  writeFileSync(
+    writerPath,
+    `
+import { readFileSync } from "node:fs";
+import { saveFactoryState } from ${JSON.stringify(new URL("./state.ts", import.meta.url).href)};
+const state = JSON.parse(readFileSync(process.env.PAYLOAD, "utf8"));
+for (;;) saveFactoryState(process.env.TARGET, state);
+`,
+  );
+
+  for (let attempt = 0; attempt < 6; attempt += 1) {
+    const path = join(dir, `killed-${attempt}.json`);
+    const childEnv: Record<string, string | undefined> = { ...process.env, TARGET: path, PAYLOAD: payload };
+    delete childEnv.NODE_TEST_CONTEXT;
+    const writer = spawn(process.execPath, ["--experimental-strip-types", writerPath], {
+      env: childEnv,
+      stdio: "ignore",
+    });
+    const start = Date.now();
+    while (Date.now() - start < 40 + attempt * 15) {
+      // busy-wait: the point is to kill at a varying offset into the write loop
+    }
+    writer.kill("SIGKILL");
+    // Give the OS a moment to reap before reading.
+    const settle = Date.now();
+    while (Date.now() - settle < 20) {
+      // wait
+    }
+
+    if (!existsSync(path)) continue; // killed before the first rename — nothing was ever published
+    const loaded = loadFactoryState(path);
+    assert.ok(
+      loaded.ok,
+      `attempt ${attempt}: the ledger exists but will not load, so every verb including \`status\` is dead: ${loaded.ok ? "" : loaded.error}`,
+    );
+  }
+});
+
+/**
+ * ISSUE G-19 — a packet id reaches a filesystem write path by interpolation, and until this guard
+ * the only check on it was `typeof o.id === "string"`.
+ *
+ * `witnessLogPaths` builds `docs/evidence/logs/<packetId>/{test,revert}.log`; `persistWitnessLogs`
+ * resolves and writes it. A hand-edited ledger carrying a traversal in the id therefore produced an
+ * arbitrary write, and the existing `witnessLogPathViolation` could not catch it because the path it
+ * compares against is derived from the same poisoned id.
+ *
+ * Both directions are asserted, because a guard that rejected the real ids would be worse than none:
+ * every id the seed actually contains must still load.
+ */
+test("a packet id that could escape the log directory is refused at the load boundary", () => {
+  const hostile = [
+    "pkt_../../../../tmp/escape",
+    "pkt_..",
+    "pkt_a/../../b",
+    "pkt_a\\..\\..\\b",
+    "pkt_a/b",
+    "pkt_a\0b",
+    "../pkt_a",
+    "pkt_",
+    "",
+    "PKT_a", // the prefix is part of the format, not a hint
+  ];
+  for (const id of hostile) {
+    assert.equal(isValidPacketId(id), false, `\`${id}\` must not be accepted as a packet id`);
+  }
+
+  // ...and every id the shipped ledger really uses still loads. A format guard that rejects
+  // production data is a self-inflicted outage.
+  for (const packet of seedState().packets) {
+    assert.equal(
+      isValidPacketId(packet.id),
+      true,
+      `the seed's own packet id \`${packet.id}\` is rejected by the format guard — the pattern is wrong, not the data`,
+    );
+  }
+
+  // Driven through the real loader, not just the predicate: a planted traversal must make the whole
+  // ledger refuse rather than load a packet whose id can write anywhere.
+  const path = join(tmp("foundry-badid"), "state.json");
+  const seed = seedState();
+  const poisoned = {
+    ...seed,
+    packets: [{ ...seed.packets[0]!, id: "pkt_../../../../tmp/escape" }, ...seed.packets.slice(1)],
+  };
+  writeFileSync(path, JSON.stringify(poisoned, null, 2));
+  const loaded = loadFactoryState(path);
+  assert.equal(loaded.ok, false, "a ledger containing a traversal packet id must not load");
 });

--- a/factory/state.ts
+++ b/factory/state.ts
@@ -1,4 +1,5 @@
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
 import { CAPS } from "./allowlist.ts";
 import { seedState } from "./seed.ts";
 import { inflightCount, type FactoryState } from "./types.ts";
@@ -241,11 +242,40 @@ function isSandbox(value: unknown): boolean {
   );
 }
 
+/**
+ * A packet id is a filesystem path component, so its FORMAT is a security property and not a
+ * cosmetic one.
+ *
+ * `witnessLogPaths` builds `docs/evidence/logs/<packetId>/{test,revert}.log` by interpolation, and
+ * `persistWitnessLogs` resolves that and writes it. Until this guard existed the only check on an id
+ * was `typeof o.id === "string"`, so a hand-edited ledger carrying
+ * `pkt_../../../../tmp/anything` produced an arbitrary write — and `witnessLogPathViolation` could
+ * not catch it, because the path it compares against is derived from the same poisoned id.
+ *
+ * This is defence in depth, stated plainly rather than oversold: `docs/10-schemas.md` already
+ * concedes that direct write access to the ledger is equivalent to operator control, so anyone who
+ * can plant the id can also run the CLI. What it removes is the gap between "can edit a JSON file"
+ * and "can write anywhere the process can reach", which are not the same capability.
+ *
+ * The shape is `idFor`'s output (`factory/packet.ts`): `pkt_<owner>_<repo>_<issue>`, where the repo
+ * id's `/` becomes `_`. GitHub owner and repo names allow letters, digits, `-`, `_` and `.`, so the
+ * class is deliberately no wider than that — and critically it contains no `/`, no `\`, no `..`
+ * and no NUL, which is the whole point.
+ */
+const PACKET_ID = /^pkt_[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+export function isValidPacketId(id: string): boolean {
+  // `..` cannot appear even though `.` is legal in a repo name: a segment of dots is a traversal,
+  // and no real owner/repo/issue triple produces one.
+  return PACKET_ID.test(id) && !id.includes("..");
+}
+
 function isPacket(value: unknown): boolean {
   if (!value || typeof value !== "object") return false;
   const o = value as Record<string, unknown>;
   return (
     typeof o.id === "string" &&
+    isValidPacketId(o.id) &&
     typeof o.repoId === "string" &&
     Number.isInteger(o.issueNumber) &&
     typeof o.issueTitle === "string" &&
@@ -451,6 +481,77 @@ export function loadFactoryState(
   }
 }
 
+/**
+ * Write the ledger so an interrupted run cannot destroy it.
+ *
+ * This used to be one line — `writeFileSync(path, json)` — and that is a truncating write in place.
+ * `open(O_TRUNC)` empties the file first, so a crash, a `SIGKILL`, a full disk or a laptop lid
+ * between truncate and the last byte leaves valid-JSON-prefix garbage. The loader above then does
+ * the right thing and REFUSES it, which is where the real cost lands: every verb goes through
+ * `mustLoad`, so a half-written ledger takes out `status` too — the one command an operator would
+ * reach for to find out what happened. There is no backup (see `backupFactoryState`, added
+ * alongside this) and there was no documented recovery.
+ *
+ * Three steps, each load-bearing:
+ *
+ *  1. **Temp file in the SAME directory.** `rename` is only atomic within a filesystem; a temp in
+ *     `os.tmpdir()` can be on a different device and fails with `EXDEV`, or silently degrades to a
+ *     copy. The `.tmp-` prefix and the pid keep two concurrent writers from colliding on the name.
+ *  2. **`flush: true`.** This is the part that is easy to leave out and useless to omit. Node's
+ *     `writeFileSync` returns once the bytes reach the OS page cache, not the disk — the `flush`
+ *     option (fsync under the hood) is what makes them durable, and its default is `false`. Without
+ *     it the rename is atomic over data that a power loss can still take, so the ledger would
+ *     survive `SIGKILL` and not survive the wall socket.
+ *  3. **`renameSync` over the target.** POSIX requires this to be atomic: a reader sees either the
+ *     whole old file or the whole new one, never a mixture, and the destination name never
+ *     disappears. On Windows Node's rename overwrites but the platform documents no atomicity
+ *     guarantee, so this is strictly better there and not a promise there.
+ *
+ * The temp file is removed on a failed write so a crashed run does not leave litter beside the
+ * ledger, and the original is left exactly as it was.
+ */
 export function saveFactoryState(path: string, state: FactoryState): void {
-  writeFileSync(path, JSON.stringify(state, null, 2));
+  const json = JSON.stringify(state, null, 2);
+  const tmpPath = join(dirname(path), `.tmp-${basename(path)}.${process.pid}`);
+  try {
+    writeFileSync(tmpPath, json, { flush: true });
+    renameSync(tmpPath, path);
+  } catch (err) {
+    // Leave the target untouched and take the debris with us.
+    try {
+      rmSync(tmpPath, { force: true });
+    } catch {
+      // Nothing useful to do: the original ledger is intact either way, and masking the real
+      // failure below with a cleanup failure would be the worse trade.
+    }
+    throw err;
+  }
+}
+
+/**
+ * Copy the ledger to `<path>.bak` before a mutating run, so there is something to restore FROM.
+ *
+ * `saveFactoryState` above makes a torn write nearly impossible; it does not help with the other
+ * ways a ledger is lost — a bad hand-edit, an `rm`, or a state the loader legitimately refuses
+ * because the invariants really are violated. The recovery procedure in
+ * `docs/08-operations.md` is written against this file.
+ *
+ * Deliberately ONE generation, not a rotation. Two files an operator must reason about under
+ * pressure is worse than one, and the durable record of record is `factory/seed.ts` plus the
+ * generated block in `docs/12-ledger.md` — this is a seatbelt for the working copy between
+ * promotions, not an archive. Absent ledger is not an error: there is nothing to back up on the
+ * first run.
+ */
+export function backupFactoryState(path: string): { ok: true; backup?: string } | { ok: false; error: string } {
+  if (!existsSync(path)) return { ok: true };
+  const backup = `${path}.bak`;
+  try {
+    // Same atomic dance: a backup that can itself be torn is not a backup.
+    const tmpPath = join(dirname(path), `.tmp-${basename(backup)}.${process.pid}`);
+    writeFileSync(tmpPath, readFileSync(path), { flush: true });
+    renameSync(tmpPath, backup);
+    return { ok: true, backup };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : "backup failed" };
+  }
 }

--- a/factory/state.ts
+++ b/factory/state.ts
@@ -545,13 +545,21 @@ export function saveFactoryState(path: string, state: FactoryState): void {
 export function backupFactoryState(path: string): { ok: true; backup?: string } | { ok: false; error: string } {
   if (!existsSync(path)) return { ok: true };
   const backup = `${path}.bak`;
+  // Same atomic dance: a backup that can itself be torn is not a backup.
+  const tmpPath = join(dirname(path), `.tmp-${basename(backup)}.${process.pid}`);
   try {
-    // Same atomic dance: a backup that can itself be torn is not a backup.
-    const tmpPath = join(dirname(path), `.tmp-${basename(backup)}.${process.pid}`);
     writeFileSync(tmpPath, readFileSync(path), { flush: true });
     renameSync(tmpPath, backup);
     return { ok: true, backup };
   } catch (err) {
+    // Take the debris. A failed backup that leaves a full-size staging copy beside the ledger turns
+    // "could not make a backup" into "quietly filled the disk with them", one per mutating run —
+    // and the operator never sees it, because a failed backup is a warning and not a refusal.
+    try {
+      rmSync(tmpPath, { force: true });
+    } catch {
+      // Nothing useful to do, and the real error below is the one worth reporting.
+    }
     return { ok: false, error: err instanceof Error ? err.message : "backup failed" };
   }
 }

--- a/factory/state.ts
+++ b/factory/state.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { closeSync, existsSync, fsyncSync, openSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { CAPS } from "./allowlist.ts";
 import { seedState } from "./seed.ts";
@@ -502,20 +502,57 @@ export function loadFactoryState(
  *     option (fsync under the hood) is what makes them durable, and its default is `false`. Without
  *     it the rename is atomic over data that a power loss can still take, so the ledger would
  *     survive `SIGKILL` and not survive the wall socket.
- *  3. **`renameSync` over the target.** POSIX requires this to be atomic: a reader sees either the
- *     whole old file or the whole new one, never a mixture, and the destination name never
- *     disappears. On Windows Node's rename overwrites but the platform documents no atomicity
- *     guarantee, so this is strictly better there and not a promise there.
+ *  3. **`renameSync` over the target, then fsync the DIRECTORY.** POSIX requires the rename to be
+ *     atomic: a reader sees either the whole old file or the whole new one, never a mixture, and
+ *     the destination name never disappears. The directory fsync is the part that is easy to
+ *     forget and was: `flush` persists the file's bytes, not the directory entry that names them,
+ *     so without it a crash after `renameSync` returns can still lose the rename and revert the
+ *     ledger after a command reported success. On Windows Node's rename overwrites but the platform
+ *     documents no atomicity guarantee, so this is strictly better there and not a promise there.
  *
  * The temp file is removed on a failed write so a crashed run does not leave litter beside the
  * ledger, and the original is left exactly as it was.
  */
+/**
+ * Persist the directory entry a `rename` just created.
+ *
+ * `flush: true` on the temp write makes the FILE's bytes durable; it says nothing about the
+ * DIRECTORY that now names them. On a crash between `renameSync` returning and the filesystem
+ * committing the directory entry, the rename can be lost — so the ledger reverts to its previous
+ * contents, or the backup vanishes, after a command reported success. Fsyncing the containing
+ * directory is what closes that, and it is the step the docblock below would otherwise have been
+ * claiming without doing.
+ *
+ * Best effort by design. Some platforms and filesystems refuse `fsync` on a directory handle
+ * (Windows has no equivalent notion), and there the rename is already as durable as the platform
+ * offers. Failing the whole write because the extra guarantee is unavailable would trade a real
+ * capability for a theoretical one.
+ */
+function syncDirectory(dir: string): void {
+  let fd: number | undefined;
+  try {
+    fd = openSync(dir, "r");
+    fsyncSync(fd);
+  } catch {
+    // Platform does not support it; the rename stands on its own.
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        // Nothing useful to do with a failed close of a handle we only fsynced.
+      }
+    }
+  }
+}
+
 export function saveFactoryState(path: string, state: FactoryState): void {
   const json = JSON.stringify(state, null, 2);
   const tmpPath = join(dirname(path), `.tmp-${basename(path)}.${process.pid}`);
   try {
     writeFileSync(tmpPath, json, { flush: true });
     renameSync(tmpPath, path);
+    syncDirectory(dirname(path));
   } catch (err) {
     // Leave the target untouched and take the debris with us.
     try {
@@ -550,6 +587,7 @@ export function backupFactoryState(path: string): { ok: true; backup?: string } 
   try {
     writeFileSync(tmpPath, readFileSync(path), { flush: true });
     renameSync(tmpPath, backup);
+    syncDirectory(dirname(backup));
     return { ok: true, backup };
   } catch (err) {
     // Take the debris. A failed backup that leaves a full-size staging copy beside the ledger turns


### PR DESCRIPTION
**T-05**, **T-06**, **T-07**, **T-11**, **T-22**. Closes the audit's top-ranked risk (gap **G-01**, severity **S0**).

## The ledger is the product, and it was not survivable

The write was one line: `writeFileSync(path, json)`. That is a **truncating** write in place — `open(O_TRUNC)` empties the file before the first new byte lands — so a crash, `SIGKILL`, a full disk or a closed lid left a prefix of valid JSON, or nothing. The loader then correctly refused it, and that is where the cost landed: every verb goes through `mustLoad`, so **a half-written ledger took out `status` too** — the one command an operator would reach for to find out what happened. No backup. No documented recovery.

Three steps, each load-bearing:

1. **Temp file in the same directory** — `rename` is only atomic within a filesystem.
2. **`flush: true`** — the part that is easy to omit and useless to skip. `writeFileSync` returns once bytes reach the page cache; `flush` is what makes them durable, and its **default is `false`**. Without it the rename is atomic over data a power loss can still take.
3. **`renameSync`** — POSIX requires atomicity. Windows documents none, so this is better there and not a promise there.

## Proven by measurement, and deliberately *not* with a kill loop

A kill loop is the obvious test and a bad one: measured, an 8 MB payload torn by `SIGKILL` was unparseable roughly **1 in 12** attempts — so it would pass most runs against a broken implementation and fail intermittently for timing reasons. A flake, in a repo that treats flakes as defects.

A concurrent reader observes the whole write window instead of racing one instant of it:



The assertion is `partial === 0`, which cannot fail spuriously. **Negative control:** reverting the write reddens it at *"23 of 113 reads saw a half-written ledger"*. A second test asserts the launch-gate wording directly — after a kill the ledger is absent or loadable, never present-and-refused.

## T-07 — backup and restore, rehearsed

`<path>.bak` is written before every mutating run, so it is the last state that **loaded**. One generation on purpose: two files to reason about under pressure is worse than one, and the durable record is `factory/seed.ts` plus the generated block in `docs/12-ledger.md`. A failed backup **warns rather than refuses** — turning a full disk into a dead factory is the worse trade.

Rehearsed end to end: two mutations → corrupt → every verb dies including `status` (exit 1) → `cp` → recovered. The evidence also records what restoring **costs** (the most recent mutation) rather than implying it is free.

## T-11 — a packet id reached a filesystem write path

`witnessLogPaths` interpolates the id into `docs/evidence/logs/<packetId>/…` and `persistWitnessLogs` writes it. The only check was `typeof === "string"`, so a hand-edited ledger carrying `pkt_../../../../tmp/x` produced an arbitrary write — and `witnessLogPathViolation` could not catch it, because the path it compares against derives from the same poisoned id.

Stated without overselling: `docs/10-schemas.md` already concedes ledger write access is operator-equivalent. What this removes is the gap between *can edit a JSON file* and *can write anywhere the process can reach*. Both directions tested — every hostile shape refused, and **every id the shipped seed uses still loads**, because a format guard that rejects production data is a self-inflicted outage.

## T-22 — the two missing runbooks, verified by following them

The audit established a stranger could recover from neither a corrupt ledger nor a revoked PAT. Both now exist in `docs/08-operations.md`, and both were **executed**, not written and hoped for. The ledger one names all three refusal causes and what each means; the PAT one distinguishes 401 from 403, lists what is safe without a write credential, and says not to substitute a personal token.

## Review round 2 caught a doc error of mine, one phase old

I had written that the in-flight cap is not consumed while a packet waits at `draft-ready`. **Wrong** — `draft-ready` is in `INFLIGHT_STATUSES`, so such a packet holds the single slot and `tick` selects nothing new. The runbook now says the factory is *stalled*, not narrowed. Also fixed: `backupFactoryState` left its temp file behind on failure, which would have quietly accumulated full-size copies unseen.

## Verified
suite **386/386** · typecheck **0** · validate green · greptile 2 rounds, **5/5**, 2 findings fixed, 0 rebutted · evidence `T-05`/`T-06`, `T-07-restore.txt`, `T-11-id-validation.txt`, `T-22-runbooks.txt`



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR hardens the local factory ledger against interrupted writes, adds one-generation backup and recovery support, and validates packet IDs before filesystem paths can be derived from them.
- Writes ledger and backup data through flushed same-directory temporary files, atomic renames, and parent-directory synchronization.
- Backs up the last successfully loaded state before each mutation and documents corruption recovery.
- Rejects packet IDs that could escape the witness-log directory.
- Adds atomic-write, kill-survival, restore, and identifier-validation coverage.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| factory/state.ts | Adds packet-ID validation and durable temp-write, rename, directory-sync, backup, and cleanup behavior; the previously reported missing directory synchronization is fixed. |
| factory/cli.ts | Creates a backup before every persisted mutation and warns without blocking when backup creation fails. |
| factory/state.test.ts | Adds coverage for concurrent-reader atomicity, interrupted writes, and hostile or production packet identifiers. |
| docs/08-operations.md | Documents ledger restoration and machine-account PAT recovery procedures. |
| .gitignore | Excludes the generated ledger backup from version control. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Load and validate ledger] --> B[Apply mutation]
  B --> C[Flush backup temp file]
  C --> D[Rename backup temp to .bak]
  D --> E[Sync parent directory]
  E --> F[Flush ledger temp file]
  F --> G[Rename ledger temp to live state]
  G --> H[Sync parent directory]
  H --> I[Mutation complete]
  J[Corrupt live ledger] --> K[Restore .bak]
  K --> A
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(state): fsync the directory after re..."](https://github.com/ravidsrk/oss-foundry/commit/f83c3f4a6c478bb80b806d61c2c7f121e1edc97e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59073679)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Factory execution lifecycle](https://app.greptile.com/heycmo/-/custom-context/knowledge-base/ravidsrk/oss-foundry/-/docs/factory-execution-lifecycle.md)
- Knowledge Base — [Factory command orchestration](https://app.greptile.com/heycmo/-/custom-context/knowledge-base/ravidsrk/oss-foundry/-/docs/factory-command-orchestration.md)
- Knowledge Base — [Witness and ledger verification](https://app.greptile.com/heycmo/-/custom-context/knowledge-base/ravidsrk/oss-foundry/-/docs/witness-and-ledger-verification.md)
</details>


<!-- /greptile_comment -->