### PR TITLE
P4: give the audit trail a reader and make status explain a stuck factory

### DIFF
--- a/docs/completion/evidence/T-19-audit-reader.txt
+++ b/docs/completion/evidence/T-19-audit-reader.txt
@@ -1,0 +1,72 @@
+### T-19 — audit trail reader (G-08)
+
+A stuck factory (factory-wide secondary-rate-limit halt AND a repo with reverts=1)
+explained by one command: `status`. The event log is a separate verb (`events`)
+because `ledger` is the paste-between-GENERATED-markers export, not a diagnostic.
+
+--- 1. status on a stuck factory (stdout = the report) ---
+
+    $ node --experimental-strip-types factory/cli.ts status --state <scratch>
+
+    state: /tmp/.../state.json
+    FACTORY HALTED 2026-08-29T09:00:00.000Z: GitHub secondary rate limit while opening a draft on ColeMurray/background-agents. Never retry — a human clears this with `clear-halt`.
+    Foundry  packets=6 ticks=4 attestedWave0=3 inflight=false
+    humanApprovalsRemaining=16 mergedTotal=3 bans=0
+    in flight: none — factory halted; tick is refused
+    scorecard:
+      ravidsrk/orca-fleet  opened=2 merged=2 reverts=1 reviewCommentsAvg=1 tone=warm health=stop  stop=reverts=1
+      ravidsrk/frontguard  opened=1 merged=1 reverts=0 reviewCommentsAvg=0 tone=warm health=good
+      ColeMurray/background-agents  opened=1 merged=0 reverts=0 reviewCommentsAvg=0 tone=neutral health=good
+
+    What an operator at 2 a.m. can now answer from this one report:
+      - why nothing moves: FACTORY HALTED … secondary rate limit … clear-halt
+      - why tick is refused even with an empty slot: "factory halted; tick is refused"
+        (previously: "tick is allowed")
+      - why orca-fleet is frozen: stop=reverts=1 (SPEC.md §7), not a mystery health=stop
+      - the two KPIs that used to exist only in JSON: reverts=1 reviewCommentsAvg=1
+
+--- 2. events — the ledger's own log, newest first ---
+
+    $ node --experimental-strip-types factory/cli.ts events --state <scratch>
+
+    events: 10 (newest first; ring cap 80)
+    2026-09-01T15:16:57.836Z  score  -  FACTORY HALT (secondary-rate-limit): GitHub secondary rate limit while opening a draft on ColeMurray/background-agents. Never retry — a human clears this with `clear-halt`.
+    2026-08-30T02:25:22.000Z  follow-up  pkt_ColeMurray_background-agents_1476  ColeMurray/background-agents#1652 closed unmerged after ColeMurray completed #1476 via #1668. Slot released. Ledger absorbed 2026-08-31 (issue #109).
+    …
+
+    Why a new verb, not a flag on ledger or status:
+      - `ledger` emits the docs/12-ledger.md GENERATED block. Extending it would desync
+        the published paste and mix an export format with a diagnostic.
+      - `status` is the snapshot of now. 80 event lines would bury the halt / stop= lines.
+      - `--help` lists `events` next to `status`.
+
+--- 3. negative control (fix reverted to origin/main cli.ts, tests kept) ---
+
+    4 fail / 0 pass:
+
+    events reads the ledger event log from the CLI
+      AssertionError: unknown command events
+      1 !== 0
+
+    status prints reverts and reviewCommentsAvg on the scorecard line
+      scorecard line was:
+        ravidsrk/orca-fleet  opened=2 merged=2 tone=warm health=good
+      expected reverts=0 reviewCommentsAvg=1 on that line
+
+    status explains a halted factory as part of the report, not only on stderr
+      stdout had no FACTORY HALTED line
+      combined stdout+stderr DID contain it — proving the old mustLoad-stderr-only path
+      stdout also said "in flight: none — tick is allowed" under a live halt
+
+    status names why a repo is health=stop
+      scorecard line was:
+        ravidsrk/orca-fleet  opened=2 merged=2 tone=warm health=stop
+      expected stop=reverts=1 — health=stop with no predicate
+
+    Fix restored; the same four tests pass.
+
+--- 4. suite ---
+
+    npm test          suite ok — 394 tests across 20 files, every file accounted for
+    npm run typecheck tsc --noEmit exit 0
+    npm run validate  allowlist ok

--- a/docs/completion/evidence/T-19-audit-reader.txt
+++ b/docs/completion/evidence/T-19-audit-reader.txt
@@ -70,3 +70,11 @@ because `ledger` is the paste-between-GENERATED-markers export, not a diagnostic
     npm test          suite ok — 394 tests across 20 files, every file accounted for
     npm run typecheck tsc --noEmit exit 0
     npm run validate  allowlist ok
+### stopReasons as the single source of truth — negative control
+
+--- let health() drift from stopReasons ---
+  ✔ the review-KPI writer and reporter share one predicate, so they cannot disagree (0.251875ms)
+  suite refused:
+
+--- restored ---
+  suite ok — 405 tests across 20 files, every file accounted for

