### PR TITLE
P3/P4: correct the published oracle, give transport errors context, alert on clock failure

### DIFF
--- a/.github/workflows/oss-tick.yml
+++ b/.github/workflows/oss-tick.yml
@@ -10,16 +10,20 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # Serialise schedule and workflow_dispatch. Search-then-create on the
-  # alert step is not atomic: two overlapping red runs can both see no
-  # open clock-alert and both create, which is exactly a 6-hourly clock
-  # plus a manual retry of a failing one. One group, shared across
-  # events, so they queue rather than race. cancel-in-progress is FALSE:
-  # GitHub would otherwise cancel the in-flight red run before its alert
-  # step, and the notification this group exists to keep unique would be
-  # the thing that got dropped. Pending runs still collapse to the newest
-  # (GitHub's default for a concurrency group); a tick that never started
-  # has nothing to alert about.
+  # Serialise whole runs (tick then its sibling alert). Search-then-create
+  # on the alert job is not atomic: two overlapping red runs can both see
+  # no open clock-alert and both create, which is exactly a 6-hourly clock
+  # plus a manual retry of a failing one. One group, shared across events,
+  # so they queue rather than race. cancel-in-progress is FALSE: GitHub
+  # would otherwise cancel the in-flight red run before its alert job, and
+  # the notification this group exists to keep unique would be the thing
+  # that got dropped. Pending runs still collapse to the newest (GitHub's
+  # default); a tick that never started has nothing to alert about.
+  #
+  # The group is workflow-level on purpose. Do NOT add a job-level group
+  # shared by `tick` and `alert`: alert needs tick, so it would wait on
+  # tick while tick held the group, and the run would hang until the
+  # workflow timeout. Jobs in the same run do not compete for this slot.
   group: oss-tick
   cancel-in-progress: false
 
@@ -81,44 +85,48 @@ jobs:
               body,
               labels: ["packet"],
             });
-      # Launch gate §6: an inherited alert, not a personal GitHub notification
-      # setting. Personal watches die with the operator; a stranger who forks
-      # this repository must still hear that the unattended 6-hour clock failed.
-      #
-      # WHY IDEMPOTENT. A naive `issues.create` on every red run turns one
-      # outage into ~40 issues a week (6-hourly). Search for an existing open
-      # `clock-alert` issue and comment on it; reopen a closed one; create only
-      # when none exists. That lookup is not atomic — two overlapping red
-      # runs can both pass it — so the workflow concurrency group (above)
-      # serialises schedule and dispatch. Together they are the one-alert
-      # guarantee; the lookup alone is not. The run URL and the failed job
-      # are in every body so a later comment is still actionable.
-      #
-      # HONEST LIMIT. A scheduled run cannot be failed on demand from this
-      # repository, so the suite drives the script body against a fake octokit
-      # (factory/ci.test.ts) rather than claiming a live red tick created the
-      # issue.
-      #
-      # WHY `always() && !success()`, NOT `failure()`. A job that hits
-      # `timeout-minutes: 20` is CANCELLED, and `failure()` and `cancelled()`
-      # are distinct statuses — `failure()` does not run on a cancelled job.
-      # A hung clock is precisely the outage nobody would otherwise notice,
-      # so the condition must cover cancellation. `always()` is what makes
-      # GitHub still consider the step while tearing the job down;
-      # `!success()` drops the green path. TRADE: a human who cancels a run
-      # deliberately also gets an alert. For an unattended 6-hourly clock a
-      # spurious alert costs a glance; a missing one costs an unnoticed
-      # outage. Do not "simplify" this back to `failure()` — that is how
-      # the hung-clock case goes silent.
-      #
-      # The alert path is two or three REST calls on purpose. A timeout
-      # teardown does not give the step a fresh timeout-minutes budget, so
-      # a long sequence may not finish; a step-level timeout-minutes can
-      # only shrink that window and is omitted. Concurrency serialises
-      # RUNS, not steps: this step still executes inside the cancelled run
-      # and is not queued behind another run's alert.
+
+  # Launch gate §6: an inherited alert, not a personal GitHub notification
+  # setting. Personal watches die with the operator; a stranger who forks
+  # this repository must still hear that the unattended 6-hour clock failed.
+  #
+  # WHY A SEPARATE JOB. timeout-minutes on `tick` kills that job outright.
+  # No remaining step in `tick` executes, whatever its `if:` says — not
+  # `failure()`, not `always() && !success()`. A hung clock is the outage
+  # nobody would otherwise notice, so the reporter cannot live in the job
+  # whose termination it reports. `needs: tick` plus
+  # `always() && needs.tick.result != 'success'` covers failure, cancelled
+  # and timed_out alike. TRADE: a human who cancels a run deliberately
+  # also gets an alert. A glance beats an unnoticed outage.
+  #
+  # WHY IDEMPOTENT. A naive `issues.create` on every red run turns one
+  # outage into ~40 issues a week (6-hourly). Search for an existing open
+  # `clock-alert` issue and comment on it; reopen a closed one; create only
+  # when none exists. That lookup is not atomic; the workflow concurrency
+  # group serialises whole runs (tick then this job). Together they are
+  # the one-alert guarantee; the lookup alone is not. The run URL is in
+  # every body so a later comment is still actionable.
+  #
+  # No checkout: github-script talks to the API with the job token. A hung
+  # clone must not eat the 5-minute budget. The path is two or three REST
+  # calls. Job-level `issues: write` is required — permissions do not
+  # inherit from `tick`.
+  #
+  # HONEST LIMIT. A scheduled run cannot be failed on demand from this
+  # repository, so the suite drives the script body against a fake octokit
+  # (factory/ci.test.ts) rather than claiming a live red tick created the
+  # issue. Separately: this job can itself fail (GitHub outage, revoked
+  # token) and nothing watches the watcher. Naming that is better than
+  # implying total coverage.
+  alert:
+    needs: tick
+    if: ${{ always() && needs.tick.result != 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
       - name: Alert on clock failure
-        if: ${{ always() && !success() }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -126,9 +134,8 @@ jobs:
             const label = "clock-alert";
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const what = [
-              "The unattended 6-hour clock failed.",
-              `Job: ${context.job}`,
-              `Workflow: ${context.workflow}`,
+              "The unattended 6-hour clock did not succeed.",
+              "Tick result: ${{ needs.tick.result }}",
               `Run: ${runUrl}`,
               "",
               "This issue is the inherited alert (launch gate §6). A stranger who clones the repo gets it without changing GitHub notification settings.",

--- a/.github/workflows/oss-tick.yml
+++ b/.github/workflows/oss-tick.yml
@@ -67,3 +67,77 @@ jobs:
               body,
               labels: ["packet"],
             });
+      # Launch gate §6: an inherited alert, not a personal GitHub notification
+      # setting. Personal watches die with the operator; a stranger who forks
+      # this repository must still hear that the unattended 6-hour clock failed.
+      #
+      # WHY IDEMPOTENT. A naive `issues.create` on every red run turns one
+      # outage into ~40 issues a week (6-hourly). Search for an existing open
+      # `clock-alert` issue and comment on it; reopen a closed one; create only
+      # when none exists. The run URL and the failed job are in every body so
+      # a later comment is still actionable.
+      #
+      # HONEST LIMIT. A scheduled run cannot be failed on demand from this
+      # repository, so the suite drives the script body against a fake octokit
+      # (factory/ci.test.ts) rather than claiming a live red tick created the
+      # issue.
+      - name: Alert on clock failure
+        if: ${{ failure() }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const title = "oss-tick: clock failed";
+            const label = "clock-alert";
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const what = [
+              "The unattended 6-hour clock failed.",
+              `Job: ${context.job}`,
+              `Workflow: ${context.workflow}`,
+              `Run: ${runUrl}`,
+              "",
+              "This issue is the inherited alert (launch gate §6). A stranger who clones the repo gets it without changing GitHub notification settings.",
+              "Fix the clock, then close this issue. A later failure will reopen it and comment with the new run URL.",
+            ].join("\n");
+            const query = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: label,
+              per_page: 5,
+            };
+            const open = await github.rest.issues.listForRepo({ ...query, state: "open" });
+            const existingOpen = open.data.find((i) => i.title === title) ?? open.data[0];
+            if (existingOpen) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existingOpen.number,
+                body: what,
+              });
+              console.log("commented on existing alert", existingOpen.html_url);
+              return;
+            }
+            const closed = await github.rest.issues.listForRepo({ ...query, state: "closed" });
+            const existingClosed = closed.data.find((i) => i.title === title) ?? closed.data[0];
+            if (existingClosed) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existingClosed.number,
+                state: "open",
+              });
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existingClosed.number,
+                body: what,
+              });
+              console.log("reopened alert", existingClosed.html_url);
+              return;
+            }
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body: what,
+              labels: [label],
+            });

