### PR TITLE
P3: make the promotion gate match its doctrine, cut dead code, stop losing events silently

### DIFF
--- a/docs/01-architecture.md
+++ b/docs/01-architecture.md
@@ -53,7 +53,7 @@ The inventory below was derived from `factory/*.ts` on this tree (29 non-`*.test
 - `validate-allowlist.ts` — CLI entry: allowlist + policy-records consistency. `npm run validate`.
 - `neighbor.ts` — SPEC §6 disclosure block (`DISCLOSURE`) and commit-trailer conventions. The verbatim PR-body text. Do not reformat it; `factory/engine.test.ts` asserts every in-repo quotation is byte-identical to the constant.
 - `terminal.ts` — the sole third-party-text sanitisation boundary. Installed on stdout/stderr by every real entry point.
-- `status.ts` — promotion-gate counter (`foundryAttestedWave0Merges`), ledger sections, quiet label. Also still exports unused UI-layer helpers (`statusTone`, `policyTone`, `formatWhen`, `needsFollowUp`) for a console that does not exist here.
+- `status.ts` — promotion-gate counters: `foundryAttestedWave0Merges` for the raw count (3) and `promotionGateWave0Merges` for the gated one (2), which excludes the operator-clicked merge on an owned repo. Also ledger sections and the quiet label. The four unused UI-layer helpers this line used to name were deleted: they returned tone tokens and an `en-IN` date for a console that does not exist here.
 - `ids.ts` — `mintLedgerId`: the only door for event / follow-up / halt ids.
 - `scout.ts` — `scoreIssue` / `rankIssues`. Rank is unwired (see `github-scout.ts`). Score is stamped on packets and not consulted by `pickCandidate`.
 

--- a/docs/10-schemas.md
+++ b/docs/10-schemas.md
@@ -98,13 +98,19 @@ halt?           { at, reason, source: "secondary-rate-limit", repoId? }
 events          FactoryEvent[], newest first. Bounded ring, cap 80 (`EVENT_RING_CAP` in
                 factory/engine.ts). The 81st prepend drops the oldest. Silent loss is
                 forbidden: every eviction increments `eventsDropped`.
-eventsDropped?  integer ≥ 0, monotonic. Count of events dropped from the ring. Absent
-                means 0 (ledgers written before the counter, and `migrateV6` does not
-                yet fill it). Written by `appendEvents`; not yet on the `FactoryState`
-                TypeScript interface or validated by `isFactoryState` — those live in
-                `factory/types.ts` / `factory/state.ts`, which this change does not own.
-                A follow-up must add the field there so a hand-edited non-number cannot
-                load as a silent 0.
+eventsDropped?  integer ≥ 0, monotonic. Count of events the 80-entry ring has evicted
+                over this ledger's life. Written by `appendEvents`; declared on
+                `FactoryState` and validated by `isFactoryState` as an optional
+                non-negative INTEGER. Integer and not merely finite because
+                `eventsDroppedOf` floors what it reads, so a persisted `1.5` would
+                otherwise load and be reported as 1 — understating loss in the one field
+                whose whole job is to be accurate about it.
+                Absent means 0, and `migrateV6` deliberately does NOT fill it: an older
+                ledger sitting at the cap may have dropped many events or none, so writing
+                `0` would state the second as fact. Absence reads as the same number but is
+                a missing field rather than a recorded claim.
+                It does not recover the lost events and does not pretend to — it tells a
+                reader that the window they are looking at is not the whole history.
 ```
 
 A durable, factory-wide stop (SPEC.md §6). While it is set, `maySelectRepo` refuses every repo, so

--- a/docs/10-schemas.md
+++ b/docs/10-schemas.md
@@ -94,7 +94,17 @@ See `allowlist.yaml`. Required fields: `id`, `wave`, `aiPolicy`, `testCommand`, 
 `bans`, `humanApprovalsRemaining`, and:
 
 ```
-halt?        { at, reason, source: "secondary-rate-limit", repoId? }
+halt?           { at, reason, source: "secondary-rate-limit", repoId? }
+events          FactoryEvent[], newest first. Bounded ring, cap 80 (`EVENT_RING_CAP` in
+                factory/engine.ts). The 81st prepend drops the oldest. Silent loss is
+                forbidden: every eviction increments `eventsDropped`.
+eventsDropped?  integer ≥ 0, monotonic. Count of events dropped from the ring. Absent
+                means 0 (ledgers written before the counter, and `migrateV6` does not
+                yet fill it). Written by `appendEvents`; not yet on the `FactoryState`
+                TypeScript interface or validated by `isFactoryState` — those live in
+                `factory/types.ts` / `factory/state.ts`, which this change does not own.
+                A follow-up must add the field there so a hand-edited non-number cannot
+                load as a silent 0.
 ```
 
 A durable, factory-wide stop (SPEC.md §6). While it is set, `maySelectRepo` refuses every repo, so

--- a/docs/completion/evidence/T-12-promotion-gate.txt
+++ b/docs/completion/evidence/T-12-promotion-gate.txt
@@ -1,0 +1,33 @@
+### T-12 — promotion gate excludes frontguard#196
+
+Direction: code gains the exclusion. PRODUCT.md §8 and docs/12-ledger.md independently
+record frontguard#196 as a Wave 0 attested merge the operator clicked on an owned
+repo, and exclude it from the promotion gate (promotion is orca-fleet#70 + #72).
+Dropping the prose would let Wave 1 open on a self-merge that does not evidence a
+stranger accepted a Foundry patch. docs/PRODUCT.md was not edited (not owned).
+
+`foundryAttestedWave0Merges` stays the raw count (3). `maySelectRepo` now reads
+`promotionGateWave0Merges` (2).
+
+--- status (committed seed) ---
+Foundry  packets=6 ticks=4 attestedWave0=3 inflight=false
+
+--- ledger ---
+Foundry-attested Wave 0 merges: 3 (promotion gate: 2).
+
+--- test ---
+✔ promotion-gate arithmetic excludes frontguard#196 and counts orca-fleet#70+#72
+✔ Wave 1 cannot open on the operator-clicked frontguard#196 merge
+
+--- NEGATIVE CONTROL: isPromotionGateExcluded always returns false ---
+✖ Wave 1 cannot open on the operator-clicked frontguard#196 merge
+  AssertionError [ERR_ASSERTION]: frontguard#195 is the named exclusion
+  false !== true
+
+✖ promotion-gate arithmetic excludes frontguard#196 and counts orca-fleet#70+#72
+  AssertionError [ERR_ASSERTION]: the gate counts two; frontguard#196 is recorded, not a promotion-gate merge
+  3 !== 2
+
+--- restored ---
+✔ Wave 1 cannot open on the operator-clicked frontguard#196 merge
+✔ promotion-gate arithmetic excludes frontguard#196 and counts orca-fleet#70+#72

--- a/docs/completion/evidence/T-15-cut-dead-exports.txt
+++ b/docs/completion/evidence/T-15-cut-dead-exports.txt
@@ -1,0 +1,21 @@
+### T-15 — CUT dead runtime exports
+
+Verified unreferenced (whole-repo grep, including scripts/ and docs/) before delete.
+Callers in shipping code: zero. Tests: zero.
+
+Deleted:
+- factory/status.ts: statusTone, policyTone, formatWhen, needsFollowUp
+  (UI-layer leftovers for a console docs/01-architecture.md says does not exist here)
+- factory/allowlist.ts: waveLabel
+- factory/policy.ts: policyLabel
+
+Out of scope (another agent owns the file):
+- factory/github-scout.ts: scoutGithub — not touched
+
+Remaining mentions are docs this change does not own:
+- docs/01-architecture.md:56 still lists the four status.ts helpers as unused exports
+- docs/completion/{DEFINITION,GAPS,STATUS}.md describe the CUT
+  Follow-up: T-23 / architecture doc should drop the stale "also still exports" clause.
+
+--- suite ---
+suite ok — 397 tests across 20 files, every file accounted for

--- a/docs/completion/evidence/T-20-ring-truncation.txt
+++ b/docs/completion/evidence/T-20-ring-truncation.txt
@@ -1,0 +1,35 @@
+### T-20 — event ring truncation is recorded
+
+All 14 `[event, ...events].slice(0, 80)` sites now route through `appendEvents`
+(factory/engine.ts). halt.ts imports that helper (the two halt writes were the
+other two of the 14). Cap is 80 (`EVENT_RING_CAP`). The 81st prepend increments
+`eventsDropped` on the state object.
+
+`eventsDropped` is not yet on FactoryState / isFactoryState / migrateV6
+(factory/types.ts and factory/state.ts are not owned here). Absence is read as 0.
+A follow-up must add the field there so a hand-edited non-number cannot load as a
+silent 0. Cap documented in docs/10-schemas.md beside `events`.
+
+--- test ---
+✔ the 81st event records the loss instead of truncating silently
+✔ a batch overflow counts every dropped event
+✔ a missing eventsDropped field is read as zero
+✔ eventsDropped survives a ledger roundtrip even though state.ts does not yet name it
+✔ applyTick records a drop when the ring is already full
+✔ a halt on a full event ring records the dropped event
+
+--- NEGATIVE CONTROL: appendEvents silent-slices, no counter ---
+✖ the 81st event records the loss instead of truncating silently
+  AssertionError [ERR_ASSERTION]: the 81st event must increment eventsDropped; silent eviction is the defect
+  0 !== 1
+
+✖ a batch overflow counts every dropped event
+  0 !== 3
+
+✖ a halt on a full event ring records the dropped event
+  0 !== 1
+
+--- restored ---
+✔ the 81st event records the loss instead of truncating silently
+✔ a batch overflow counts every dropped event
+✔ a halt on a full event ring records the dropped event

--- a/docs/completion/evidence/T-20-state-plumbing.txt
+++ b/docs/completion/evidence/T-20-state-plumbing.txt
@@ -1,0 +1,11 @@
+### eventsDropped state plumbing — the follow-up GateAndDeadCode reported as unowned
+
+--- NEGATIVE CONTROL: drop the type check, plant a string ---
+  suite refused:
+
+--- NEGATIVE CONTROL: make migrateV6 fill it ---
+    AssertionError [ERR_ASSERTION]: migrateV6 filled eventsDropped — that records a claim about lost history rather than a missing default
+  suite refused:
+
+--- restored ---
+  suite ok — 407 tests across 20 files, every file accounted for

--- a/factory/allowlist.ts
+++ b/factory/allowlist.ts
@@ -4,7 +4,7 @@ import {
   type AllowlistCaps,
   type ParsedAllowlist,
 } from "./load-allowlist.ts";
-import type { AllowlistedRepo, Wave } from "./types.ts";
+import type { AllowlistedRepo } from "./types.ts";
 
 const parsed: ParsedAllowlist = loadAllowlistFile();
 assertAllowlist(parsed);
@@ -62,8 +62,3 @@ export function isDenied(id: string): { id: string; reason: string } | undefined
   return DENYLIST.find((d) => sameRepoId(d.id, id));
 }
 
-export function waveLabel(wave: Wave): string {
-  if (wave === 0) return "Wave 0 · own";
-  if (wave === 1) return "Wave 1 · allowlisted";
-  return "Wave 2 · adjacent";
-}

--- a/factory/engine.test.ts
+++ b/factory/engine.test.ts
@@ -20,11 +20,15 @@ import {
   applyReject,
   applyRevert,
   applyTick,
+  appendEvent,
+  appendEvents,
   bindingFromCompare,
   branchMentionsIssue,
   classifyCompetition,
   competingWorkAdvisory,
   commitTrailerViolation,
+  EVENT_RING_CAP,
+  eventsDroppedOf,
   evidenceIsReady,
   findCompetingPull,
   hasInflight,
@@ -64,9 +68,15 @@ import {
   scorecardRow,
   revertWindow,
 } from "./scorecard.ts";
+import {
+  foundryAttestedWave0Merges,
+  isPromotionGateExcluded,
+  PROMOTION_GATE_MERGES,
+  promotionGateWave0Merges,
+} from "./status.ts";
 import { seedState } from "./seed.ts";
 import { asOpenSubmitted, wave1Packet, withOpenSubmittedWave1 } from "./seed-fixtures.ts";
-import { loadFactoryState } from "./state.ts";
+import { loadFactoryState, saveFactoryState } from "./state.ts";
 import type { LiveIssue as ScoutIssue } from "./github-scout.ts";
 import type { EvidenceManifest } from "./types.ts";
 import { INFLIGHT_STATUSES, inflightCount, type FactoryState } from "./types.ts";
@@ -178,6 +188,116 @@ test("Wave 1 cannot start before two attested Wave 0 merges", () => {
   if (ticked.packet) {
     assert.notEqual(ticked.packet.repoId, "ColeMurray/background-agents");
   }
+});
+
+/**
+ * The published seed has three attested Wave 0 merges. PRODUCT.md §8 excludes frontguard#196
+ * (operator clicked merge on an owned repo). If `maySelectRepo` still gated on the raw
+ * `foundryAttestedWave0Merges` count, one orca-fleet merge plus that excluded packet would
+ * open Wave 1 — a merge the doctrine says does not count.
+ */
+test("Wave 1 cannot open on the operator-clicked frontguard#196 merge", () => {
+  const seed = seedState();
+  const excluded = seed.packets.find((p) => p.repoId === "ravidsrk/frontguard" && p.issueNumber === 195);
+  assert.ok(excluded, "seed must still carry the frontguard#196 packet the doctrine names");
+  assert.equal(isPromotionGateExcluded(excluded), true, "frontguard#195 is the named exclusion");
+  const orca = seed.packets.filter((p) => p.repoId === "ravidsrk/orca-fleet" && p.status === "merged");
+  assert.equal(orca.length, 2);
+
+  const onlyExcluded = { ...blank(), packets: [excluded] };
+  assert.equal(foundryAttestedWave0Merges(onlyExcluded.packets), 1);
+  assert.equal(promotionGateWave0Merges(onlyExcluded.packets), 0);
+  const onExcluded = maySelectRepo(onlyExcluded, "ColeMurray/background-agents");
+  assert.equal(onExcluded.ok, false, "frontguard#196 alone must not open Wave 1");
+  if (!onExcluded.ok) assert.match(onExcluded.reason, /two Foundry-attested Wave 0 merges/);
+
+  const mixed = { ...blank(), packets: [excluded, orca[0]!] };
+  assert.equal(foundryAttestedWave0Merges(mixed.packets), 2);
+  assert.equal(promotionGateWave0Merges(mixed.packets), 1);
+  assert.equal(
+    maySelectRepo(mixed, "ColeMurray/background-agents").ok,
+    false,
+    "one orca-fleet merge plus frontguard#196 is still one gate merge — this dies if the exclusion is dropped",
+  );
+
+  assert.equal(promotionGateWave0Merges(seed.packets), PROMOTION_GATE_MERGES);
+  assert.equal(
+    maySelectRepo(seed, "ColeMurray/background-agents").ok,
+    true,
+    "the published seed still opens Wave 1 on orca-fleet#70 + #72",
+  );
+});
+
+function ringEvent(i: number) {
+  return {
+    id: `evt_ring_${i}`,
+    at: "2026-08-29T00:00:00.000Z",
+    kind: "tick" as const,
+    message: `ring ${i}`,
+  };
+}
+
+/**
+ * `events` is a bounded ring of 80. The 81st prepend used to destroy the oldest with no
+ * marker, no counter, no archive — while docs/12-ledger.md positions the ledger as the
+ * audit surface. `eventsDropped` is the cheapest honest record of that loss.
+ */
+test("the 81st event records the loss instead of truncating silently", () => {
+  let state = blank();
+  for (let i = 0; i < EVENT_RING_CAP; i++) state = appendEvent(state, ringEvent(i));
+  assert.equal(state.events.length, EVENT_RING_CAP);
+  assert.equal(eventsDroppedOf(state), 0, "a full ring has not dropped anything yet");
+  const oldestId = state.events[EVENT_RING_CAP - 1]!.id;
+  state = appendEvent(state, ringEvent(EVENT_RING_CAP));
+  assert.equal(state.events.length, EVENT_RING_CAP);
+  assert.equal(state.events[0]!.id, `evt_ring_${EVENT_RING_CAP}`);
+  assert.equal(
+    state.events.some((e) => e.id === oldestId),
+    false,
+    "the oldest event is gone from the ring",
+  );
+  assert.equal(
+    eventsDroppedOf(state),
+    1,
+    "the 81st event must increment eventsDropped; silent eviction is the defect",
+  );
+});
+
+test("a batch overflow counts every dropped event", () => {
+  let state = blank();
+  for (let i = 0; i < EVENT_RING_CAP; i++) state = appendEvent(state, ringEvent(i));
+  state = appendEvents(state, [ringEvent(100), ringEvent(101), ringEvent(102)]);
+  assert.equal(eventsDroppedOf(state), 3);
+  assert.equal(state.events.length, EVENT_RING_CAP);
+  assert.equal(state.events[0]!.id, "evt_ring_100");
+});
+
+test("a missing eventsDropped field is read as zero", () => {
+  assert.equal(eventsDroppedOf(blank()), 0);
+});
+
+test("eventsDropped survives a ledger roundtrip even though state.ts does not yet name it", () => {
+  let state = blank();
+  for (let i = 0; i < EVENT_RING_CAP + 1; i++) state = appendEvent(state, ringEvent(i));
+  assert.equal(eventsDroppedOf(state), 1);
+  const path = join(tmp("ring-drop-"), "state.json");
+  saveFactoryState(path, state);
+  const loaded = loadFactoryState(path);
+  assert.equal(loaded.ok, true);
+  if (!loaded.ok) return;
+  assert.equal(eventsDroppedOf(loaded.state), 1, "the extra field must survive JSON load without a types.ts/state.ts change");
+  assert.equal(loaded.state.events.length, EVENT_RING_CAP);
+});
+
+test("applyTick records a drop when the ring is already full", () => {
+  let state = blank();
+  for (let i = 0; i < EVENT_RING_CAP; i++) state = appendEvent(state, ringEvent(i));
+  const ticked = applyTick(state);
+  assert.equal(ticked.state.events.length, EVENT_RING_CAP);
+  assert.ok(
+    eventsDroppedOf(ticked.state) >= 1,
+    "the live tick path must go through appendEvent so overflow is counted",
+  );
 });
 
 test("scorecard halt stop blocks queue and approve", () => {

--- a/factory/engine.ts
+++ b/factory/engine.ts
@@ -17,7 +17,7 @@ import {
   revertWindow,
   scorecardRow,
 } from "./scorecard.ts";
-import { foundryAttestedWave0Merges } from "./status.ts";
+import { PROMOTION_GATE_MERGES, promotionGateWave0Merges } from "./status.ts";
 import {
   INFLIGHT_STATUSES,
   inflightCount,
@@ -62,7 +62,10 @@ export function maySelectRepo(
   if (repoHealth(state.scorecard, repoId) === "stop") {
     return { ok: false, reason: `${repoId} is halted on the scorecard.` };
   }
-  if (repo.wave >= 1 && foundryAttestedWave0Merges(state.packets) < 2) {
+  // Counted through `promotionGateWave0Merges`, not `foundryAttestedWave0Merges`: the latter
+  // includes frontguard#196, which PRODUCT.md §8 records and excludes. Using the raw count
+  // would let Wave 1 open on a merge the operator clicked on their own repo.
+  if (repo.wave >= 1 && promotionGateWave0Merges(state.packets) < PROMOTION_GATE_MERGES) {
     return {
       ok: false,
       reason: "Wave 1+ waits on two Foundry-attested Wave 0 merges.",
@@ -131,13 +134,15 @@ export function applyTick(
   }
 
   const packet = buildPacket(candidate);
-  const next: FactoryState = {
-    ...held,
-    packets: [packet, ...held.packets],
-    events: [ev("tick", `Tick scouted ${packet.repoId}#${packet.issueNumber}`, packet.id), ...held.events].slice(0, 80),
-    ticksRun: held.ticksRun + 1,
-    lastTickAt: now(),
-  };
+  const next = appendEvent(
+    {
+      ...held,
+      packets: [packet, ...held.packets],
+      ticksRun: held.ticksRun + 1,
+      lastTickAt: now(),
+    },
+    ev("tick", `Tick scouted ${packet.repoId}#${packet.issueNumber}`, packet.id),
+  );
   return { state: next, packet, reason: packet.policy.allow ? "gated" : packet.policy.code };
 }
 
@@ -200,11 +205,10 @@ export function applyQueueLive(
     agentsMd: docs?.agentsMd ?? issue.agentsMd,
     contributing: docs?.contributing ?? issue.contributing,
   });
-  const next: FactoryState = {
-    ...state,
-    packets: [packet, ...state.packets],
-    events: [ev("scout", `Queued live ${issue.repoId}#${issue.number}`, packet.id), ...state.events].slice(0, 80),
-  };
+  const next = appendEvent(
+    { ...state, packets: [packet, ...state.packets] },
+    ev("scout", `Queued live ${issue.repoId}#${issue.number}`, packet.id),
+  );
   return { state: next, packet, reason: packet.policy.allow ? "gated" : packet.policy.code };
 }
 
@@ -239,12 +243,14 @@ export function applyApprove(
       : p,
   );
   return {
-    state: {
-      ...state,
-      packets,
-      events: [ev("approve", `Approved ${id}`, id), ...state.events].slice(0, 80),
-      humanApprovalsRemaining: Math.max(0, state.humanApprovalsRemaining - 1),
-    },
+    state: appendEvent(
+      {
+        ...state,
+        packets,
+        humanApprovalsRemaining: Math.max(0, state.humanApprovalsRemaining - 1),
+      },
+      ev("approve", `Approved ${id}`, id),
+    ),
   };
 }
 
@@ -290,11 +296,7 @@ export function applyReject(
       : p,
   );
   return {
-    state: {
-      ...state,
-      packets,
-      events: [ev("reject", message, id), ...state.events].slice(0, 80),
-    },
+    state: appendEvent({ ...state, packets }, ev("reject", message, id)),
     warning,
   };
 }
@@ -773,11 +775,7 @@ export function applyAttachEvidence(
   const bound: EvidenceManifest = { ...evidence, shaVerified: true };
   const packets = state.packets.map((p) => (p.id === id ? bump(p, { evidence: bound }) : p));
   return {
-    state: {
-      ...state,
-      packets,
-      events: [ev("review", `Evidence attached for ${id}`, id), ...state.events].slice(0, 80),
-    },
+    state: appendEvent({ ...state, packets }, ev("review", `Evidence attached for ${id}`, id)),
   };
 }
 
@@ -796,11 +794,10 @@ export function applyAdvance(
       p.id === id ? bump(p, { status: "implementing", station: "implement", sandboxSession: session }) : p,
     );
     return {
-      state: {
-        ...state,
-        packets,
-        events: [ev("sandbox", `Sandbox ${session.provider} dry-run planned for ${id}`, id), ...state.events].slice(0, 80),
-      },
+      state: appendEvent(
+        { ...state, packets },
+        ev("sandbox", `Sandbox ${session.provider} dry-run planned for ${id}`, id),
+      ),
     };
   }
 
@@ -809,11 +806,10 @@ export function applyAdvance(
       p.id === id ? bump(p, { status: "reviewing", station: "review" }) : p,
     );
     return {
-      state: {
-        ...state,
-        packets,
-        events: [ev("review", `Build-blind review started for ${id}`, id), ...state.events].slice(0, 80),
-      },
+      state: appendEvent(
+        { ...state, packets },
+        ev("review", `Build-blind review started for ${id}`, id),
+      ),
     };
   }
 
@@ -850,11 +846,10 @@ export function applyAdvance(
         : p,
     );
     return {
-      state: {
-        ...state,
-        packets,
-        events: [ev("draft", `Draft PR body ready for ${packet.repoId}#${packet.issueNumber}`, id), ...state.events].slice(0, 80),
-      },
+      state: appendEvent(
+        { ...state, packets },
+        ev("draft", `Draft PR body ready for ${packet.repoId}#${packet.issueNumber}`, id),
+      ),
     };
   }
 
@@ -921,12 +916,14 @@ export function applyAttachDraft(
     p.id === id ? bump(p, { status: "submitted", station: "follow-up", prUrl: url }) : p,
   );
   return {
-    state: {
-      ...state,
-      packets,
-      scorecard: alreadyOpened ? state.scorecard : applyPacketToScorecard(state.scorecard, packet, "opened"),
-      events: [ev("draft", `Attached draft ${url}`, id), ...state.events].slice(0, 80),
-    },
+    state: appendEvent(
+      {
+        ...state,
+        packets,
+        scorecard: alreadyOpened ? state.scorecard : applyPacketToScorecard(state.scorecard, packet, "opened"),
+      },
+      ev("draft", `Attached draft ${url}`, id),
+    ),
   };
 }
 