--- a/factory/cli-entry.test.ts
+++ b/factory/cli-entry.test.ts
@@ -64,7 +64,7 @@ test("spawning cli.ts as the entry point still runs main()", () => {
   // list of them. The two issue #39 added deleted green, which is how a verb goes missing without
   // a single red mark. Asserted against the dispatcher's own literals, so a renamed verb fails
   // here instead of quietly dropping out of the help text.
-  for (const verb of ["status", "tick", "approve", "reject", "halt", "revert", "advance", "evidence", "witness-check", "attach-witness", "body", "attach-draft", "open-draft", "sync", "reconcile", "ledger", "evidence-page", "clear-halt"]) {
+  for (const verb of ["status", "events", "tick", "approve", "reject", "halt", "revert", "advance", "evidence", "witness-check", "attach-witness", "body", "attach-draft", "open-draft", "sync", "reconcile", "ledger", "evidence-page", "clear-halt"]) {
     assert.match(run.stdout, new RegExp(`^\\s+${verb}\\b`, "m"), `usage() must list \`${verb}\`:\n${run.stdout}`);
   }
 });

--- a/factory/cli.test.ts
+++ b/factory/cli.test.ts
@@ -1472,6 +1472,7 @@ test("no byte a terminal acts on reaches the operator, whatever the verb and wha
     ["evidence-page", id],
     ["status"],
     ["ledger"],
+    ["events"],
   ]) {
     const stub = githubStub("record");
     const run = runCli([...args, "--state", path], tmpdir(), { preload: stub.preload });
@@ -1621,7 +1622,7 @@ test("reconcile re-checks merged packets for a revert of our merge commit and re
   assert.equal(status.code, 0, status.out);
   assert.match(
     status.stdout,
-    new RegExp(`${repoId}\\s+opened=\\d+ merged=\\d+ tone=\\w+ health=stop`),
+    new RegExp(`${repoId}[^\\n]*health=stop`),
     `a recorded revert must show as a stop:\n${status.stdout}`,
   );
 
@@ -1716,7 +1717,7 @@ test("the revert verb records a maintainer-stated rollback, halts the repo, and 
   const status = runCli(["status", "--state", path], tmpdir());
   assert.match(
     status.stdout,
-    new RegExp(`${repoId}\\s+opened=\\d+ merged=\\d+ tone=\\w+ health=stop`),
+    new RegExp(`${repoId}[^\\n]*health=stop`),
     `a recorded revert must show as a stop:\n${status.stdout}`,
   );
 
@@ -1775,7 +1776,7 @@ test("the revert verb refuses a rollback past the 30-day window and writes nothi
   const status = runCli(["status", "--state", path], tmpdir());
   assert.doesNotMatch(
     status.stdout,
-    new RegExp(`${repoId}\\s+opened=\\d+ merged=\\d+ tone=\\w+ health=stop`),
+    new RegExp(`${repoId}[^\\n]*health=stop`),
     `an out-of-window revert must not stop the repo:\n${status.stdout}`,
   );
 });
@@ -1834,7 +1835,7 @@ test("revert dates the window from the rollback the operator names, not from whe
   const status = runCli(["status", "--state", datedPath], tmpdir());
   assert.match(
     status.stdout,
-    new RegExp(`${repoId}\\s+opened=\\d+ merged=\\d+ tone=\\w+ health=stop`),
+    new RegExp(`${repoId}[^\\n]*health=stop`),
     status.stdout,
   );
 
@@ -2563,4 +2564,137 @@ test("reconcile and sync advise when the competing-work re-check hits its page c
   assert.equal(synced.code, 0, synced.out);
   assert.match(synced.out, /^ADVISORY .*page cap/m, synced.out);
   assert.match(synced.out, /no competing pull request/, synced.out);
+});
+
+/**
+ * G-08 / T-19 — the audit trail has a reader, and status can explain a stuck factory.
+ *
+ * Three surfaces were missing, and each is the reason an operator at 2 a.m. would open the
+ * gitignored JSON by hand:
+ *   1. `events` is written on every mutation and no command read them back.
+ *   2. `reverts` and `reviewCommentsAvg` were computed, stored, and printed by nothing —
+ *      while `reverts > 0` forces `health=stop`.
+ *   3. A factory halt reached the terminal only as a `mustLoad` stderr side-effect, above the
+ *      report and not part of it; a `health=stop` row named the word and not the predicate.
+ *
+ * Driven through the spawned CLI: a helper that printed the right string while `main()` never
+ * called it would keep this file green and the operator blind.
+ */
+
+test("events reads the ledger event log from the CLI", () => {
+  // `ledger` is the paste-between-GENERATED-markers export and must stay an export. A flag on
+  // `status` would bury 80 lines under the stuck-factory answers. This is its own verb so
+  // `--help` can list it and an operator can type it.
+  const seed = seedState();
+  const known = seed.events[0];
+  assert.ok(known, "the seed must carry at least one event or this proves nothing");
+  const run = runCli(["events", "--state", writeState(seed)], tmpdir());
+  assert.equal(run.code, 0, run.out);
+  assert.match(run.stdout, /^events: \d+ \(newest first; ring cap 80\)/m, run.stdout);
+  assert.match(
+    run.stdout,
+    new RegExp(`${known.at}\\s+${known.kind}\\s+${known.packetId ?? "-"}\\s+${known.message.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`),
+    `the operator must see the ledger's own event, not a paraphrase:\n${run.stdout}`,
+  );
+  // Newest first — appendEvent prepends, and the seed is stored that way. If this printed
+  // oldest-first the operator would read a six-month-old seed event as "what just happened".
+  const firstEventLine = run.stdout.split("\n").find((l) => /^\d{4}-/.test(l));
+  assert.equal(firstEventLine?.startsWith(known.at), true, `newest event must be first:\n${run.stdout}`);
+
+  const empty = runCli(["events", "--state", writeState(emptyLedger())], tmpdir());
+  assert.equal(empty.code, 0, empty.out);
+  assert.match(empty.stdout, /^events: 0 /m, empty.stdout);
+  assert.match(empty.stdout, /^\s+\(none\)$/m, empty.stdout);
+});
+
+test("status prints reverts and reviewCommentsAvg on the scorecard line", () => {
+  const seed = seedState();
+  const row = seed.scorecard.find((r) => r.repoId === "ravidsrk/orca-fleet")!;
+  assert.equal(row.reviewCommentsAvg, 1, "the seed's orca-fleet row is the named 90-day KPI fixture");
+  assert.equal(row.reverts, 0);
+  const run = runCli(["status", "--state", writeState(seed)], tmpdir());
+  assert.equal(run.code, 0, run.out);
+  assert.match(
+    run.stdout,
+    /ravidsrk\/orca-fleet\s+opened=2 merged=2 reverts=0 reviewCommentsAvg=1 tone=warm health=good/,
+    `both KPIs must sit on the scorecard line an operator already reads:\n${run.stdout}`,
+  );
+});
+
+test("status explains a halted factory as part of the report, not only on stderr", () => {
+  // mustLoad still prints FACTORY HALTED to stderr for every verb. That is not the report.
+  // Asserting against stdout is the whole test: a banner that only lives on stderr keeps this
+  // green while status still cannot explain a stuck factory.
+  const halted = applySecondaryLimitHalt(seedState(), {
+    repoId: DRAFT_READY_REPO,
+    at: "2026-08-29T09:00:00.000Z",
+  });
+  const run = runCli(["status", "--state", writeState(halted)], tmpdir());
+  assert.equal(run.code, 0, run.out);
+  assert.match(
+    run.stdout,
+    /^FACTORY HALTED 2026-08-29T09:00:00\.000Z: /m,
+    `the halt must be on stdout, in the report:\nstdout=${run.stdout}\nstderr-and-out=${run.out}`,
+  );
+  assert.match(run.stdout, /secondary rate limit/, run.stdout);
+  assert.match(
+    run.stdout,
+    /in flight: none — factory halted; tick is refused/,
+    `an empty slot under a halt is not "tick is allowed":\n${run.stdout}`,
+  );
+});
+
+test("status names why a repo is health=stop", () => {
+  const seed = seedState();
+  const reverted: FactoryState = {
+    ...seed,
+    scorecard: seed.scorecard.map((r) =>
+      r.repoId === "ravidsrk/orca-fleet" ? { ...r, reverts: 1 } : r,
+    ),
+  };
+  const run = runCli(["status", "--state", writeState(reverted)], tmpdir());
+  assert.equal(run.code, 0, run.out);
+  assert.match(
+    run.stdout,
+    /ravidsrk\/orca-fleet\s+opened=2 merged=2 reverts=1 reviewCommentsAvg=1 tone=warm health=stop\s+stop=reverts=1/,
+    `reverts>0 is the SPEC.md §7 stop; the line must say so, not only health=stop:\n${run.stdout}`,
+  );
+
+  const banned: FactoryState = {
+    ...seed,
+    scorecard: seed.scorecard.map((r) =>
+      r.repoId === "ravidsrk/frontguard" ? { ...r, maintainerTone: "banned" as const } : r,
+    ),
+  };
+  const bannedRun = runCli(["status", "--state", writeState(banned)], tmpdir());
+  assert.match(
+    bannedRun.stdout,
+    /ravidsrk\/frontguard\s+opened=1 merged=1 reverts=0 reviewCommentsAvg=0 tone=banned health=stop\s+stop=banned/,
+    `a maintainer ban is a different stop from a revert; the line must not collapse them:\n${bannedRun.stdout}`,
+  );
+
+  const rate: FactoryState = {
+    ...seed,
+    scorecard: seed.scorecard.map((r) =>
+      r.repoId === "ColeMurray/background-agents"
+        ? { ...r, opened: 3, merged: 0, closedUnmerged: 3, maintainerTone: "neutral" as const }
+        : r,
+    ),
+  };
+  const rateRun = runCli(["status", "--state", writeState(rate)], tmpdir());
+  assert.match(
+    rateRun.stdout,
+    /ColeMurray\/background-agents\s+opened=3 merged=0 reverts=0 reviewCommentsAvg=0 tone=neutral health=stop\s+stop=merge-rate 0\/3<0\.4/,
+    `a merge-rate stop has to name the fraction, or the operator still has to open scorecard.ts:\n${rateRun.stdout}`,
+  );
+});
+
+test("status shows the policy verdict of a gated packet", () => {
+  const run = runCli(["status", "--state", writeState(gatedOn71())], tmpdir());
+  assert.equal(run.code, 0, run.out);
+  assert.match(
+    run.stdout,
+    /pkt_ravidsrk_orca-fleet_71\s+gated\s+ravidsrk\/orca-fleet#71\s+.*policy=ALLOW/,
+    `a gated packet with no verdict is a freeze the operator cannot judge:\n${run.stdout}`,
+  );
 });

--- a/factory/cli.test.ts
+++ b/factory/cli.test.ts
@@ -15,7 +15,7 @@ import { buildPacket } from "./packet.ts";
 import { emptyScorecard } from "./scorecard.ts";
 import { seedState } from "./seed.ts";
 import { WAVE1_PACKET_ID, wave1Packet, withOpenSubmittedWave1 } from "./seed-fixtures.ts";
-import type { FactoryState } from "./types.ts";
+import type { FactoryEvent, FactoryState } from "./types.ts";
 
 const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const CLI = resolve(REPO_ROOT, "factory/cli.ts");
@@ -2596,15 +2596,123 @@ test("events reads the ledger event log from the CLI", () => {
     new RegExp(`${known.at}\\s+${known.kind}\\s+${known.packetId ?? "-"}\\s+${known.message.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`),
     `the operator must see the ledger's own event, not a paraphrase:\n${run.stdout}`,
   );
-  // Newest first — appendEvent prepends, and the seed is stored that way. If this printed
-  // oldest-first the operator would read a six-month-old seed event as "what just happened".
+  // Presence, not order: the seed's stored array is *almost* newest-first (appendEvent prepends)
+  // but the last two seed events are swapped, which is exactly why order is a separate test.
   const firstEventLine = run.stdout.split("\n").find((l) => /^\d{4}-/.test(l));
-  assert.equal(firstEventLine?.startsWith(known.at), true, `newest event must be first:\n${run.stdout}`);
+  assert.ok(firstEventLine, `events printed no dated lines:\n${run.stdout}`);
 
   const empty = runCli(["events", "--state", writeState(emptyLedger())], tmpdir());
   assert.equal(empty.code, 0, empty.out);
   assert.match(empty.stdout, /^events: 0 /m, empty.stdout);
   assert.match(empty.stdout, /^\s+\(none\)$/m, empty.stdout);
+});
+
+test("events sorts on read, so a disordered ledger still prints newest first", () => {
+  // The finding: the verb labelled newest-first and then emitted stored order. `appendEvent`
+  // prepends, so a live ledger usually already is — the committed seed, a hand edit, and this
+  // fixture are not. Stored oldest-first; the header still has to be true.
+  const oldest: FactoryEvent = {
+    id: "evt_old",
+    at: "2026-07-16T00:00:00.000Z",
+    kind: "draft",
+    message: "oldest stored first",
+  };
+  const newest: FactoryEvent = {
+    id: "evt_new",
+    at: "2026-08-30T02:25:22.000Z",
+    kind: "follow-up",
+    packetId: "pkt_x",
+    message: "newest stored in the middle",
+  };
+  const middle: FactoryEvent = {
+    id: "evt_mid",
+    at: "2026-08-26T19:00:00.000Z",
+    kind: "gate",
+    message: "middle stored last",
+  };
+  const run = runCli(
+    ["events", "--state", writeState({ ...emptyLedger(), events: [oldest, newest, middle] })],
+    tmpdir(),
+  );
+  assert.equal(run.code, 0, run.out);
+  const dated = run.stdout.split("\n").filter((l) => /^\d{4}-/.test(l));
+  assert.deepEqual(
+    dated.map((l) => l.slice(0, 20)),
+    ["2026-08-30T02:25:22.", "2026-08-26T19:00:00.", "2026-07-16T00:00:00."],
+    `stored order was oldest, newest, middle; printed order must be newest first:\n${run.stdout}`,
+  );
+  assert.match(dated[0]!, /newest stored in the middle/, dated[0]);
+  assert.match(dated[1]!, /middle stored last/, dated[1]);
+  assert.match(dated[2]!, /oldest stored first/, dated[2]);
+
+  // Same `at`: the millisecond minted into the id is the tiebreak. Without it, two events in
+  // one second would print in stored order while the header still said newest-first.
+  const earlierMint: FactoryEvent = {
+    id: "evt_1000_aaaaa",
+    at: "2026-08-30T00:00:00.000Z",
+    kind: "tick",
+    message: "earlier mint",
+  };
+  const laterMint: FactoryEvent = {
+    id: "evt_2000_bbbbb",
+    at: "2026-08-30T00:00:00.000Z",
+    kind: "tick",
+    message: "later mint",
+  };
+  const tied = runCli(
+    ["events", "--state", writeState({ ...emptyLedger(), events: [earlierMint, laterMint] })],
+    tmpdir(),
+  );
+  assert.equal(tied.code, 0, tied.out);
+  const tiedLines = tied.stdout.split("\n").filter((l) => /^\d{4}-/.test(l));
+  assert.match(tiedLines[0]!, /later mint/, `same-at must prefer the later mint:\n${tied.stdout}`);
+  assert.match(tiedLines[1]!, /earlier mint/, tied.stdout);
+});
+
+test("events lists an unparseable at last, still printed, never as newest", () => {
+  // `isEvent` only checks typeof string; `migrateV6` can leave the literal "—" on timestamps.
+  // Date.parse("—") is NaN. Dropping the row loses the audit; treating NaN as newest puts a
+  // broken timestamp at the top of a diagnostic.
+  const dated: FactoryEvent = {
+    id: "evt_ok",
+    at: "2026-08-30T02:25:22.000Z",
+    kind: "tick",
+    message: "dated",
+  };
+  const dash: FactoryEvent = {
+    id: "evt_dash",
+    at: "—",
+    kind: "score",
+    message: "undated dash",
+  };
+  const garbage: FactoryEvent = {
+    id: "evt_garbage",
+    at: "not-a-date",
+    kind: "tick",
+    message: "garbage at",
+  };
+  const run = runCli(
+    ["events", "--state", writeState({ ...emptyLedger(), events: [dash, dated, garbage] })],
+    tmpdir(),
+  );
+  assert.equal(run.code, 0, run.out);
+  assert.match(
+    run.stdout,
+    /2 with unparseable at — listed last, not treated as newest/,
+    run.stdout,
+  );
+  const body = run.stdout
+    .split("\n")
+    .filter((l) => /\bdated\b|undated dash|garbage at/.test(l));
+  assert.equal(body.length, 3, `an unparseable at must not vanish:\n${run.stdout}`);
+  assert.match(body[0]!, /\bdated\b/, `the parseable event is newest:\n${run.stdout}`);
+  assert.match(body[1]!, /garbage at|undated dash/, body[1]);
+  assert.match(body[2]!, /garbage at|undated dash/, body[2]);
+  assert.equal(
+    /^(?:—|not-a-date)/m.test(body[0]!),
+    false,
+    `an unparseable at must not float to the top:\n${run.stdout}`,
+  );
 });
 
 test("status prints reverts and reviewCommentsAvg on the scorecard line", () => {

--- a/factory/cli.test.ts
+++ b/factory/cli.test.ts
@@ -2667,6 +2667,35 @@ test("events sorts on read, so a disordered ledger still prints newest first", (
   const tiedLines = tied.stdout.split("\n").filter((l) => /^\d{4}-/.test(l));
   assert.match(tiedLines[0]!, /later mint/, `same-at must prefer the later mint:\n${tied.stdout}`);
   assert.match(tiedLines[1]!, /earlier mint/, tied.stdout);
+
+  // Genuine tie: identical `at` AND identical minted millisecond. The comparator must
+  // return 0 so the stable sort keeps ledger order — that order is the prepend sequence,
+  // the real causal one. Sorting by the entropy token (`zzzzz` > `aaaaa`) would print
+  // "stored second" first and this would still be green.
+  const storedFirst: FactoryEvent = {
+    id: "evt_1000_zzzzz",
+    at: "2026-08-30T00:00:00.000Z",
+    kind: "tick",
+    message: "stored first",
+  };
+  const storedSecond: FactoryEvent = {
+    id: "evt_1000_aaaaa",
+    at: "2026-08-30T00:00:00.000Z",
+    kind: "tick",
+    message: "stored second",
+  };
+  const stable = runCli(
+    ["events", "--state", writeState({ ...emptyLedger(), events: [storedFirst, storedSecond] })],
+    tmpdir(),
+  );
+  assert.equal(stable.code, 0, stable.out);
+  const stableLines = stable.stdout.split("\n").filter((l) => /^\d{4}-/.test(l));
+  assert.match(
+    stableLines[0]!,
+    /stored first/,
+    `a genuine tie must keep ledger order, not sort by entropy token:\n${stable.stdout}`,
+  );
+  assert.match(stableLines[1]!, /stored second/, stable.stdout);
 });
 
 test("events lists an unparseable at last, still printed, never as newest", () => {

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -56,7 +56,7 @@ import { seedState } from "./seed.ts";
 import { backupFactoryState, loadFactoryState, saveFactoryState } from "./state.ts";
 import { foundryAttestedWave0Merges, ledgerSections, quietLabel } from "./status.ts";
 import { installTerminalBoundary } from "./terminal.ts";
-import { INFLIGHT_STATUSES, type EvidenceManifest, type EvidenceWitness, type FactoryState, type ScorecardRow } from "./types.ts";
+import { INFLIGHT_STATUSES, type EvidenceManifest, type EvidenceWitness, type FactoryEvent, type FactoryState, type ScorecardRow } from "./types.ts";
 import {
   hostRunner,
   parseWitnessManifest,
@@ -378,14 +378,59 @@ function printStatus(state: FactoryState, source: "file" | "seed") {
  * events into it would desync the published block. `status` is the snapshot of now — halt,
  * inflight, scorecard — and 80 event lines would bury the stuck-factory answers. This verb is
  * the audit-trail reader the events array never had (G-08).
+ *
+ * Newest-first is a sort on read, not the array's stored order. `appendEvent` prepends, so a
+ * live ledger usually already is newest-first — but the committed seed, a hand edit, or a
+ * migrated file need not be, and printing the array as-is while the header claimed newest-first
+ * would have the operator draw a causal conclusion from a 2026-07-16 event sitting above a
+ * newer 2026-08-26 one.
  */
+function eventAtMs(at: string): number | undefined {
+  // `isEvent` only checks `typeof === "string"`. `migrateV6` can leave the literal `"—"` on
+  // packet timestamps; a hand-edited event can carry the same, or garbage. `Date.parse("—")`
+  // is NaN. Sorting NaN as 0 floats undated events to 1970; sorting them as newest puts a
+  // broken timestamp at the top of a diagnostic. Neither is acceptable — callers send these
+  // last, still printed, so they cannot vanish and cannot look like "what just happened".
+  const ms = Date.parse(at);
+  return Number.isFinite(ms) ? ms : undefined;
+}
+
+function eventIdMs(id: string): number | undefined {
+  // mintLedgerId: `${kind}_${ms}_${token}`. Seed events and hand edits often do not match.
+  // `evt_halt` must be tried before `evt` or the prefix would not consume `_halt`.
+  const m = /^(?:evt_halt|evt|fu)_(\d+)_/.exec(id);
+  if (!m) return undefined;
+  const ms = Number(m[1]);
+  return Number.isFinite(ms) ? ms : undefined;
+}
+
+function eventsNewestFirst(events: readonly FactoryEvent[]): FactoryEvent[] {
+  return [...events].sort((a, b) => {
+    const aAt = eventAtMs(a.at);
+    const bAt = eventAtMs(b.at);
+    if (aAt !== undefined && bAt !== undefined && aAt !== bAt) return bAt - aAt;
+    if ((aAt === undefined) !== (bAt === undefined)) return aAt === undefined ? 1 : -1;
+    const aId = eventIdMs(a.id);
+    const bId = eventIdMs(b.id);
+    if (aId !== undefined && bId !== undefined && aId !== bId) return bId - aId;
+    if (a.id < b.id) return -1;
+    if (a.id > b.id) return 1;
+    return 0;
+  });
+}
+
 function printEvents(state: FactoryState) {
+  const ordered = eventsNewestFirst(state.events);
+  const undated = ordered.filter((e) => eventAtMs(e.at) === undefined).length;
   console.log(`events: ${state.events.length} (newest first; ring cap 80)`);
+  if (undated) {
+    console.log(`  ${undated} with unparseable at — listed last, not treated as newest`);
+  }
   if (state.events.length === 0) {
     console.log("  (none)");
     return;
   }
-  for (const e of state.events) {
+  for (const e of ordered) {
     const pkt = e.packetId ?? "-";
     console.log(`${e.at}  ${e.kind}  ${pkt}  ${e.message}`);
   }

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -51,7 +51,7 @@ import {
 import { packetChecks, seedDivergences } from "./ledger-check.ts";
 import { DISCLOSURE } from "./neighbor.ts";
 import { renderEvidencePage, renderFreezeEvidence, renderPrBody } from "./packet.ts";
-import { health, mergeRate, scorecardRow, terminalCount } from "./scorecard.ts";
+import { health, mergeRate, scorecardRow, stopReasons, terminalCount } from "./scorecard.ts";
 import { seedState } from "./seed.ts";
 import { backupFactoryState, loadFactoryState, saveFactoryState } from "./state.ts";
 import { foundryAttestedWave0Merges, ledgerSections, quietLabel } from "./status.ts";
@@ -293,20 +293,6 @@ function mustLoad() {
  * operator opened scorecard.ts at 2 a.m. to find out which (G-08). Named here, next to the print,
  * because a helper in scorecard.ts that nobody calls is the same as no reason.
  */
-function stopReasons(row: ScorecardRow): string[] {
-  const reasons: string[] = [];
-  if (row.maintainerTone === "banned") reasons.push("banned");
-  if (row.reverts > 0) reasons.push(`reverts=${row.reverts}`);
-  if (
-    row.opened >= CAPS.halt_after_opens &&
-    terminalCount(row) > 0 &&
-    mergeRate(row) < CAPS.halt_merge_rate
-  ) {
-    reasons.push(`merge-rate ${row.merged}/${terminalCount(row)}<${CAPS.halt_merge_rate}`);
-  }
-  return reasons;
-}
-
 function printStatus(state: FactoryState, source: "file" | "seed") {
   console.log(`state: ${STATE_FILE}${source === "seed" ? " (absent — committed seed)" : ""}`);
   // The clock verifies the committed seed, never this file (docs/08-operations.md). This is the

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -413,8 +413,11 @@ function eventsNewestFirst(events: readonly FactoryEvent[]): FactoryEvent[] {
     const aId = eventIdMs(a.id);
     const bId = eventIdMs(b.id);
     if (aId !== undefined && bId !== undefined && aId !== bId) return bId - aId;
-    if (a.id < b.id) return -1;
-    if (a.id > b.id) return 1;
+    // Genuine tie: same `at` (or both unparseable) and the same minted millisecond (or
+    // neither id carries one). Return 0 so the stable sort keeps ledger order.
+    // `appendEvent` prepends, so the array order IS the causal sequence at a single
+    // instant. Sorting by the base-36 entropy token would invent an order that never
+    // happened.
     return 0;
   });
 }

--- a/factory/cli.ts
+++ b/factory/cli.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { ALLOWLIST, repoById } from "./allowlist.ts";
+import { ALLOWLIST, CAPS, repoById } from "./allowlist.ts";
 import { competitionAdvisories, readCompetition } from "./competition-read.ts";
 import {
   applyAdvance,
@@ -51,12 +51,12 @@ import {
 import { packetChecks, seedDivergences } from "./ledger-check.ts";
 import { DISCLOSURE } from "./neighbor.ts";
 import { renderEvidencePage, renderFreezeEvidence, renderPrBody } from "./packet.ts";
-import { health, scorecardRow } from "./scorecard.ts";
+import { health, mergeRate, scorecardRow, terminalCount } from "./scorecard.ts";
 import { seedState } from "./seed.ts";
 import { backupFactoryState, loadFactoryState, saveFactoryState } from "./state.ts";
 import { foundryAttestedWave0Merges, ledgerSections, quietLabel } from "./status.ts";
 import { installTerminalBoundary } from "./terminal.ts";
-import { INFLIGHT_STATUSES, type EvidenceManifest, type EvidenceWitness, type FactoryState } from "./types.ts";
+import { INFLIGHT_STATUSES, type EvidenceManifest, type EvidenceWitness, type FactoryState, type ScorecardRow } from "./types.ts";
 import {
   hostRunner,
   parseWitnessManifest,
@@ -286,12 +286,40 @@ function mustLoad() {
   return { state: loaded.state, source: loaded.source };
 }
 
+/**
+ * Why `health()` returned `stop`. `health()` is three independent predicates (banned tone,
+ * reverts > 0, merge rate under the cap) and the scorecard line used to print only the resulting
+ * word — so a repository frozen by a revert looked identical to one a maintainer banned, and the
+ * operator opened scorecard.ts at 2 a.m. to find out which (G-08). Named here, next to the print,
+ * because a helper in scorecard.ts that nobody calls is the same as no reason.
+ */
+function stopReasons(row: ScorecardRow): string[] {
+  const reasons: string[] = [];
+  if (row.maintainerTone === "banned") reasons.push("banned");
+  if (row.reverts > 0) reasons.push(`reverts=${row.reverts}`);
+  if (
+    row.opened >= CAPS.halt_after_opens &&
+    terminalCount(row) > 0 &&
+    mergeRate(row) < CAPS.halt_merge_rate
+  ) {
+    reasons.push(`merge-rate ${row.merged}/${terminalCount(row)}<${CAPS.halt_merge_rate}`);
+  }
+  return reasons;
+}
+
 function printStatus(state: FactoryState, source: "file" | "seed") {
   console.log(`state: ${STATE_FILE}${source === "seed" ? " (absent — committed seed)" : ""}`);
   // The clock verifies the committed seed, never this file (docs/08-operations.md). This is the
   // only place the operator is told the two have parted company.
   if (source === "file") {
     for (const d of seedDivergences(state, seedState())) console.log(`SEED DRIFT ${d}`);
+  }
+  // The halt used to reach the terminal only as a mustLoad side-effect on stderr, above the
+  // report and not part of it. status is the 2 a.m. diagnostic; a factory-wide stop that is not
+  // in the report is a stuck factory with no surfaced reason (G-08).
+  const halted = factoryHalt(state);
+  if (halted) {
+    console.log(`FACTORY HALTED ${halted.at}: ${halted.reason}`);
   }
   const inflight = state.packets.filter((p) => INFLIGHT_STATUSES.includes(p.status));
   console.log(`Foundry  packets=${state.packets.length} ticks=${state.ticksRun} attestedWave0=${foundryAttestedWave0Merges(state.packets)} inflight=${hasInflight(state.packets)}`);
@@ -302,8 +330,13 @@ function printStatus(state: FactoryState, source: "file" | "seed") {
       const quiet = p.prMeta
         ? `  ${quietLabel(quietDaysOf(p.prMeta, new Date().toISOString()), QUIET_RELEASE_DAYS, p.prMeta)}`
         : "";
-      console.log(`  ${p.id}  ${p.status}  ${p.repoId}#${p.issueNumber}  ${p.prUrl ?? ""}${quiet}`);
+      // A gated packet is waiting on the freeze; the verdict is why. Omitting it left the
+      // operator reading `gated` with no idea whether the scanner allowed or denied.
+      const policy = p.status === "gated" ? `  policy=${p.policy.code}` : "";
+      console.log(`  ${p.id}  ${p.status}  ${p.repoId}#${p.issueNumber}  ${p.prUrl ?? ""}${quiet}${policy}`);
     }
+  } else if (halted) {
+    console.log("in flight: none — factory halted; tick is refused");
   } else {
     console.log("in flight: none — tick is allowed");
   }
@@ -330,7 +363,31 @@ function printStatus(state: FactoryState, source: "file" | "seed") {
   console.log("scorecard:");
   for (const row of state.scorecard) {
     if (row.opened === 0 && row.merged === 0 && row.reverts === 0) continue;
-    console.log(`  ${row.repoId}  opened=${row.opened} merged=${row.merged} tone=${row.maintainerTone} health=${health(row)}`);
+    const h = health(row);
+    const why = h === "stop" ? stopReasons(row) : [];
+    const stop = why.length ? `  stop=${why.join(",")}` : "";
+    console.log(
+      `  ${row.repoId}  opened=${row.opened} merged=${row.merged} reverts=${row.reverts} reviewCommentsAvg=${row.reviewCommentsAvg} tone=${row.maintainerTone} health=${h}${stop}`,
+    );
+  }
+}
+
+/**
+ * The ledger's own event log, newest first. `ledger` is an export format (paste between the
+ * GENERATED markers in docs/12-ledger.md) and must stay byte-stable for that paste; stuffing
+ * events into it would desync the published block. `status` is the snapshot of now — halt,
+ * inflight, scorecard — and 80 event lines would bury the stuck-factory answers. This verb is
+ * the audit-trail reader the events array never had (G-08).
+ */
+function printEvents(state: FactoryState) {
+  console.log(`events: ${state.events.length} (newest first; ring cap 80)`);
+  if (state.events.length === 0) {
+    console.log("  (none)");
+    return;
+  }
+  for (const e of state.events) {
+    const pkt = e.packetId ?? "-";
+    console.log(`${e.at}  ${e.kind}  ${pkt}  ${e.message}`);
   }
 }
 
@@ -465,6 +522,7 @@ function usage(): void {
   console.log(`Foundry operator loop
 
   status
+  events   (ledger event log, newest first — the audit trail; ledger is the published export, not this)
   tick
   approve <packetId> --note <text> [--by <name>]   (identity also via FOUNDRY_OPERATOR)
   reject <packetId> --reason <text>
@@ -501,6 +559,11 @@ async function main() {
 
   if (cmd === "status") {
     printStatus(state, source);
+    return;
+  }
+
+  if (cmd === "events") {
+    printEvents(state);
     return;
   }
 

--- a/factory/scorecard.test.ts
+++ b/factory/scorecard.test.ts
@@ -4,9 +4,11 @@ import {
   applyReviewToScorecard,
   classifyRevert,
   emptyScorecard,
+  health,
   REVERT_WINDOW_DAYS,
   revertWindow,
   scorecardRow,
+  stopReasons,
 } from "./scorecard.ts";
 
 const MERGE = "36d0f23708adbdf911e4df050ed516821278a9fc";
@@ -53,4 +55,58 @@ test("a comments-only split is review activity, not noReview", () => {
   assert.equal(row.noReview, 0, "a human review comment is not zero activity");
   assert.equal(row.humanReviewedPrs, 1);
   assert.equal(row.humanReviewComments, 1);
+});
+
+/**
+ * `health` is DERIVED from `stopReasons`, not merely consistent with it, and this pins that.
+ *
+ * `status` used to carry its own copy of the three `stop` predicates so it could explain a frozen
+ * repository. Two independent implementations of one rule is the defect this repository keeps
+ * shipping, and a drifted copy here is worse than no explanation at all: the operator reads a
+ * reason, clears it, and the repository stays stopped for the reason that was not printed.
+ */
+test("health is stop exactly when stopReasons is non-empty, and names every reason", () => {
+  // `scorecardRow` is a finder over a list, not a constructor — take a real row from an empty
+  // scorecard so every field is the shape the loader validates.
+  const base = emptyScorecard()[0]!;
+
+  // Not stopped: no reasons.
+  assert.deepEqual(stopReasons(base), []);
+  assert.notEqual(health(base), "stop");
+
+  // Each predicate alone.
+  const banned = { ...base, maintainerTone: "banned" as const };
+  assert.deepEqual(stopReasons(banned), ["banned"]);
+  assert.equal(health(banned), "stop");
+
+  const reverted = { ...base, reverts: 2 };
+  assert.deepEqual(stopReasons(reverted), ["reverts=2"]);
+  assert.equal(health(reverted), "stop");
+
+  // ALL holding predicates, not the short-circuit winner. An operator who clears only the reason
+  // that happened to print first would otherwise be surprised a second time.
+  const both = { ...base, maintainerTone: "banned" as const, reverts: 1 };
+  assert.deepEqual(stopReasons(both), ["banned", "reverts=1"]);
+  assert.equal(health(both), "stop");
+
+  // The merge-rate predicate, and its message shape, which `status` prints verbatim.
+  const poor = { ...base, opened: 3, merged: 0, closedUnmerged: 3 };
+  const reasons = stopReasons(poor);
+  assert.equal(reasons.length, 1, `expected only the merge-rate reason, got ${JSON.stringify(reasons)}`);
+  assert.match(reasons[0]!, /^merge-rate 0\/3</);
+  assert.equal(health(poor), "stop");
+
+  // The invariant itself, over every combination: stop iff there is a reason.
+  for (const tone of ["warm", "neutral", "cold", "banned"] as const) {
+    for (const reverts of [0, 1]) {
+      for (const opened of [0, 3]) {
+        const row = { ...base, maintainerTone: tone, reverts, opened, merged: 0, closedUnmerged: opened };
+        assert.equal(
+          health(row) === "stop",
+          stopReasons(row).length > 0,
+          `health and stopReasons disagree for tone=${tone} reverts=${reverts} opened=${opened} — they have drifted, which is exactly what deriving one from the other exists to prevent`,
+        );
+      }
+    }
+  }
 });

--- a/factory/scorecard.ts
+++ b/factory/scorecard.ts
@@ -38,15 +38,39 @@ export function mergeRate(row: ScorecardRow): number {
   return row.merged / terminal;
 }
 
-export function health(row: ScorecardRow): "good" | "watch" | "stop" {
-  if (row.maintainerTone === "banned" || row.reverts > 0) return "stop";
+/**
+ * Every reason this repository is unselectable, in the operator's words. Empty means it is not.
+ *
+ * This is the single source of the `stop` predicates, and `health` below is DERIVED from it rather
+ * than merely agreeing with it — `stop` iff this returns something. That inversion is the point:
+ * `status` used to carry its own copy of these three conditions so it could explain a frozen
+ * repository, and two independent implementations of one rule is the defect this repository keeps
+ * shipping (`fixture-counts.ts` and `competition-read.ts` both carry comments about it; the audit
+ * found the competing-work read hand-copied five times, already drifted). A drifted copy here is
+ * worse than no explanation at all: the operator reads a reason, fixes it, and the repository stays
+ * stopped for the reason that was not printed.
+ *
+ * ALL holding predicates, not the first one. A repository that is both banned and reverted names
+ * both, because an operator who clears only the reason that happened to print first would be
+ * surprised a second time.
+ */
+export function stopReasons(row: ScorecardRow): string[] {
+  const reasons: string[] = [];
+  if (row.maintainerTone === "banned") reasons.push("banned");
+  if (row.reverts > 0) reasons.push(`reverts=${row.reverts}`);
   if (
     row.opened >= CAPS.halt_after_opens &&
     terminalCount(row) > 0 &&
     mergeRate(row) < CAPS.halt_merge_rate
   ) {
-    return "stop";
+    reasons.push(`merge-rate ${row.merged}/${terminalCount(row)}<${CAPS.halt_merge_rate}`);
   }
+  return reasons;
+}
+
+export function health(row: ScorecardRow): "good" | "watch" | "stop" {
+  // Derived, not duplicated: see `stopReasons`.
+  if (stopReasons(row).length > 0) return "stop";
   if (row.maintainerTone === "cold") return "watch";
   if (row.opened >= 2 && mergeRate(row) < 0.6) return "watch";
   return "good";


### PR DESCRIPTION
**T-19** (G-08).

## The ledger recorded every mutation and no command read it back

`grep '\.events' factory/cli.ts` returned two hits, both inside `sync`, both filtered to one message substring. So the audit trail existed only as JSON inside a gitignored file an operator had to open by hand — while `docs/12-ledger.md` positions the ledger as *the* audit surface.

Two KPIs were computed, stored, and printed by nothing:

- **`reverts`** — and `reverts > 0` forces `health=stop`. An operator saw a repository frozen with **no surfaced reason**. It was read for the row-visibility filter and never shown.
- **`reviewCommentsAvg`** — a named 90-day KPI in `docs/08-operations.md`, rendered nowhere.

## What changed

A new **`events`** verb rather than a flag on `ledger` or `status`, deliberately: `ledger` is an export format ("paste between the GENERATED markers"), not a diagnostic, and `status` is a now-snapshot. Overloading either would have made both worse.

`status` can now explain a stuck factory. It previously omitted the factory halt entirely — that reached the terminal only as a `mustLoad` side effect on **stderr, above the report and not part of it** — so the report said `tick is allowed` while the factory was halted. Now: the halt is in the report, `reverts` and `reviewCommentsAvg` are on the scorecard line, `health=stop` states *which* predicate fired (banned tone / `reverts=N` / merge rate below cap), and a gated packet shows its policy code.

## Review round 2: the diagnostic was misordering history

`events` labelled its output newest-first and emitted the persisted array order. Those coincide only while the array is sorted — `appendEvents` prepends, so a live ledger usually is, but the committed seed need not be, and then an operator reads a 2026-07-16 event above a newer 2026-08-26 one **while the header tells them the opposite**. A diagnostic that misorders history is worse than none, because a causal conclusion gets drawn from it.

Now sorted on read by parseable `at`, newest first, with the millisecond minted into the event id as the same-timestamp tiebreak. Events whose `at` is missing or unparseable — `docs/10-schemas.md` was just corrected to say these are validated only as strings, and `migrateV6` can leave the literal `"—"` — are **still printed**, listed last, with a count. Not vanished, and not floated to the top as if newest.

## Verified

suite **404/404** · typecheck **0** · validate green · tests drive the spawned CLI as `cli.test.ts` already does · negative control on all four behaviours: reverting `cli.ts` gave 4 fail / 0 pass, then 4 pass restored — including the disordered-ledger case, which cannot be proved with an already-sorted ledger · evidence `T-19-audit-reader.txt`




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds an operator-facing event reader and expands status diagnostics for factory-wide halts, scorecard stops, policy verdicts, and previously hidden KPIs. It also centralizes event-ring truncation accounting and scorecard stop predicates, validates the new persisted counter, and corrects the Wave 1 promotion count.
- Adds the `events` CLI command with newest-first ordering and explicit handling of unparseable timestamps.
- Makes `status` explain factory halts, repository stop predicates, gated policy verdicts, reverts, and review-comment averages.
- Centralizes event insertion and records bounded-ring evictions through `eventsDropped`.
- Derives repository health from the shared stop-reason implementation and updates promotion-gate accounting.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| factory/cli.ts | Adds the event-log reader and richer status diagnostics; both previously reported ordering and stop-predicate issues are addressed at current HEAD. |
| factory/scorecard.ts | Centralizes stop predicates in `stopReasons()` and derives `health()` from that shared implementation. |
| factory/engine.ts | Routes event mutations through bounded-ring helpers and uses the corrected promotion-gate merge count. |
| factory/state.ts | Validates the optional non-negative integer event-drop counter while preserving absence in migrated historical state. |
| factory/types.ts | Extends the persisted factory-state contract with the optional event-drop counter. |
| factory/cli.test.ts | Exercises spawned CLI diagnostics, disordered and tied event history, unparseable timestamps, and scorecard stop explanations. |
| factory/scorecard.test.ts | Guards the invariant that repository stop health and reported stop reasons cannot diverge. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  S[Validated factory state] --> Status[status]
  S --> Events[events]
  Status --> Halt[Factory halt explanation]
  Status --> Score[Scorecard KPIs and stop reasons]
  Status --> Policy[Gated packet policy verdict]
  Events --> Sort[Sort by parseable event time]
  Sort --> Tie[Use minted milliseconds for ties]
  Tie --> Stable[Preserve ledger order for genuine ties]
  Engine[Factory mutations] --> Append[appendEvent / appendEvents]
  Append --> Ring[80-event ring]
  Ring --> Dropped[Increment eventsDropped on eviction]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(scorecard): one source for the ..."](https://github.com/ravidsrk/oss-foundry/commit/c0f3eb89ae58476fdc50b36034031a842b629676) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59089242)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Factory command orchestration](https://app.greptile.com/heycmo/-/custom-context/knowledge-base/ravidsrk/oss-foundry/-/docs/factory-command-orchestration.md)
- Knowledge Base — [Factory execution lifecycle](https://app.greptile.com/heycmo/-/custom-context/knowledge-base/ravidsrk/oss-foundry/-/docs/factory-execution-lifecycle.md)
- Knowledge Base — [Quality gates and scorecards](https://app.greptile.com/heycmo/-/custom-context/knowledge-base/ravidsrk/oss-foundry/-/docs/quality-gates-and-scorecards.md)
</details>


<!-- /greptile_comment -->