--- a/.github/workflows/oss-tick.yml
+++ b/.github/workflows/oss-tick.yml
@@ -9,6 +9,20 @@ on:
     - cron: "0 */6 * * *"
   workflow_dispatch:
 
+concurrency:
+  # Serialise schedule and workflow_dispatch. Search-then-create on the
+  # alert step is not atomic: two overlapping red runs can both see no
+  # open clock-alert and both create, which is exactly a 6-hourly clock
+  # plus a manual retry of a failing one. One group, shared across
+  # events, so they queue rather than race. cancel-in-progress is FALSE:
+  # GitHub would otherwise cancel the in-flight red run before its alert
+  # step, and the notification this group exists to keep unique would be
+  # the thing that got dropped. Pending runs still collapse to the newest
+  # (GitHub's default for a concurrency group); a tick that never started
+  # has nothing to alert about.
+  group: oss-tick
+  cancel-in-progress: false
+
 jobs:
   tick:
     runs-on: ubuntu-latest
@@ -74,8 +88,11 @@ jobs:
       # WHY IDEMPOTENT. A naive `issues.create` on every red run turns one
       # outage into ~40 issues a week (6-hourly). Search for an existing open
       # `clock-alert` issue and comment on it; reopen a closed one; create only
-      # when none exists. The run URL and the failed job are in every body so
-      # a later comment is still actionable.
+      # when none exists. That lookup is not atomic — two overlapping red
+      # runs can both pass it — so the workflow concurrency group (above)
+      # serialises schedule and dispatch. Together they are the one-alert
+      # guarantee; the lookup alone is not. The run URL and the failed job
+      # are in every body so a later comment is still actionable.
       #
       # HONEST LIMIT. A scheduled run cannot be failed on demand from this
       # repository, so the suite drives the script body against a fake octokit

--- a/.github/workflows/oss-tick.yml
+++ b/.github/workflows/oss-tick.yml
@@ -98,8 +98,27 @@ jobs:
       # repository, so the suite drives the script body against a fake octokit
       # (factory/ci.test.ts) rather than claiming a live red tick created the
       # issue.
+      #
+      # WHY `always() && !success()`, NOT `failure()`. A job that hits
+      # `timeout-minutes: 20` is CANCELLED, and `failure()` and `cancelled()`
+      # are distinct statuses — `failure()` does not run on a cancelled job.
+      # A hung clock is precisely the outage nobody would otherwise notice,
+      # so the condition must cover cancellation. `always()` is what makes
+      # GitHub still consider the step while tearing the job down;
+      # `!success()` drops the green path. TRADE: a human who cancels a run
+      # deliberately also gets an alert. For an unattended 6-hourly clock a
+      # spurious alert costs a glance; a missing one costs an unnoticed
+      # outage. Do not "simplify" this back to `failure()` — that is how
+      # the hung-clock case goes silent.
+      #
+      # The alert path is two or three REST calls on purpose. A timeout
+      # teardown does not give the step a fresh timeout-minutes budget, so
+      # a long sequence may not finish; a step-level timeout-minutes can
+      # only shrink that window and is omitted. Concurrency serialises
+      # RUNS, not steps: this step still executes inside the cancelled run
+      # and is not queued behind another run's alert.
       - name: Alert on clock failure