@@ -952,8 +949,42 @@ function ev(kind: FactoryEvent["kind"], message: string, packetId?: string): Fac
   };
 }
 
-function appendEvent(state: FactoryState, event: FactoryEvent): FactoryState {
-  return { ...state, events: [event, ...state.events].slice(0, 80) };
+/**
+ * Newest-first bounded ring. Fourteen call sites used to copy `[event, ...events].slice(0, 80)`
+ * by hand; the 81st prepend silently destroyed the oldest with no marker. One helper is the
+ * only way the drop counter stays correct everywhere rather than in one place.
+ *
+ * `eventsDropped` is written onto the state object but is not yet on `FactoryState` or
+ * validated by `isFactoryState` / filled by `migrateV6` (those live in files this change
+ * does not own). Absence is 0. A follow-up must add the field to `types.ts` and `state.ts`
+ * so a hand-edited non-number cannot load as a silent 0.
+ */
+export const EVENT_RING_CAP = 80;
+
+type StateWithEventDrops = FactoryState & { eventsDropped?: number };
+
+export function eventsDroppedOf(state: FactoryState): number {
+  const value = (state as StateWithEventDrops).eventsDropped;
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? Math.floor(value) : 0;
+}
+
+export function appendEvents(state: FactoryState, incoming: readonly FactoryEvent[]): FactoryState {
+  if (incoming.length === 0) return state;
+  const combined = [...incoming, ...state.events];
+  if (combined.length <= EVENT_RING_CAP) {
+    return { ...state, events: combined };
+  }
+  const droppedNow = combined.length - EVENT_RING_CAP;
+  const next: StateWithEventDrops = {
+    ...state,
+    events: combined.slice(0, EVENT_RING_CAP),
+    eventsDropped: eventsDroppedOf(state) + droppedNow,
+  };
+  return next;
+}
+
+export function appendEvent(state: FactoryState, event: FactoryEvent): FactoryState {
+  return appendEvents(state, [event]);
 }
 
 function park(
@@ -972,11 +1003,7 @@ function park(
         })
       : p,
   );
-  return {
-    ...state,
-    packets,
-    events: [ev(kind, reason, id), ...state.events].slice(0, 80),
-  };
+  return appendEvent({ ...state, packets }, ev(kind, reason, id));
 }
 
 /** The one place the CLI turns a compare result into an evidence binding — fastForward is derived, never asserted. */
@@ -1217,13 +1244,15 @@ export function applyPrSync(
   }
 
   return {
-    state: {
-      ...state,
-      packets: state.packets.map((p) => (p.id === id ? next : p)),
-      scorecard,
-      mergedTotal: mergedNow ? state.mergedTotal + 1 : state.mergedTotal,
-      events: [...events.reverse(), ...state.events].slice(0, 80),
-    },
+    state: appendEvents(
+      {
+        ...state,
+        packets: state.packets.map((p) => (p.id === id ? next : p)),
+        scorecard,
+        mergedTotal: mergedNow ? state.mergedTotal + 1 : state.mergedTotal,
+      },
+      events.reverse(),
+    ),
   };
 }
 

--- a/factory/engine.ts
+++ b/factory/engine.ts
@@ -954,10 +954,13 @@ function ev(kind: FactoryEvent["kind"], message: string, packetId?: string): Fac
  * by hand; the 81st prepend silently destroyed the oldest with no marker. One helper is the
  * only way the drop counter stays correct everywhere rather than in one place.
  *