-        if: ${{ failure() }}
+        if: ${{ always() && !success() }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |

--- a/docs/completion/evidence/T-13-negative-control.txt
+++ b/docs/completion/evidence/T-13-negative-control.txt
@@ -1,0 +1,39 @@
+### T-13 — published frontguard packet records a real oracle (G-13)
+
+The committed seed at factory/seed.ts recorded
+
+  testCommand: "true"
+  negativeControl: "red-on-revert"
+
+on pkt_ravidsrk_frontguard_195. A noop cannot go red on revert (issue #112),
+so that pair asserted a proof it cannot have performed. Compounding it,
+allowlist.yaml:42 has always declared `npm test` for ravidsrk/frontguard —
+the published oracle did not match the roster's declared oracle for the
+same repo.
+
+Which correction is honest: the recorded command was wrong, not the
+control. `no-suite` is the exemption for repos that genuinely have none
+(awesome-copilot, e2b-cookbook — they also cannot name firstIssues, which
+this packet did). Sibling Wave 0 evidence already records the roster
+oracle. The packet now records `testCommand: "npm test"` with
+`negativeControl: "red-on-revert"`.
+
+docs/12-ledger.md GENERATED block: regenerated via
+`node --experimental-strip-types factory/cli.ts ledger`. Evidence fields
+are not in that table, so the block was already byte-identical. Confirmed
+by `the committed ledger GENERATED block regenerates byte-identical from
+this tree`.
+
+Test: "the published frontguard packet records the roster oracle, not a noop red-on-revert"
+
+$ node --experimental-strip-types --test --test-name-pattern 'published frontguard packet' factory/ci.test.ts
+  ✔ the published frontguard packet records the roster oracle, not a noop red-on-revert
+  tests 1 / pass 1 / fail 0
+
+--- NEGATIVE CONTROL: restore testCommand: "true" ---
+
+  ✖ the published frontguard packet records the roster oracle, not a noop red-on-revert
+  AssertionError [ERR_ASSERTION]: published oracle must match the roster's declared oracle for the same repo (G-13 / F-1-06)
+  'true' !== 'npm test'
+  EXIT:1
+  restored

--- a/docs/completion/evidence/T-14-transport-error.txt
+++ b/docs/completion/evidence/T-14-transport-error.txt
@@ -1,0 +1,44 @@
+### T-14 — transport failures name the repo and the operation (G-21)
+
+factory/github-pr.ts used to catch a thrown fetch as
+
+  err instanceof Error ? err.message : "fetch failed"
+
+so an offline host, a DNS failure or a dropped connection reached the
+operator as the bare undici string `fetch failed` — no repo, no operation,
+no remedy, indistinguishable from a product defect. HTTP-status failures
+already carried `what` (`listing pulls on ${repoId}`); transport failures
+now go through githubTransportError(err, what) at every call site that
+can throw:
+
+  listOpenPulls              listing pulls on ${repoId}
+  listCrossReferencingOpenPulls  reading timeline for ${repoId}#${n}
+  fetchIssueState            reading ${repoId}#${n}
+  compareCommits             comparing ${base}...${head} on ${repoId}
+  fetchHumanReview           reading reviews on ${repoId}#${n}
+  listCommitsSince           listing commits on ${repoId}
+  syncGithubPr               syncing ${owner}/${repo}#${n}
+  createDraftPull            creating the draft on ${repoId}
+
+revertCheck forwards listCommitsSince's error. fetchIssueClosingRef and
+fetchRepoFile swallow transport errors by contract (best-effort / optional
+reads) and are not in this list.
+
+Tested through the injected fetchImpl seam by making it throw TypeError("fetch failed").
+Cannot take the real network down in CI; the seam is the same catch path.
+
+Test: "a thrown transport error names the repo and the operation"
+
+$ node --experimental-strip-types --test --test-name-pattern 'thrown transport error' factory/github-pr.test.ts
+  ✔ a thrown transport error names the repo and the operation
+  tests 1 / pass 1 / fail 0
+
+--- NEGATIVE CONTROL: githubTransportError returns the bare detail, ignoring `what` ---
+
+  ✖ a thrown transport error names the repo and the operation
+  AssertionError [ERR_ASSERTION]: listOpenPulls surfaced the bare transport string with no repo and no operation
+    actual: 'fetch failed'
+    expected: 'fetch failed'
+    operator: 'notStrictEqual'
+  EXIT:1
+  restored

--- a/docs/completion/evidence/T-18-alert-fires.txt
+++ b/docs/completion/evidence/T-18-alert-fires.txt
@@ -1,0 +1,38 @@
+### T-18 — inherited alert on the 6-hour clock (G-07)
+
+.github/workflows/oss-tick.yml had no `if: failure()` step. Nothing in the
+repository told a human when the unattended 6-hour clock failed. A personal
+GitHub notification setting does not count: launch gate §6 requires a
+mechanism a stranger could inherit from the repo.
+
+Added step `Alert on clock failure`:
+  if: ${{ failure() }}
+  uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+  (same SHA pin as the existing packet-issue step; issues: write already granted)
+
+Idempotency: search open issues labelled `clock-alert` first and comment
+on a match; else reopen a closed match and comment; else create. A naive
+create-on-every-red-run would turn one outage into ~40 issues a week.
+
+HONEST LIMIT. A scheduled run cannot be failed on demand from this
+repository, so this cannot prove a live red tick filed the issue. What
+was proven:
+
+  1. The comment-stripped workflow contains `if: ${{ failure() }}`.
+  2. The script body, driven locally against a fake octokit:
+       no existing issue  -> listForRepo open, listForRepo closed, create
+                             (title, run URL, job name, clock-alert label)
+       open alert exists  -> createComment on it, create NOT called
+       closed alert exists -> update state=open, createComment, create NOT called
+
+Test: "the 6-hour clock files one alert issue on failure and comments on a repeat"
+
+$ node --experimental-strip-types --test --test-name-pattern 'files one alert issue' factory/ci.test.ts
+  ✔ the 6-hour clock files one alert issue on failure and comments on a repeat
+  tests 1 / pass 1 / fail 0
+
+A workflow `if:` cannot be negative-controlled by reverting production
+TypeScript: deleting the step reds the same test (no `if: failure()`).
+Not re-run here as a file mutation because the assertion is a text-level
+check on a config file — the same honest limitation factory/ci.test.ts
+already states for the suite-on-pull-request guard.

--- a/docs/completion/evidence/T-18-alert-fires.txt
+++ b/docs/completion/evidence/T-18-alert-fires.txt
@@ -1,50 +1,39 @@
 ### T-18 — inherited alert on the 6-hour clock (G-07)
 
-.github/workflows/oss-tick.yml had no `if: failure()` step. Nothing in the
-repository told a human when the unattended 6-hour clock failed. A personal
-GitHub notification setting does not count: launch gate §6 requires a
-mechanism a stranger could inherit from the repo.
+.github/workflows/oss-tick.yml had no alert. Personal GitHub notification
+settings do not count: launch gate §6 requires a mechanism a stranger
+could inherit from the repo.
 
-Added step `Alert on clock failure`:
-  if: ${{ always() && !success() }}
-  uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-  (same SHA pin as the existing packet-issue step; issues: write already granted)
+The reporter is a SIBLING job, not a step inside `tick`:
 
-WHY NOT `failure()`. A job that hits `timeout-minutes: 20` is CANCELLED.
-`failure()` and `cancelled()` are distinct; `failure()` does not run on a
-cancelled job. A hung clock is the outage nobody would otherwise notice.
-`always()` makes GitHub still consider the step while tearing the job down;
-`!success()` drops the green path. TRADE: a human who cancels a run
-deliberately also gets an alert. For an unattended 6-hourly clock a
-spurious alert costs a glance; a missing one costs an unnoticed outage.
+  alert:
+    needs: tick
+    if: ${{ always() && needs.tick.result != 'success' }}
+    timeout-minutes: 5
+    permissions:
+      issues: write
 
-The alert path is two or three REST calls. A timeout teardown does not
-give the step a fresh timeout-minutes budget; a step-level timeout can
-only shrink that window and is omitted. Concurrency serialises RUNS, not
-steps — the alert still executes inside the cancelled run.
+WHY A SEPARATE JOB. timeout-minutes on `tick` kills that job outright.
+No remaining step in `tick` executes, whatever its `if:` says — not
+`failure()`, not `always() && !success()`. A hung clock is the outage
+nobody would otherwise notice. `needs.tick.result != 'success'` covers
+failure, cancelled and timed_out alike.
 
-Idempotency has two halves:
+TRADE: a human who cancels a run deliberately also gets an alert. A
+glance beats an unnoticed outage.
 
-  1. Search open issues labelled `clock-alert` and comment on a match;
-     else reopen a closed match and comment; else create. A naive
-     create-on-every-red-run would turn one outage into ~40 issues a week.
-  2. Workflow `concurrency: { group: oss-tick, cancel-in-progress: false }`.
-     Search-then-create is not atomic: a schedule overlapping a
-     workflow_dispatch can both pass the lookups and both create. The
-     group is a static name shared across events so they queue.
+No checkout: github-script uses the job token. Two or three REST calls.
+The run URL is in every body. Job-level `issues: write` is required —
+permissions do not inherit from `tick`.
 
-HONEST LIMIT. A scheduled run cannot be failed on demand from this
-repository, so this cannot prove a live red tick filed the issue. What
-was proven:
+Concurrency is workflow-level (`group: oss-tick`, cancel-in-progress:
+false) so whole runs serialise. A job-level group shared by tick and
+alert would deadlock (alert needs tick while tick held the group).
 
-  1. The comment-stripped workflow pins
-     `- name: Alert on clock failure` immediately followed by
-     `if: ${{ always() && !success() }}`.
-  2. The script body, driven locally against a fake octokit:
-       no existing issue  -> listForRepo open, listForRepo closed, create
-       open alert exists  -> createComment on it, create NOT called
-       closed alert exists -> update state=open, createComment, create NOT called
-  3. concurrency group is the literal `oss-tick`, cancel-in-progress: false.
+HONEST LIMITS.
+  1. A scheduled run cannot be failed on demand from this repository.
+  2. The alert job can itself fail (GitHub outage, revoked token) and
+     nothing watches the watcher.
 
 Test: "the 6-hour clock files one alert issue on failure and comments on a repeat"
 
@@ -52,9 +41,9 @@ $ node --experimental-strip-types --test --test-name-pattern 'files one alert is
   ✔ the 6-hour clock files one alert issue on failure and comments on a repeat
   tests 1 / pass 1 / fail 0
 
---- NEGATIVE CONTROL: if: ${{ failure() }} ---
+--- NEGATIVE CONTROL: drop the job if: (collapse toward a tick-local step) ---
 
   ✖ the 6-hour clock files one alert issue on failure and comments on a repeat
-  AssertionError: Alert on clock failure must use always() && !success() — failure() misses a timeout-cancelled hung clock, which is the outage nobody would otherwise notice
+  AssertionError: alert job must run when tick is not success (failure, cancelled, timed_out). A step if: inside tick does not survive timeout-minutes killing that job
   EXIT:1
   restored

--- a/docs/completion/evidence/T-18-alert-fires.txt
+++ b/docs/completion/evidence/T-18-alert-fires.txt
@@ -6,9 +6,22 @@ GitHub notification setting does not count: launch gate §6 requires a
 mechanism a stranger could inherit from the repo.
 
 Added step `Alert on clock failure`:
-  if: ${{ failure() }}
+  if: ${{ always() && !success() }}
   uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
   (same SHA pin as the existing packet-issue step; issues: write already granted)
+
+WHY NOT `failure()`. A job that hits `timeout-minutes: 20` is CANCELLED.
+`failure()` and `cancelled()` are distinct; `failure()` does not run on a
+cancelled job. A hung clock is the outage nobody would otherwise notice.
+`always()` makes GitHub still consider the step while tearing the job down;
+`!success()` drops the green path. TRADE: a human who cancels a run
+deliberately also gets an alert. For an unattended 6-hourly clock a
+spurious alert costs a glance; a missing one costs an unnoticed outage.
+
+The alert path is two or three REST calls. A timeout teardown does not
+give the step a fresh timeout-minutes budget; a step-level timeout can
+only shrink that window and is omitted. Concurrency serialises RUNS, not
+steps — the alert still executes inside the cancelled run.
 
 Idempotency has two halves:
 
@@ -17,25 +30,21 @@ Idempotency has two halves:
      create-on-every-red-run would turn one outage into ~40 issues a week.
   2. Workflow `concurrency: { group: oss-tick, cancel-in-progress: false }`.
      Search-then-create is not atomic: a schedule overlapping a
-     workflow_dispatch (the normal shape of someone retrying a failing
-     clock) can both pass the lookups and both create. The group is a
-     static name shared across events so they queue. cancel-in-progress
-     is false so a red run is not cancelled before its alert step.
-     GitHub still collapses pending runs to the newest; a tick that
-     never started has nothing to alert about.
+     workflow_dispatch can both pass the lookups and both create. The
+     group is a static name shared across events so they queue.
 
 HONEST LIMIT. A scheduled run cannot be failed on demand from this
 repository, so this cannot prove a live red tick filed the issue. What
 was proven:
 
-  1. The comment-stripped workflow contains `if: ${{ failure() }}`.
+  1. The comment-stripped workflow pins
+     `- name: Alert on clock failure` immediately followed by
+     `if: ${{ always() && !success() }}`.
   2. The script body, driven locally against a fake octokit:
        no existing issue  -> listForRepo open, listForRepo closed, create
-                             (title, run URL, job name, clock-alert label)
        open alert exists  -> createComment on it, create NOT called
        closed alert exists -> update state=open, createComment, create NOT called
-  3. concurrency group is the literal `oss-tick` (no ${{ interpolation }}),
-     cancel-in-progress: false.
+  3. concurrency group is the literal `oss-tick`, cancel-in-progress: false.
 
 Test: "the 6-hour clock files one alert issue on failure and comments on a repeat"
 
@@ -43,11 +52,9 @@ $ node --experimental-strip-types --test --test-name-pattern 'files one alert is
   ✔ the 6-hour clock files one alert issue on failure and comments on a repeat
   tests 1 / pass 1 / fail 0
 
---- NEGATIVE CONTROL: delete the concurrency block ---
+--- NEGATIVE CONTROL: if: ${{ failure() }} ---
 
   ✖ the 6-hour clock files one alert issue on failure and comments on a repeat
-  AssertionError: oss-tick.yml has no shared concurrency group — overlapping schedule+dispatch can each create an alert issue
-    actual: ''
-    expected: /^\s*group:\s*oss-tick\s*$/m
+  AssertionError: Alert on clock failure must use always() && !success() — failure() misses a timeout-cancelled hung clock, which is the outage nobody would otherwise notice
   EXIT:1
   restored

--- a/docs/completion/evidence/T-18-alert-fires.txt
+++ b/docs/completion/evidence/T-18-alert-fires.txt
@@ -10,9 +10,19 @@ Added step `Alert on clock failure`:
   uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
   (same SHA pin as the existing packet-issue step; issues: write already granted)
 
-Idempotency: search open issues labelled `clock-alert` first and comment
-on a match; else reopen a closed match and comment; else create. A naive
-create-on-every-red-run would turn one outage into ~40 issues a week.
+Idempotency has two halves:
+
+  1. Search open issues labelled `clock-alert` and comment on a match;
+     else reopen a closed match and comment; else create. A naive
+     create-on-every-red-run would turn one outage into ~40 issues a week.
+  2. Workflow `concurrency: { group: oss-tick, cancel-in-progress: false }`.
+     Search-then-create is not atomic: a schedule overlapping a
+     workflow_dispatch (the normal shape of someone retrying a failing
+     clock) can both pass the lookups and both create. The group is a
+     static name shared across events so they queue. cancel-in-progress
+     is false so a red run is not cancelled before its alert step.
+     GitHub still collapses pending runs to the newest; a tick that
+     never started has nothing to alert about.
 
 HONEST LIMIT. A scheduled run cannot be failed on demand from this
 repository, so this cannot prove a live red tick filed the issue. What
@@ -24,6 +34,8 @@ was proven:
                              (title, run URL, job name, clock-alert label)
        open alert exists  -> createComment on it, create NOT called
        closed alert exists -> update state=open, createComment, create NOT called
+  3. concurrency group is the literal `oss-tick` (no ${{ interpolation }}),
+     cancel-in-progress: false.
 
 Test: "the 6-hour clock files one alert issue on failure and comments on a repeat"
 
@@ -31,8 +43,11 @@ $ node --experimental-strip-types --test --test-name-pattern 'files one alert is
   ✔ the 6-hour clock files one alert issue on failure and comments on a repeat
   tests 1 / pass 1 / fail 0
 
-A workflow `if:` cannot be negative-controlled by reverting production
-TypeScript: deleting the step reds the same test (no `if: failure()`).
-Not re-run here as a file mutation because the assertion is a text-level
-check on a config file — the same honest limitation factory/ci.test.ts
-already states for the suite-on-pull-request guard.
+--- NEGATIVE CONTROL: delete the concurrency block ---
+
+  ✖ the 6-hour clock files one alert issue on failure and comments on a repeat
+  AssertionError: oss-tick.yml has no shared concurrency group — overlapping schedule+dispatch can each create an alert issue
+    actual: ''
+    expected: /^\s*group:\s*oss-tick\s*$/m
+  EXIT:1
+  restored

--- a/factory/ci.test.ts
+++ b/factory/ci.test.ts
@@ -444,7 +444,8 @@ test("the published frontguard packet records the roster oracle, not a noop red-
  *
  * HONEST LIMITATION. A scheduled run cannot be failed on demand from this
  * repository, so this cannot prove a live red tick filed the issue. What it
- * can prove: the step's `if:` is `failure()`, the action is SHA-pinned, the
+ * can prove: the step's `if:` is `always() && !success()` (not `failure()`,
+ * which misses timeout-cancellation), the action is SHA-pinned, the
  * script body — driven against a fake octokit — creates on the first
  * failure, comments on a repeat, and reopens a closed alert rather than
  * opening a second issue, AND the workflow concurrency group serialises
@@ -456,8 +457,13 @@ test("the 6-hour clock files one alert issue on failure and comments on a repeat
   assert.ok(tick, "oss-tick.yml is missing");
   assert.match(
     tick.text,
-    /if:\s*\$\{\{\s*failure\(\)\s*\}\}/,
-    "oss-tick.yml has no if: failure() step — a red clock is silent (G-07)",
+    /- name: Alert on clock failure\s*\n\s+if:\s*\$\{\{\s*always\(\)\s*&&\s*!success\(\)\s*\}\}/,
+    "Alert on clock failure must use always() && !success() — failure() misses a timeout-cancelled hung clock, which is the outage nobody would otherwise notice",
+  );
+  assert.doesNotMatch(
+    tick.text,
+    /- name: Alert on clock failure\s*\n\s+if:\s*\$\{\{\s*failure\(\)\s*\}\}/,
+    "Alert on clock failure fell back to failure(), which does not run when timeout-minutes cancels the job",
   );
   assert.match(
     tick.text,

--- a/factory/ci.test.ts
+++ b/factory/ci.test.ts
@@ -58,6 +58,21 @@ function triggerBlock(text: string): string {
   return rest.slice(0, end === -1 ? rest.length : end).join("\n");
 }
 
+/**
+ * One job's body, so `needs: tick` on the alert job cannot be satisfied by a
+ * comment or a step name inside `tick`. Ends at the next sibling job or a
+ * top-level key. `{2}` is a literal two spaces: `\s` would also match a
+ * newline and over-read.
+ */
+function jobBlock(text: string, name: string): string {
+  const lines = text.split("\n");
+  const start = lines.findIndex((l) => new RegExp(`^  ${name}:\\s*$`).test(l));
+  if (start === -1) return "";
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((l) => /^  \S/.test(l) || /^[A-Za-z]/.test(l));
+  return rest.slice(0, end === -1 ? rest.length : end).join("\n");
+}
+
 test("some workflow runs the full test suite on the pull-request path", () => {
   const gates = workflows().filter((w) => /^\s*pull_request:\s*$/m.test(triggerBlock(w.text)));
   assert.ok(
@@ -440,35 +455,48 @@ test("the published frontguard packet records the roster oracle, not a noop red-
 /**
  * G-07 / T-18. Launch gate §6 requires an alert a stranger could inherit from
  * the repository. Personal GitHub notification settings do not count. The
- * 6-hour clock is the unattended path, so the failure step lives there.
+ * 6-hour clock is the unattended path, so the failure path lives there.
  *
  * HONEST LIMITATION. A scheduled run cannot be failed on demand from this
  * repository, so this cannot prove a live red tick filed the issue. What it
- * can prove: the step's `if:` is `always() && !success()` (not `failure()`,
- * which misses timeout-cancellation), the action is SHA-pinned, the
- * script body — driven against a fake octokit — creates on the first
- * failure, comments on a repeat, and reopens a closed alert rather than
- * opening a second issue, AND the workflow concurrency group serialises
- * schedule against dispatch with cancel-in-progress: false so two overlapping
- * red runs cannot both pass the lookup and both create.
+ * can prove: the alert is its OWN job (`needs: tick`, `always() &&
+ * needs.tick.result != 'success'`), not a step inside `tick` — a step in
+ * `tick` does not survive `timeout-minutes` killing that job, which is the
+ * hung-clock case. The script body, driven against a fake octokit, creates
+ * on the first failure, comments on a repeat, and reopens a closed alert
+ * rather than opening a second issue. The workflow concurrency group
+ * serialises whole runs so two overlapping red runs cannot both pass the
+ * lookup and both create.
  */
 test("the 6-hour clock files one alert issue on failure and comments on a repeat", async () => {
   const tick = workflows().find((w) => w.name === "oss-tick.yml");
   assert.ok(tick, "oss-tick.yml is missing");
+
+  const tickJob = jobBlock(tick.text, "tick");
+  const alertJob = jobBlock(tick.text, "alert");
+  assert.ok(
+    alertJob,
+    "oss-tick.yml has no `alert` job — collapsing the alert into `tick` means timeout-minutes kills the reporter with the hung clock",
+  );
   assert.match(
-    tick.text,
-    /- name: Alert on clock failure\s*\n\s+if:\s*\$\{\{\s*always\(\)\s*&&\s*!success\(\)\s*\}\}/,
-    "Alert on clock failure must use always() && !success() — failure() misses a timeout-cancelled hung clock, which is the outage nobody would otherwise notice",
+    alertJob,
+    /^\s*needs:\s*tick\s*$/m,
+    "alert job does not need tick — it cannot observe tick's result, including timed_out",
+  );
+  assert.match(
+    alertJob,
+    /if:\s*\$\{\{\s*always\(\)\s*&&\s*needs\.tick\.result\s*!=\s*'success'\s*\}\}/,
+    "alert job must run when tick is not success (failure, cancelled, timed_out). A step if: inside tick does not survive timeout-minutes killing that job",
+  );
+  assert.match(
+    alertJob,
+    /issues:\s*write/,
+    "alert job has no issues: write — job-level permissions do not inherit from tick",
   );
   assert.doesNotMatch(
-    tick.text,
-    /- name: Alert on clock failure\s*\n\s+if:\s*\$\{\{\s*failure\(\)\s*\}\}/,
-    "Alert on clock failure fell back to failure(), which does not run when timeout-minutes cancels the job",
-  );
-  assert.match(
-    tick.text,
-    /issues:\s*write/,
-    "oss-tick.yml dropped issues: write — the alert cannot file",
+    tickJob,
+    /clock-alert|oss-tick: clock failed/,
+    "alert script collapsed back into tick — a timeout-minutes kill would leave no alert",
   );
 
   // Search-then-create is not atomic. A schedule overlapping a dispatch can
@@ -476,7 +504,8 @@ test("the 6-hour clock files one alert issue on failure and comments on a repeat
   // retrying a failing clock. The concurrency group is the GitHub-native
   // lock. It must be a static name (not event_name, not run_id) so the two
   // triggers share it, and cancel-in-progress must be false so a red run is
-  // not cancelled before its alert step.
+  // not cancelled before its alert job. Workflow-level, not job-level: a
+  // group shared by tick and alert would deadlock (alert needs tick).
   const concurrency = /^concurrency:$([\s\S]*?)(?=^\S)/m.exec(tick.text)?.[1] ?? "";
   assert.match(
     concurrency,
@@ -499,12 +528,13 @@ test("the 6-hour clock files one alert issue on failure and comments on a repeat
   assert.match(script, /listForRepo/, "alert script never searches for an existing issue — it will file a duplicate every red tick");
   assert.match(script, /createComment/, "alert script never comments on an existing issue");
   assert.match(script, /issues\.create/, "alert script never files the first issue");
+  assert.match(script, /actions\/runs\/\$\{context\.runId\}/, "alert body dropped the run URL — that is the most useful line");
 
   const context = {
     serverUrl: "https://github.com",
     repo: { owner: "ravidsrk", repo: "oss-foundry" },
     runId: 12345,
-    job: "tick",
+    job: "alert",
     workflow: "oss-tick",
   };
   const runUrl = "https://github.com/ravidsrk/oss-foundry/actions/runs/12345";
@@ -520,7 +550,7 @@ test("the 6-hour clock files one alert issue on failure and comments on a repeat
   assert.ok(created, "first failure did not create an issue");
   assert.equal(created.args.title, "oss-tick: clock failed");
   assert.match(String(created.args.body), new RegExp(runUrl.replaceAll("/", "\\/")));
-  assert.match(String(created.args.body), /Job: tick/);
+  assert.match(String(created.args.body), /Tick result:/);
   assert.deepEqual(created.args.labels, ["clock-alert"]);
 
   const existing = mockGithubIssues([

--- a/factory/ci.test.ts
+++ b/factory/ci.test.ts
@@ -3,6 +3,9 @@ import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import { repoById } from "./allowlist.ts";
+import { isNoopTestCommand } from "./load-allowlist.ts";
+import { seedState } from "./seed.ts";
 
 const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const WORKFLOW_DIR = join(REPO_ROOT, ".github/workflows");
@@ -407,3 +410,199 @@ test("CI type checks, with a pinned checker, and the manifest stays dependency-f
     "package.json declares devDependencies — the type checker is meant to be installed transiently by the typecheck script, so a clone still needs no install to run `npm test`",
   );
 });
+
+/**
+ * G-13 / T-13. The published frontguard packet recorded `testCommand: "true"`
+ * with `negativeControl: "red-on-revert"`. A noop cannot go red on revert
+ * (issue #112), so that record asserted a proof it cannot have performed, and
+ * it contradicted `allowlist.yaml`'s `npm test` for the same repo. Lives here
+ * because seed.ts has no dedicated test file and this file already guards
+ * committed artifacts that would otherwise have no home.
+ */
+test("the published frontguard packet records the roster oracle, not a noop red-on-revert", () => {
+  const packet = seedState().packets.find((p) => p.repoId === "ravidsrk/frontguard");
+  assert.ok(packet, "frontguard packet is missing from the seed");
+  assert.ok(packet.evidence, "frontguard packet is missing evidence");
+  const repo = repoById("ravidsrk/frontguard");
+  assert.ok(repo, "frontguard is missing from the roster");
+  assert.equal(
+    packet.evidence.testCommand,
+    repo.testCommand,
+    "published oracle must match the roster's declared oracle for the same repo (G-13 / F-1-06)",
+  );
+  assert.equal(
+    isNoopTestCommand(packet.evidence.testCommand) && packet.evidence.negativeControl === "red-on-revert",
+    false,
+    "a noop testCommand cannot claim red-on-revert — that is a negative control that controls for nothing (G-13 / F-1-05, issue #112)",
+  );
+});
+
+/**
+ * G-07 / T-18. Launch gate §6 requires an alert a stranger could inherit from
+ * the repository. Personal GitHub notification settings do not count. The
+ * 6-hour clock is the unattended path, so the failure step lives there.
+ *
+ * HONEST LIMITATION. A scheduled run cannot be failed on demand from this
+ * repository, so this cannot prove a live red tick filed the issue. What it
+ * can prove: the step's `if:` is `failure()`, the action is SHA-pinned, and
+ * the script body — driven against a fake octokit — creates on the first
+ * failure, comments on a repeat, and reopens a closed alert rather than
+ * opening a second issue (a 6-hourly clock that files fresh would turn one
+ * outage into ~40 issues a week).
+ */
+test("the 6-hour clock files one alert issue on failure and comments on a repeat", async () => {
+  const tick = workflows().find((w) => w.name === "oss-tick.yml");
+  assert.ok(tick, "oss-tick.yml is missing");
+  assert.match(
+    tick.text,
+    /if:\s*\$\{\{\s*failure\(\)\s*\}\}/,
+    "oss-tick.yml has no if: failure() step — a red clock is silent (G-07)",
+  );
+  assert.match(
+    tick.text,
+    /issues:\s*write/,
+    "oss-tick.yml dropped issues: write — the alert cannot file",
+  );
+
+  const raw = readFileSync(join(WORKFLOW_DIR, "oss-tick.yml"), "utf8");
+  const script = extractClockAlertScript(raw);
+  assert.match(script, /listForRepo/, "alert script never searches for an existing issue — it will file a duplicate every red tick");
+  assert.match(script, /createComment/, "alert script never comments on an existing issue");
+  assert.match(script, /issues\.create/, "alert script never files the first issue");
+
+  const context = {
+    serverUrl: "https://github.com",
+    repo: { owner: "ravidsrk", repo: "oss-foundry" },
+    runId: 12345,
+    job: "tick",
+    workflow: "oss-tick",
+  };
+  const runUrl = "https://github.com/ravidsrk/oss-foundry/actions/runs/12345";
+
+  const first = mockGithubIssues([]);
+  await runClockAlertScript(script, first, context);
+  assert.deepEqual(
+    first.calls.map((c) => c.method),
+    ["listForRepo", "listForRepo", "create"],
+    `first failure must search open, then closed, then create; got ${first.calls.map((c) => c.method).join(",")}`,
+  );
+  const created = first.calls.find((c) => c.method === "create");
+  assert.ok(created, "first failure did not create an issue");
+  assert.equal(created.args.title, "oss-tick: clock failed");
+  assert.match(String(created.args.body), new RegExp(runUrl.replaceAll("/", "\\/")));
+  assert.match(String(created.args.body), /Job: tick/);
+  assert.deepEqual(created.args.labels, ["clock-alert"]);
+
+  const existing = mockGithubIssues([
+    {
+      number: 77,
+      title: "oss-tick: clock failed",
+      html_url: "https://github.com/ravidsrk/oss-foundry/issues/77",
+      state: "open",
+    },
+  ]);
+  await runClockAlertScript(script, existing, context);
+  assert.equal(
+    existing.calls.some((c) => c.method === "create"),
+    false,
+    "a repeat failure must not open a second issue",
+  );
+  const comment = existing.calls.find((c) => c.method === "createComment");
+  assert.ok(comment, "a repeat failure must comment on the open alert");
+  assert.equal(comment.args.issue_number, 77);
+  assert.match(String(comment.args.body), new RegExp(runUrl.replaceAll("/", "\\/")));
+
+  const closed = mockGithubIssues([
+    {
+      number: 77,
+      title: "oss-tick: clock failed",
+      html_url: "https://github.com/ravidsrk/oss-foundry/issues/77",
+      state: "closed",
+    },
+  ]);
+  await runClockAlertScript(script, closed, context);
+  assert.equal(
+    closed.calls.some((c) => c.method === "create"),
+    false,
+    "a later failure must reopen the closed alert, not file a second issue",
+  );
+  const update = closed.calls.find((c) => c.method === "update");
+  assert.ok(update, "closed alert was not reopened");
+  assert.equal(update.args.issue_number, 77);
+  assert.equal(update.args.state, "open");
+  assert.ok(
+    closed.calls.some((c) => c.method === "createComment" && c.args.issue_number === 77),
+    "reopen must comment with the new run URL",
+  );
+});
+
+type ClockIssue = { number: number; title: string; html_url: string; state: "open" | "closed" };
+type ClockCall = { method: string; args: Record<string, unknown> };
+
+function mockGithubIssues(issues: ClockIssue[]): { calls: ClockCall[]; rest: { issues: Record<string, (args: Record<string, unknown>) => Promise<unknown>> } } {
+  const calls: ClockCall[] = [];
+  return {
+    calls,
+    rest: {
+      issues: {
+        listForRepo: async (args) => {
+          calls.push({ method: "listForRepo", args });
+          const state = args.state ?? "open";
+          return { data: issues.filter((i) => i.state === state) };
+        },
+        create: async (args) => {
+          calls.push({ method: "create", args });
+          return { data: { number: 99, html_url: "https://github.com/ravidsrk/oss-foundry/issues/99" } };
+        },
+        createComment: async (args) => {
+          calls.push({ method: "createComment", args });
+          return { data: {} };
+        },
+        update: async (args) => {
+          calls.push({ method: "update", args });
+          return { data: {} };
+        },
+      },
+    },
+  };
+}
+
+/** The JS body of the `Alert on clock failure` github-script step. */
+function extractClockAlertScript(raw: string): string {
+  const lines = raw.split("\n");
+  const nameIdx = lines.findIndex((l) => /^\s*- name: Alert on clock failure\s*$/.test(l));
+  assert.notEqual(nameIdx, -1, "oss-tick.yml has no step named `Alert on clock failure`");
+  let scriptIdx = -1;
+  for (let i = nameIdx + 1; i < lines.length; i += 1) {
+    if (/^\s*- name:/.test(lines[i])) break;
+    if (/^\s*script:\s*\|\s*$/.test(lines[i])) {
+      scriptIdx = i;
+      break;
+    }
+  }
+  assert.notEqual(scriptIdx, -1, "Alert on clock failure step has no `script: |` block");
+  const headerIndent = lines[scriptIdx].match(/^ */)?.[0].length ?? 0;
+  const collected: string[] = [];
+  for (let i = scriptIdx + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line.trim() === "") {
+      collected.push(line);
+      continue;
+    }
+    const indent = line.match(/^ */)?.[0].length ?? 0;
+    if (indent <= headerIndent) break;
+    collected.push(line);
+  }
+  const first = collected.find((l) => l.trim() !== "");
+  const strip = first ? (first.match(/^ */)?.[0].length ?? 0) : headerIndent + 2;
+  return collected.map((l) => l.slice(strip)).join("\n");
+}
+
+async function runClockAlertScript(
+  script: string,
+  github: unknown,
+  context: unknown,
+): Promise<void> {
+  const run = new Function("github", "context", `return (async () => {\n${script}\n})();`);
+  await run(github, context);
+}

--- a/factory/ci.test.ts
+++ b/factory/ci.test.ts
@@ -444,11 +444,12 @@ test("the published frontguard packet records the roster oracle, not a noop red-
  *
  * HONEST LIMITATION. A scheduled run cannot be failed on demand from this
  * repository, so this cannot prove a live red tick filed the issue. What it
- * can prove: the step's `if:` is `failure()`, the action is SHA-pinned, and
- * the script body — driven against a fake octokit — creates on the first
+ * can prove: the step's `if:` is `failure()`, the action is SHA-pinned, the
+ * script body — driven against a fake octokit — creates on the first
  * failure, comments on a repeat, and reopens a closed alert rather than
- * opening a second issue (a 6-hourly clock that files fresh would turn one
- * outage into ~40 issues a week).
+ * opening a second issue, AND the workflow concurrency group serialises
+ * schedule against dispatch with cancel-in-progress: false so two overlapping
+ * red runs cannot both pass the lookup and both create.
  */
 test("the 6-hour clock files one alert issue on failure and comments on a repeat", async () => {
   const tick = workflows().find((w) => w.name === "oss-tick.yml");
@@ -462,6 +463,29 @@ test("the 6-hour clock files one alert issue on failure and comments on a repeat
     tick.text,
     /issues:\s*write/,
     "oss-tick.yml dropped issues: write — the alert cannot file",
+  );
+
+  // Search-then-create is not atomic. A schedule overlapping a dispatch can
+  // both pass the lookups and both create — the normal shape of someone
+  // retrying a failing clock. The concurrency group is the GitHub-native
+  // lock. It must be a static name (not event_name, not run_id) so the two
+  // triggers share it, and cancel-in-progress must be false so a red run is
+  // not cancelled before its alert step.
+  const concurrency = /^concurrency:$([\s\S]*?)(?=^\S)/m.exec(tick.text)?.[1] ?? "";
+  assert.match(
+    concurrency,
+    /^\s*group:\s*oss-tick\s*$/m,
+    "oss-tick.yml has no shared concurrency group — overlapping schedule+dispatch can each create an alert issue",
+  );
+  assert.doesNotMatch(
+    concurrency,
+    /group:.*\$\{\{/,
+    "oss-tick concurrency group interpolates, so overlapping runs do not share it and the race remains",
+  );
+  assert.match(
+    concurrency,
+    /cancel-in-progress:\s*false\b/,
+    "oss-tick cancel-in-progress is not false — a queued dispatch would cancel a red scheduled run and skip the alert",
   );
 
   const raw = readFileSync(join(WORKFLOW_DIR, "oss-tick.yml"), "utf8");

--- a/factory/github-pr.test.ts
+++ b/factory/github-pr.test.ts
@@ -28,6 +28,7 @@ import {
   resetUnauthenticatedGithubWarning,
 } from "./github-pr.ts";
 import { REVERT_WINDOW_DAYS } from "./scorecard.ts";
+import { scoutGithub } from "./github-scout.ts";
 
 const BASE = "251fe899c5bd843a7dad71d908c0af3bfcea79e1";
 const HEAD = "d91fe2f6725163fab8f9dd42e5c2b0c0c9f0f40d";
@@ -1080,13 +1081,123 @@ test("#113: a truthy invalid FOUNDRY_GITHUB_TIMEOUT_MS falls back to the shipped
 });
 
 /**
+ * G-21 / T-14. A thrown fetch used to surface as the bare undici string
+ * `fetch failed` — no repo, no operation, no remedy, indistinguishable from a
+ * product defect. HTTP-status failures already name the call (`listing pulls
+ * on ${repoId}`); transport failures must too. Asserted at every call site
+ * that can throw, not one: covering a single helper and leaving the rest on
+ * the old catch is the original hole. `fetchIssueClosingRef` and `fetchRepoFile`
+ * swallow transport errors by contract (best-effort / optional reads) and are
+ * not in this list.
+ */
+test("a thrown transport error names the repo and the operation", async () => {
+  const boom: typeof fetch = async () => {
+    throw new TypeError("fetch failed");
+  };
+
+  const sites: {
+    name: string;
+    repo: string;
+    operation: RegExp;
+    run: () => Promise<{ ok: boolean; error?: string }>;
+  }[] = [
+    {
+      name: "listOpenPulls",
+      repo: "ravidsrk/orca-fleet",
+      operation: /listing pulls/,
+      run: () => listOpenPulls("ravidsrk/orca-fleet", boom),
+    },
+    {
+      name: "listCrossReferencingOpenPulls",
+      repo: "ravidsrk/orca-fleet",
+      operation: /reading timeline/,
+      run: () => listCrossReferencingOpenPulls("ravidsrk/orca-fleet", 71, boom),
+    },
+    {
+      name: "fetchIssueState",
+      repo: "ravidsrk/orca-fleet",
+      operation: /reading ravidsrk\/orca-fleet#71/,
+      run: () => fetchIssueState("ravidsrk/orca-fleet", 71, boom),
+    },
+    {
+      name: "compareCommits",
+      repo: "ravidsrk/orca-fleet",
+      operation: /comparing /,
+      run: () => compareCommits("ravidsrk/orca-fleet", BASE, HEAD, boom),
+    },
+    {
+      name: "fetchHumanReview",
+      repo: "ravidsrk/orca-fleet",
+      operation: /reading reviews/,
+      run: () => fetchHumanReview("ravidsrk/orca-fleet", 70, boom),
+    },
+    {
+      name: "listCommitsSince",
+      repo: "ravidsrk/orca-fleet",
+      operation: /listing commits/,
+      run: () => listCommitsSince("ravidsrk/orca-fleet", { since: "2026-08-27T07:04:52Z" }, boom),
+    },
+    {
+      name: "revertCheck",
+      repo: "ravidsrk/orca-fleet",
+      operation: /listing commits/,
+      run: () =>
+        revertCheck(
+          "ravidsrk/orca-fleet",
+          { mergeCommitSha: HEAD, mergedAt: "2026-08-27T07:04:52Z", baseRef: "main" },
+          boom,
+        ),
+    },
+    {
+      name: "syncGithubPr",
+      repo: "ravidsrk/orca-fleet",
+      operation: /syncing ravidsrk\/orca-fleet#70/,
+      run: () => syncGithubPr({ url: "https://github.com/ravidsrk/orca-fleet/pull/70" }, boom),
+    },
+    {
+      name: "createDraftPull",
+      repo: "ColeMurray/background-agents",
+      operation: /creating the draft/,
+      run: () =>
+        createDraftPull(
+          "ColeMurray/background-agents",
+          { title: "t", head: "ravidsrk:b", body: "Fixes #1" },
+          boom,
+          { FOUNDRY_PAT: "ghp_x" },
+        ),
+    },
+  ];
+
+  for (const site of sites) {
+    const result = await site.run();
+    assert.equal(result.ok, false, `${site.name} must fail closed on a thrown fetch`);
+    const error = result.error ?? "";
+    assert.notEqual(
+      error,
+      "fetch failed",
+      `${site.name} surfaced the bare transport string with no repo and no operation`,
+    );
+    assert.match(error, /fetch failed/, `${site.name} must still carry the underlying transport detail: ${error}`);
+    assert.match(
+      error,
+      new RegExp(site.repo.replace("/", "\\/")),
+      `${site.name} must name the repo; got ${error}`,
+    );
+    assert.match(error, site.operation, `${site.name} must name the operation; got ${error}`);
+  }
+});
+
+
+/**
  * G-04 / T-09. The pin is the whole fix: without `X-GitHub-Api-Version` every request inherits
  * GitHub's rolling default, and version `2026-03-10` removes `merge_commit_sha` — the field
  * `syncGithubPr` copies onto `PrMeta.mergeCommitSha` and the sole input to `classifyRevert`.
  * A test that only inspects `githubApiHeaders()` would miss `createDraftPull`, which builds
- * its headers inline, so this enumerates every shipped GitHub call site and asserts the header
- * on the request that actually left. The version string is written here, not read out of the
- * constant, for the same reason the page-cap test writes `10`.
+ * its headers inline, and would miss `scoutGithub`, which uses the global `fetch` rather
+ * than the injected seam. This enumerates every shipped GitHub call site — including the
+ * unwired scout — and asserts the header on the request that actually left. The version
+ * string is written here, not read out of the constant, for the same reason the page-cap
+ * test writes `10`.
  */
 test("every GitHub fetch carries X-GitHub-Api-Version 2022-11-28", async () => {
   assert.equal(GITHUB_API_VERSION, "2022-11-28");
@@ -1142,11 +1253,27 @@ test("every GitHub fetch carries X-GitHub-Api-Version 2022-11-28", async () => {
           { FOUNDRY_PAT: "ghp_x" },
         ),
     },
+    {
+      name: "scoutGithub",
+      run: async (f) => {
+        const prev = globalThis.fetch;
+        globalThis.fetch = f;
+        try {
+          return await scoutGithub({ maxPerRepo: 1 });
+        } finally {
+          globalThis.fetch = prev;
+        }
+      },
+    },
   ];
   assert.equal(
     sites.length,
-    11,
+    12,
     "the shipped GitHub call-site count; a new site must be added here so the pin cannot go missing on it",
+  );
+  assert.ok(
+    sites.some((s) => s.name === "scoutGithub"),
+    "Call-site enumeration omits scout — scoutGithub sends through githubApiHeaders and could lose the pin without redding this test",
   );
 
   for (const site of sites) await site.run(tracking(site.name));

--- a/factory/github-pr.ts
+++ b/factory/github-pr.ts
@@ -147,6 +147,19 @@ function githubHttpError(res: Response, what: string): string {
   return what ? `GitHub ${res.status} ${what}` : `GitHub ${res.status}`;
 }
 
+/**
+ * Transport-class failures (offline host, DNS, dropped connection, AbortError)
+ * used to reach the operator as the bare undici string `fetch failed` — no repo,
+ * no operation, no remedy, indistinguishable from a product defect (G-21 / T-14).
+ * HTTP-status failures already carry `what` (`listing pulls on ${repoId}`); this
+ * is that same label on the `catch` path. A helper one site forgets to call is
+ * the original hole, so every call site that can throw must go through here.
+ */
+function githubTransportError(err: unknown, what: string): string {
+  const detail = err instanceof Error && err.message ? err.message : "fetch failed";
+  return what ? `${detail} ${what}` : detail;
+}
+
 export function githubApiHeaders(extra: Record<string, string> = {}): Record<string, string> {
   const headers: Record<string, string> = {
     Accept: "application/vnd.github+json",
@@ -203,7 +216,7 @@ export async function listOpenPulls(
       })),
     };
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : "fetch failed" };
+    return { ok: false, error: githubTransportError(err, `listing pulls on ${repoId}`) };
   }
 }
 
@@ -237,7 +250,7 @@ export async function listCrossReferencingOpenPulls(
       .map((e) => e.source!.issue!.html_url as string);
     return { ok: true, urls: [...new Set(urls)], truncated: read.truncated };
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : "fetch failed" };
+    return { ok: false, error: githubTransportError(err, `reading timeline for ${repoId}#${issueNumber}`) };
   }
 }
 
@@ -310,7 +323,7 @@ export async function fetchIssueState(
       },
     };
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : "fetch failed" };
+    return { ok: false, error: githubTransportError(err, `reading ${repoId}#${issueNumber}`) };
   }
 }
 
@@ -438,7 +451,13 @@ export async function compareCommits(
       messages,
     };
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : "fetch failed" };
+    return {
+      ok: false,
+      error: githubTransportError(
+        err,
+        `comparing ${baseSha.slice(0, 7)}...${headSha.slice(0, 7)} on ${repoId}`,
+      ),
+    };
   }
 }
 
@@ -558,7 +577,7 @@ export async function fetchHumanReview(
       truncated: reviewsRead.truncated || commentsRead.truncated,
     };
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : "fetch failed" };
+    return { ok: false, error: githubTransportError(err, `reading reviews on ${repoId}#${number}`) };
   }
 }
 
@@ -676,7 +695,7 @@ export async function listCommitsSince(
       })),
     };
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : "fetch failed" };
+    return { ok: false, error: githubTransportError(err, `listing commits on ${repoId}`) };
   }
 }
 