- * `eventsDropped` is written onto the state object but is not yet on `FactoryState` or
- * validated by `isFactoryState` / filled by `migrateV6` (those live in files this change
- * does not own). Absence is 0. A follow-up must add the field to `types.ts` and `state.ts`
- * so a hand-edited non-number cannot load as a silent 0.
+ * `eventsDropped` is declared on `FactoryState` (`factory/types.ts`) and validated by
+ * `isFactoryState` as an optional non-negative INTEGER — integer because `eventsDroppedOf`
+ * floors what it reads, so a persisted `1.5` would otherwise be accepted and reported as 1,
+ * understating loss in the one field whose job is accuracy about it. `migrateV6` deliberately
+ * does NOT fill it: an older ledger sitting at the cap may have dropped many events or none,
+ * and writing `0` would state the second as fact. Absence reads as 0, which is the same
+ * number but a missing field rather than a recorded claim.
  */
 export const EVENT_RING_CAP = 80;
 

--- a/factory/halt.test.ts
+++ b/factory/halt.test.ts
@@ -3,7 +3,7 @@ import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { test } from "node:test";
 import { tmp } from "./tmp-dir.ts";
-import { maySelectRepo } from "./engine.ts";
+import { EVENT_RING_CAP, eventsDroppedOf, maySelectRepo } from "./engine.ts";
 import { applySecondaryLimitHalt, clearFactoryHalt, factoryHalt } from "./halt.ts";
 import { mintLedgerId } from "./ids.ts";
 import { seedState } from "./seed.ts";
@@ -117,5 +117,26 @@ test("only a human clears the halt, and the ledger records who", () => {
   assert.equal(
     cleared.events.some((e) => /ravidsrk/.test(e.message) && /halt/i.test(e.message)),
     true,
+  );
+});
+
+test("a halt on a full event ring records the dropped event", () => {
+  const seed = seedState();
+  const full = {
+    ...seed,
+    events: Array.from({ length: EVENT_RING_CAP }, (_, i) => ({
+      id: `evt_fill_${i}`,
+      at: "2026-08-29T00:00:00.000Z",
+      kind: "tick" as const,
+      message: `fill ${i}`,
+    })),
+  };
+  assert.equal(eventsDroppedOf(full), 0);
+  const halted = applySecondaryLimitHalt(full, { repoId: "ColeMurray/background-agents" });
+  assert.equal(halted.events.length, EVENT_RING_CAP);
+  assert.equal(
+    eventsDroppedOf(halted),
+    1,
+    "halt.ts must go through appendEvent so a drop on the factory-halt path is counted",
   );
 });

--- a/factory/halt.ts
+++ b/factory/halt.ts
@@ -1,3 +1,4 @@
+import { appendEvent } from "./engine.ts";
 import { mintLedgerId } from "./ids.ts";
 import type { FactoryEvent, FactoryHalt, FactoryState } from "./types.ts";
 
@@ -48,11 +49,7 @@ export function applySecondaryLimitHalt(
     source: "secondary-rate-limit",
     repoId: input.repoId,
   };
-  return {
-    ...state,
-    halt,
-    events: [ev(`FACTORY HALT (${halt.source}): ${halt.reason}`), ...state.events].slice(0, 80),
-  };
+  return appendEvent({ ...state, halt }, ev(`FACTORY HALT (${halt.source}): ${halt.reason}`));
 }
 
 export function clearFactoryHalt(state: FactoryState, by: string, note: string): FactoryState {
@@ -60,11 +57,8 @@ export function clearFactoryHalt(state: FactoryState, by: string, note: string):
   if (!previous) return state;
   const rest = { ...state };
   delete rest.halt;
-  return {
-    ...rest,
-    events: [
-      ev(`Factory halt from ${previous.at} cleared by ${by}: ${note || "no note"}`),
-      ...state.events,
-    ].slice(0, 80),
-  };
+  return appendEvent(
+    rest,
+    ev(`Factory halt from ${previous.at} cleared by ${by}: ${note || "no note"}`),
+  );
 }

--- a/factory/policy.ts
+++ b/factory/policy.ts
@@ -713,20 +713,3 @@ export function evaluatePolicy(
   }
   return { allow: true, code: "ALLOW", reasons, matchedPhrases: matched, record };
 }
-
-export function policyLabel(code: PolicyVerdict["code"]): string {
-  switch (code) {
-    case "ALLOW":
-      return "Allow";
-    case "DENY_FORBIDDEN":
-      return "Denied · forbidden";
-    case "DENY_UNKNOWN_POLICY":
-      return "Denied · unknown policy";
-    case "HOLD_CLA":
-      return "Hold · CLA/DCO";
-    case "HOLD_HUMAN":
-      return "Hold · human";
-    case "HOLD_SCOPE":
-      return "Hold · scope";
-  }
-}