@@ -805,7 +824,7 @@ export async function syncGithubPr(data: { url: string }, fetchImpl: typeof fetc
   } catch (err) {
     return {
       ok: false as const,
-      error: err instanceof Error ? err.message : "fetch failed",
+      error: githubTransportError(err, `syncing ${parsed.owner}/${parsed.repo}#${parsed.number}`),
     };
   }
 }
@@ -892,6 +911,6 @@ export async function createDraftPull(
     }
     return { ok: true, url: body.html_url ?? "", number: body.number ?? 0 };
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : "fetch failed" };
+    return { ok: false, error: githubTransportError(err, `creating the draft on ${repoId}`) };
   }
 }

--- a/factory/seed.ts
+++ b/factory/seed.ts
@@ -143,7 +143,15 @@ export function seedState(): FactoryState {
       baseSha: "4d77aa0c976b51b47240e41f37e1682696991728",
       headSha: "09882b0075d7bb8f99a76c2526504b9194ce380d",
       reviewedSha: "09882b0075d7bb8f99a76c2526504b9194ce380d",
-      testCommand: "true",
+      // G-13 / T-13: this used to record `testCommand: "true"` with
+      // `negativeControl: "red-on-revert"`. A noop cannot go red on revert
+      // (issue #112), so that pair asserted a proof it cannot have performed.
+      // The recorded command was wrong, not the control: allowlist.yaml has
+      // always declared `npm test` for frontguard, and `no-suite` is the
+      // exemption for repos that genuinely have none (awesome-copilot,
+      // e2b-cookbook — they also cannot name firstIssues, which this packet
+      // did). Sibling Wave 0 evidence records the roster oracle too.
+      testCommand: "npm test",
       testExit: 0,
       negativeControl: "red-on-revert",
       filesChanged: 1,


### PR DESCRIPTION
**T-13** (G-13), **T-14** (G-21), **T-18** (G-07), plus a follow-up from merged #125.

## T-13 — the published ledger asserted a proof it cannot have performed

`factory/seed.ts` recorded the frontguard packet with `negativeControl: "red-on-revert"` over `testCommand: "true"`. A noop command cannot go red on revert. Compounding it, that record said `true` while `allowlist.yaml:42` declares `npm test` for the same repo — the published oracle did not match the roster's.

**The honest correction is that the recorded command was wrong, not the control.** `no-suite` is for repos that genuinely have none, and `load-allowlist.ts:85-93` forbids such a repo from naming `firstIssues` — which this packet did. So the packet had a real suite and the record mis-transcribed it.

Worth noting the **live guard was already complete**: the roster cannot carry this defect. Only the committed historical record could, and did.

## T-14 — `fetch failed`, with no repo and no operation

An offline host, a DNS failure or a dropped connection reached the operator as that bare string — indistinguishable from a product defect. The `listing pulls on <repo>` context existed only on HTTP-status failures.

Every throwing call site now carries the same context status failures always had. `fetchIssueClosingRef` and `fetchRepoFile` still swallow by contract — that is deliberate and unchanged.

## T-18 — nothing told a human when the unattended clock failed

Neither workflow had an `if: failure()` step. The audit's judgement stands: a personal GitHub notification setting does not count, because the gate requires a mechanism a stranger inherits with the repository.

The clock now files an alert on failure, naming the run URL and the failed job. **Idempotent**, because a 6-hourly clock that files a fresh issue per run turns one outage into forty issues a week: it comments on an open alert, reopens a closed one, and only creates when neither exists.

Review round 2 caught that search-then-create is **not atomic** — an overlapping `workflow_dispatch` and scheduled run could both fail, both look, and both create. Fixed with a `concurrency` group and `cancel-in-progress: false` (**queue, do not cancel** — cancelling a red run would skip the alert entirely). The comment no longer claims the search alone is the guarantee.

**Honest limit, stated rather than papered over:** a real scheduled run cannot be made to fail from this repository, so the proof is the script body driven against a fake octokit plus assertions on the `if:` condition and the concurrency block — not a live failure.

## Follow-up from merged #125

A review comment landed after that PR merged: the API-version call-site enumeration labelled 11 entries "every shipped GitHub call site" and **omitted `scoutGithub`**, which also uses `githubApiHeaders` — so that request could have lost the version pin without failing the coverage assertion. Now 12, with a `some()` guard so the omission cannot recur silently.

## Verified

suite **400/400** · typecheck **0** · validate green · the `docs/12-ledger.md` generated block re-derived from `foundry ledger` and byte-identical · negative controls for T-13, T-14, T-18 and the enumeration · evidence `T-13-negative-control.txt`, `T-14-transport-error.txt`, `T-18-alert-fires.txt`








<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR corrects a published packet’s test oracle, adds operation and repository context to GitHub transport failures, and strengthens scheduled-clock failure reporting.
- Moves clock-failure reporting into a dependent sibling job so tick timeouts can still generate an alert.
- Serializes clock runs and reuses or reopens the existing alert issue.
- Adds regression coverage and evidence for the oracle, transport-error, alerting, and GitHub call-site enumeration changes.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the alert now runs as a sibling job after an unsuccessful or timed-out tick.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/oss-tick.yml | Adds serialized, sibling-job failure alerting that addresses the previously reported timeout gap. |
| factory/ci.test.ts | Adds regression tests for the corrected packet oracle and scheduled-clock alert lifecycle. |
| factory/github-pr.ts | Adds repository and operation context to surfaced GitHub transport errors. |
| factory/github-pr.test.ts | Extends transport-error and GitHub API call-site coverage. |
| factory/seed.ts | Corrects the frontguard packet’s recorded test command to match the allowlist oracle. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Trigger[Schedule or manual dispatch] --> Tick[Tick job]
    Tick --> Result{Tick succeeded?}
    Result -->|Yes| Done[Complete]
    Result -->|No, cancelled, or timed out| Alert[Sibling alert job]
    Alert --> Existing{Existing clock alert?}
    Existing -->|Open| Comment[Comment with run URL]
    Existing -->|Closed| Reopen[Reopen and comment]
    Existing -->|None| Create[Create clock-alert issue]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["Move clock alert into a sibling job of t..."](https://github.com/ravidsrk/oss-foundry/commit/2c8495aed114dc347ca3d6b2d363878012f6d4ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59089224)</sub>

<!-- /greptile_comment -->