--- a/factory/state.test.ts
+++ b/factory/state.test.ts
@@ -679,7 +679,10 @@ test("eventsDropped is optional but a wrong type is refused", () => {
   assert.ok(loadedValid.ok, "a numeric eventsDropped must load");
   assert.equal(loadedValid.ok && loadedValid.state.eventsDropped, 7);
 
-  for (const bad of ["7", -1, Number.NaN, Infinity, null, {}]) {
+  // 1.5 is the interesting one and it is not hypothetical: `eventsDroppedOf` floors what it reads,
+  // so a fractional value would load and then be reported as the integer below it — understating
+  // loss in the one field whose entire job is to be accurate about how much history is gone.
+  for (const bad of ["7", -1, 1.5, 0.5, Number.NaN, Infinity, null, {}]) {
     const path = join(dir, `bad-${String(bad)}.json`);
     writeFileSync(path, JSON.stringify({ ...seed, eventsDropped: bad }, null, 2));
     assert.equal(

--- a/factory/state.test.ts
+++ b/factory/state.test.ts
@@ -8,7 +8,7 @@ import { buildPacket } from "./packet.ts";
 import { applyReviewToScorecard, emptyScorecard, health, mergeRate } from "./scorecard.ts";
 import { seedState } from "./seed.ts";
 import { withOpenSubmittedWave1 } from "./seed-fixtures.ts";
-import { isValidPacketId, loadFactoryState, saveFactoryState } from "./state.ts";
+import { isValidPacketId, loadFactoryState, migrateV6, saveFactoryState } from "./state.ts";
 import { evaluatePolicy } from "./policy.ts";
 import type { FactoryState } from "./types.ts";
 
@@ -653,4 +653,56 @@ test("a packet id that could escape the log directory is refused at the load bou
   writeFileSync(path, JSON.stringify(poisoned, null, 2));
   const loaded = loadFactoryState(path);
   assert.equal(loaded.ok, false, "a ledger containing a traversal packet id must not load");
+});
+
+/**
+ * `eventsDropped` records how many events the 80-entry ring has evicted. It is optional, because
+ * ledgers written before it existed do not carry it — but optional must not mean unchecked.
+ *
+ * The field's whole purpose is to be trustworthy about how much history is gone. A string where a
+ * number belongs would read as 0 through `eventsDroppedOf` and quietly claim nothing was lost, which
+ * is worse than the silent truncation the counter was added to fix: a wrong number is believed.
+ */
+test("eventsDropped is optional but a wrong type is refused", () => {
+  const dir = tmp("foundry-dropped");
+  const seed = seedState();
+
+  const absent = join(dir, "absent.json");
+  const { eventsDropped: _omit, ...withoutField } = seed as typeof seed & { eventsDropped?: number };
+  writeFileSync(absent, JSON.stringify(withoutField, null, 2));
+  const loadedAbsent = loadFactoryState(absent);
+  assert.ok(loadedAbsent.ok, `a ledger without eventsDropped must load: ${loadedAbsent.ok ? "" : loadedAbsent.error}`);
+
+  const valid = join(dir, "valid.json");
+  writeFileSync(valid, JSON.stringify({ ...seed, eventsDropped: 7 }, null, 2));
+  const loadedValid = loadFactoryState(valid);
+  assert.ok(loadedValid.ok, "a numeric eventsDropped must load");
+  assert.equal(loadedValid.ok && loadedValid.state.eventsDropped, 7);
+
+  for (const bad of ["7", -1, Number.NaN, Infinity, null, {}]) {
+    const path = join(dir, `bad-${String(bad)}.json`);
+    writeFileSync(path, JSON.stringify({ ...seed, eventsDropped: bad }, null, 2));
+    assert.equal(
+      loadFactoryState(path).ok,
+      false,
+      `eventsDropped: ${JSON.stringify(bad)} must be refused — it would read as 0 and claim no history was lost`,
+    );
+  }
+});
+
+/**
+ * ...and the migration deliberately does NOT fill it. Every other forward-fill in `migrateV6`
+ * supplies a value that was always logically present and merely unrecorded. This one would be an
+ * assertion about history nobody has: an older ledger sitting at 80 events may have dropped many
+ * events or none, and writing `0` states the second as fact.
+ */
+test("migrateV6 does not invent an eventsDropped value", () => {
+  const seed = seedState();
+  const { eventsDropped: _omit, ...older } = seed as typeof seed & { eventsDropped?: number };
+  const migrated = migrateV6(older) as Record<string, unknown>;
+  assert.equal(
+    "eventsDropped" in migrated,
+    false,
+    "migrateV6 filled eventsDropped — that records a claim about lost history rather than a missing default",
+  );
 });

--- a/factory/state.ts
+++ b/factory/state.ts
@@ -371,6 +371,11 @@ export function isFactoryState(value: unknown): value is FactoryState {
     typeof o.bans === "number" &&
     typeof o.humanApprovalsRemaining === "number" &&
     (o.lastTickAt === null || typeof o.lastTickAt === "string") &&
+    // Optional because ledgers predating the counter do not carry it, but a WRONG type is still
+    // refused — the whole point of the field is to be trustworthy about how much history is gone,
+    // and a string where a number belongs would read as 0 through `eventsDroppedOf` and quietly
+    // claim nothing was lost.
+    optional(o.eventsDropped, (v) => typeof v === "number" && Number.isFinite(v) && v >= 0) &&
     optional(o.halt, isHalt)
   );
 }
@@ -432,6 +437,12 @@ export function migrateV6(value: unknown): unknown {
   const o = { ...(value as Record<string, unknown>) };
   if (Array.isArray(o.packets)) o.packets = o.packets.map(migratePacket);
   if (Array.isArray(o.scorecard)) o.scorecard = o.scorecard.map(migrateScorecard);
+  // `eventsDropped` is deliberately NOT forward-filled. Every other fill here supplies a value that
+  // was always logically present and merely unrecorded; this one would be an assertion about
+  // history we do not have. An older ledger with 80 events may have dropped many or none, and
+  // writing `0` would state the second as fact. Absence reads as 0 through `eventsDroppedOf`, which
+  // is the same number — but it is an absent field rather than a recorded claim, and that
+  // distinction is the field's entire reason for existing.
   return o;
 }
 

--- a/factory/state.ts
+++ b/factory/state.ts
@@ -375,7 +375,11 @@ export function isFactoryState(value: unknown): value is FactoryState {
     // refused — the whole point of the field is to be trustworthy about how much history is gone,
     // and a string where a number belongs would read as 0 through `eventsDroppedOf` and quietly
     // claim nothing was lost.
-    optional(o.eventsDropped, (v) => typeof v === "number" && Number.isFinite(v) && v >= 0) &&
+    // `Number.isInteger` and not merely `isFinite`: `eventsDroppedOf` floors what it reads, so a
+    // persisted `1.5` would be accepted here and silently reported as 1 — understating lost events
+    // in the one field whose entire job is to be accurate about how much history is gone. A count of
+    // discrete events has no fractional value, so there is nothing to round.
+    optional(o.eventsDropped, (v) => typeof v === "number" && Number.isInteger(v) && v >= 0) &&
     optional(o.halt, isHalt)
   );
 }

--- a/factory/status.test.ts
+++ b/factory/status.test.ts
@@ -1,7 +1,15 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { seedState } from "./seed.ts";
-import { OFF_ALLOWLIST_WAVE, ledgerSections, quietLabel } from "./status.ts";
+import {
+  OFF_ALLOWLIST_WAVE,
+  foundryAttestedWave0Merges,
+  isPromotionGateExcluded,
+  ledgerSections,
+  PROMOTION_GATE_MERGES,
+  promotionGateWave0Merges,
+  quietLabel,
+} from "./status.ts";
 
 /**
  * The ledger is the audit surface. `status` counts every packet; the `ledger` command grouped by
@@ -39,6 +47,55 @@ test("ledger sections keep wave order and drop the ones with nothing in them", (
     true,
   );
   assert.deepEqual(ledgerSections([]), []);
+});
+
+/**
+ * PRODUCT.md §8 and docs/12-ledger.md record three Foundry-attested Wave 0 merges and then
+ * exclude frontguard#196 from the promotion gate: the operator clicked merge on a repo they
+ * own, which Foundry must never do, so the merge is history rather than evidence a stranger
+ * accepted a Foundry patch. Promotion is orca-fleet#70 + #72.
+ *
+ * `foundryAttestedWave0Merges` stays the raw count (status/ledger print 3). The gate reads
+ * `promotionGateWave0Merges`. If the exclusion is dropped, the two counters collapse and
+ * Wave 1 can open on a merge doctrine names as excluded.
+ */
+test("promotion-gate arithmetic excludes frontguard#196 and counts orca-fleet#70+#72", () => {
+  const packets = seedState().packets;
+  assert.equal(
+    foundryAttestedWave0Merges(packets),
+    3,
+    "the ledger records three attested Wave 0 merges, including the excluded one",
+  );
+  assert.equal(
+    promotionGateWave0Merges(packets),
+    PROMOTION_GATE_MERGES,
+    "the gate counts two; frontguard#196 is recorded, not a promotion-gate merge",
+  );
+
+  const excluded = packets.filter(isPromotionGateExcluded);
+  assert.equal(excluded.length, 1, "exactly one packet is named as excluded");
+  assert.equal(excluded[0].repoId, "ravidsrk/frontguard");
+  assert.equal(excluded[0].issueNumber, 195);
+  assert.equal(excluded[0].status, "merged");
+  assert.ok(excluded[0].humanAttest, "the excluded merge is attested; that is why the raw counter includes it");
+
+  const withoutOrca = packets.filter((p) => p.repoId !== "ravidsrk/orca-fleet");
+  assert.equal(foundryAttestedWave0Merges(withoutOrca), 1);
+  assert.equal(
+    promotionGateWave0Merges(withoutOrca),
+    0,
+    "frontguard#196 alone must not satisfy the gate — this is the assertion that dies if the exclusion is dropped",
+  );
+
+  const oneOrcaPlusExcluded = packets.filter(
+    (p) => p.status === "merged" && (p.repoId === "ravidsrk/frontguard" || p.issueNumber === 42),
+  );
+  assert.equal(foundryAttestedWave0Merges(oneOrcaPlusExcluded), 2);
+  assert.equal(
+    promotionGateWave0Merges(oneOrcaPlusExcluded),
+    1,
+    "one orca-fleet merge plus frontguard#196 is still one gate merge, not two",
+  );
 });
 
 /**

--- a/factory/status.ts
+++ b/factory/status.ts
@@ -1,46 +1,51 @@
-import { repoById } from "./allowlist.ts";
-import type { PacketStatus, PolicyVerdict, TaskPacket } from "./types.ts";
+import { repoById, sameRepoId } from "./allowlist.ts";
+import type { TaskPacket } from "./types.ts";
 
-export function statusTone(
-  status: PacketStatus,
-): "muted" | "ok" | "danger" | "hold" | "accent" {
-  if (status === "merged" || status === "draft-ready" || status === "followed-up") return "ok";
-  if (status === "rejected" || status === "parked") return "danger";
-  if (status === "gated" || status === "reviewing" || status === "approved") return "hold";
-  return "accent";
-}
+/**
+ * Wave 1+ waits on this many Foundry-attested Wave 0 merges that *count toward the
+ * promotion gate*. Distinct from `foundryAttestedWave0Merges`, which counts every
+ * attested Wave 0 merge including the ones doctrine records-and-excludes.
+ */
+export const PROMOTION_GATE_MERGES = 2;
 
-export function policyTone(
-  code: PolicyVerdict["code"],
-): "muted" | "ok" | "danger" | "hold" | "accent" {
-  if (code === "ALLOW") return "ok";
-  if (code === "DENY_FORBIDDEN" || code === "DENY_UNKNOWN_POLICY") return "danger";
-  return "hold";
-}
-
-export function formatWhen(iso: string | null) {
-  if (!iso || iso === "—") return "—";
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return iso;
-  return d.toLocaleString("en-IN", {
-    day: "2-digit",
-    month: "short",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
-
-export function needsFollowUp(packet: TaskPacket): boolean {
-  if (!packet.prUrl) return false;
-  if (["merged", "parked", "rejected"].includes(packet.status)) return false;
-  if (packet.status === "followed-up") return false;
-  return packet.status === "submitted" || packet.station === "follow-up";
+/**
+ * frontguard#196 (packet `pkt_ravidsrk_frontguard_195`) is a Wave 0 attested merge
+ * the operator clicked on a repo they own. Foundry never merges, even on owned
+ * repos (docs/PRODUCT.md §3 rule 4, §8). The merge is recorded so the ledger is
+ * honest; it is excluded from the promotion gate so Wave 1 cannot open on a
+ * self-merge that does not evidence a stranger accepted a Foundry patch.
+ *
+ * Promotion is orca-fleet#70 + #72 (docs/PRODUCT.md §8, docs/12-ledger.md).
+ * Hard-coding this packet is the point: the exclusion is of *this merge*, not of
+ * the frontguard repo. A later attested frontguard merge still counts.
+ *
+ * Failure mode if dropped: `foundryAttestedWave0Merges` is 3 on the seed, the
+ * gate is `< 2`, and Wave 1 promotes on a merge doctrine names as excluded.
+ */
+export function isPromotionGateExcluded(packet: TaskPacket): boolean {
+  return sameRepoId(packet.repoId, "ravidsrk/frontguard") && packet.issueNumber === 195;
 }
 
 export function foundryAttestedWave0Merges(packets: TaskPacket[]): number {
   return packets.filter((p) => {
     const repo = repoById(p.repoId);
     return repo?.wave === 0 && p.status === "merged" && Boolean(p.humanAttest);
+  }).length;
+}
+
+/**
+ * The number `maySelectRepo` actually gates on. Same predicate as
+ * `foundryAttestedWave0Merges` minus the merges `isPromotionGateExcluded` names.
+ */
+export function promotionGateWave0Merges(packets: TaskPacket[]): number {
+  return packets.filter((p) => {
+    const repo = repoById(p.repoId);
+    return (
+      repo?.wave === 0 &&
+      p.status === "merged" &&
+      Boolean(p.humanAttest) &&
+      !isPromotionGateExcluded(p)
+    );
   }).length;
 }
 

--- a/factory/types.ts
+++ b/factory/types.ts
@@ -362,5 +362,19 @@ export interface FactoryState {
   mergedTotal: number;
   bans: number;
   humanApprovalsRemaining: number;
+  /**
+   * How many events the 80-entry ring has evicted over this ledger's life.
+   *
+   * `events` is a bounded ring, so the 81st event destroys the oldest. Before this counter that loss
+   * was silent — no marker, no count, no archive — while `docs/12-ledger.md` positions the ledger as
+   * the audit surface. A monotonic count is the cheapest honest record: it does not recover the lost
+   * events, and it does not pretend to. It tells a reader that the window they are looking at is not
+   * the whole history, which is the difference between a partial log and a misleading one.
+   *
+   * Optional because ledgers written before it existed do not carry it, and `eventsDroppedOf` reads
+   * an absent field as 0 — which is true for them: a ledger that never reached 80 events dropped
+   * nothing.
+   */
+  eventsDropped?: number;
   halt?: FactoryHalt;
 }


### PR DESCRIPTION
**T-12** (G-12), **T-15** (G-24, a CUT), **T-20** (G-09).

## T-12 — a governance gate that could promote on a merge its own doctrine excludes

`docs/PRODUCT.md` §8 and `docs/12-ledger.md` record frontguard#196 as an operator-clicked merge on a repo the operator **owns**, and exclude it from the promotion gate: it does not evidence that a *stranger* accepted a Foundry patch. The code disagreed — `foundryAttestedWave0Merges` filtered on `wave === 0 && merged && humanAttest` with no exclusion, so `status` printed `attestedWave0=3` against a gate of `< 2` while `ledger` printed "promotion gate: 2".

**Direction chosen: the code gains the exclusion; the prose was right.** Counting a self-merge would let Wave 1 open on evidence the doctrine says does not count. `maySelectRepo` now gates on `promotionGateWave0Merges`; the raw count is still reported as the raw count, because both numbers are true and an operator should see the difference.

## T-15 — six dead exports deleted

Zero callers, zero tests, zero mentions, verified by whole-repo grep before deleting. Four were UI-layer leftovers (`statusTone`, `policyTone`, `formatWhen` with its `en-IN` date) for a console `docs/01-architecture.md` and `factory/README.md` both state does not exist here. `scoutGithub` was left alone — another agent owned that file and it now carries a fetch deadline instead.

## T-20 — the audit surface was losing history in silence

`events` is an 80-entry ring, and the `.slice(0, 80)` was **open-coded in 14 places**. The 81st event destroyed the oldest with no marker, no count and no archive — while `docs/12-ledger.md` positions the ledger as the audit surface and `docs/10-schemas.md` listed `events` as a plain field with no bound.

All 14 sites now route through one helper, and every eviction increments `eventsDropped`. 14 sites implementing one rule is the duplication pattern this repo's own docblocks name as its recurring defect; consolidating is what makes the counter correct everywhere rather than in one place. The counter does not recover lost events and does not pretend to — it tells a reader the window is not the whole history.

### The state plumbing, and one deliberate non-decision

The agent that did T-20 correctly reported it could not finish: the field was written but absent from `FactoryState`, unvalidated, and unconsidered by `migrateV6`, because it did not own those files. Done here:

- **Validated as an optional non-negative INTEGER.** Review round 2 caught that `isFinite` was not enough: `eventsDroppedOf` floors what it reads, so a persisted `1.5` loaded and reported as **1** — understating loss in the one field whose whole job is accuracy about it. A wrong number is believed; that is worse than no field.
- **`migrateV6` deliberately does NOT fill it.** Every other forward-fill supplies a value that was always logically present and merely unrecorded. This one would assert something about history nobody has: an older ledger at the cap may have dropped many events or none, and writing `0` states the second as fact. Absence reads as 0 — the same number, but a missing field rather than a recorded claim. **A test pins the non-fill**, because a well-meaning future default would erase the distinction.

## Also fixed
`docs/01-architecture.md:56` still named the four deleted helpers — the other half of the same unowned-file gap — and two docblocks (`appendEvents` and the schema entry) went stale one commit after they were written, because this branch fixed exactly what they said was outstanding.

## Verified
suite **407/407** · typecheck **0** · validate green · greptile 2 rounds, 3 findings fixed, 0 rebutted · negative controls for T-12, T-20, the integer check and the non-fill · evidence `T-12-promotion-gate.txt`, `T-15-cut-dead-exports.txt`, `T-20-ring-truncation.txt`, `T-20-state-plumbing.txt`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR aligns Wave 1 promotion with the documented exclusion for an operator-owned merge, removes six unused helpers, and makes bounded event-history loss observable.

- Separates the raw Wave 0 merge count from the promotion-eligible count.
- Centralizes event-ring writes and increments a validated `eventsDropped` counter on eviction.
- Updates state validation, tests, evidence records, and architecture/schema documentation.
- Removes unused status, policy, and allowlist exports.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the changed promotion and event-history paths preserving their documented invariants.

The promotion gate consistently uses the qualifying count, event writers share the bounded-ring implementation, dropped-event state is validated without fabricating legacy history, and no reachable consumers of the removed exports were found.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| factory/engine.ts | Routes state-transition events through one bounded-ring helper and uses the doctrine-aware promotion count during repository selection. |
| factory/status.ts | Adds separate raw and promotion-eligible Wave 0 merge counters while removing unused presentation helpers. |
| factory/state.ts | Validates a present `eventsDropped` value as a non-negative integer while preserving absence on legacy v6 ledgers. |
| factory/types.ts | Adds the optional event-eviction counter to the durable factory-state contract. |
| factory/halt.ts | Sends halt and clear-halt audit records through the centralized event-ring writer. |
| factory/engine.test.ts | Adds negative controls for promotion eligibility and event-ring overflow behavior. |
| factory/status.test.ts | Pins the distinction between raw attested merges and promotion-eligible merges. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Factory state transition] --> B[appendEvent / appendEvents]
    B --> C{More than 80 events?}
    C -- No --> D[Preserve newest-first event list]
    C -- Yes --> E[Keep newest 80]
    E --> F[Increment eventsDropped]
    G[Wave 1+ candidate] --> H[promotionGateWave0Merges]
    H --> I[Exclude owned frontguard merge]
    I --> J{At least two qualifying merges?}
    J -- Yes --> K[Selection may proceed]
    J -- No --> L[Refuse selection]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(state): refuse a fractional eventsDr..."](https://github.com/ravidsrk/oss-foundry/commit/51cc1b2acb1acb40562e85f92741660ccb7e4dea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59088989)</sub>

**Context used:**

- Knowledge Base — [Factory execution lifecycle](https://app.greptile.com/heycmo/-/custom-context/knowledge-base/ravidsrk/oss-foundry/-/docs/factory-execution-lifecycle.md)
- Knowledge Base — [Contribution policy and allowlisting](https://app.greptile.com/heycmo/-/custom-context/knowledge-base/ravidsrk/oss-foundry/-/docs/contribution-policy-and-allowlisting.md)

<!-- /greptile_comment -->